### PR TITLE
Removed  unnecessary code

### DIFF
--- a/architecture-examples/emberjs/js/app.js
+++ b/architecture-examples/emberjs/js/app.js
@@ -13,12 +13,9 @@ Todos.todosController = Ember.ArrayProxy.create({
   content: [],
 
   createTodo: function(title) {
-    var todo = Todos.Todo.create({ title: title }),
-    stats = document.getElementById('stats-area');
+    var todo = Todos.Todo.create({ title: title });
     this.pushObject(todo);
     Todos.TodoStore.create(todo);
-
-    (stats.style.display=='block')? stats.style.display = 'inline' : stats.style.display = 'block';
   },
 
   pushObject: function (item, ignoreStorage) {


### PR DESCRIPTION
Why change `#stats-area` css display to block and inline on every added item? I removed it.

I seen `document.getElementById` and  `stats.style.display = 'inline'` and think, why not jQuery? Well, after it I seen that this code dont do nothing exactly.

I's ok to remove it?
