### PR TITLE
Fix: double click on item allows editing of item.

### DIFF
--- a/architecture-examples/backbone/js/todos.js
+++ b/architecture-examples/backbone/js/todos.js
@@ -92,7 +92,7 @@ $(function(){
     // The DOM events specific to an item.
     events: {
       "click .check"              : "toggleDone",
-      "dblclick div.todo-content" : "edit",
+      "dblclick label.todo-content" : "edit",
       "click span.todo-destroy"   : "clear",
       "keypress .todo-input"      : "updateOnEnter",
       "blur .todo-input"          : "close"


### PR DESCRIPTION
In the backbone.js todo app the dblclick event was attached to div.todo-content when it needed to be label.todo-content.
