### PR TITLE
Bugfix: Removed reference to missing image file

### DIFF
--- a/todo-example/backbone/css/todos.css
+++ b/todo-example/backbone/css/todos.css
@@ -446,7 +446,6 @@ body {
 	cursor: pointer;
 	width: 20px;
 	height: 20px;
-	background: url(/images/destroy.png) no-repeat center center;
 }
 /* line 106 */
 #todoapp .content ul#todo-list li:hover .todo-destroy {


### PR DESCRIPTION
The backbone.js example didn't show the "x" icon on hover. The CSS rule was too specific and referenced a non-existent location (images/destroy.png). See

https://skitch.com/kalidazad/f3dw4/backbone.js

for an example (Chrome 13.0.782.220).

Without that CSS rule, the default rules on lines

https://github.com/addyosmani/todomvc/blob/master/todo-example/backbone/css/todos.css#L148

and

https://github.com/addyosmani/todomvc/blob/master/todo-example/backbone/css/todos.css#L154

can take effect.
