### PR TITLE
fix broken link to epitome home page from todo page

### DIFF
--- a/labs/architecture-examples/epitome/index.html
+++ b/labs/architecture-examples/epitome/index.html
@@ -25,7 +25,7 @@
 	<footer id="info">
 		<p>Double-click to edit a todo</p>
 		<p>Created by <a href="https://github.com/DimitarChristoff/">Dimitar Christoff</a></p>
-        <p>Powered by <a href="https://dimitarchristoff.github.com/Epitome">Epitome for MooTools</a></p>
+        <p>Powered by <a href="http://dimitarchristoff.github.com/Epitome">Epitome for MooTools</a></p>
 		<p>Part of <a href="http://todomvc.com">TodoMVC</a></p>
 	</footer>
 	<script type="text/template" id="item-template">


### PR DESCRIPTION
link to epitome docs was https, needed to be http. 
