### PR TITLE
sammyjs/index.html - fix localStorage test

### DIFF
--- a/todo-example/sammyjs/index.html
+++ b/todo-example/sammyjs/index.html
@@ -11,7 +11,7 @@
         <script src="lib/model.js" type="text/javascript" charset="utf-8"></script>
         <script src="app.js" type="text/javascript" charset="utf-8"></script>
         <script type="text/javascript" charset="utf-8">
-            if (!'localStorage' in window) {
+            if (!('localStorage' in window)) {
             		alert('Your browser does not support localStorage');
 	            }
         </script>


### PR DESCRIPTION
The expression `!'localStorage' in window` is always false because `!` has higher precedence than `in`.
