### PR TITLE
fixed path to destroy icon

### DIFF
--- a/reference-examples/vanillajs/css/todos.css
+++ b/reference-examples/vanillajs/css/todos.css
@@ -145,7 +145,7 @@ body {
 	cursor: pointer;
 	width: 20px;
 	height: 20px;
-	background: url(../../TodoMVC/todo-example/backbone/css/destroy.png) no-repeat 0 0;
+	background: url(destroy.png) no-repeat 0 0;
 }
 #todo-list li:hover .todo-destroy {
 	display: block;


### PR DESCRIPTION
the reference example's css was pointing to an invalid path. I replaced the path, now pointing to the destroy.png icon in the same folder.
