### PR TITLE
fixed broken HTML structure

### DIFF
--- a/architecture-examples/backbone/index.html
+++ b/architecture-examples/backbone/index.html
@@ -18,13 +18,13 @@
 			<label for="toggle-all">Mark all as complete</label>
 			<ul id="todo-list"></ul>
 		</section>
-		<footer id="footer"></div>
+		<footer id="footer"></footer>
 	</section>
 	<div id="info">
 		<p>Double-click to edit a todo</p>
 		<p>Written by <a href="http://addyosmani.github.com/todomvc/">Addy Osmani</a></p>
 		<p>Part of <a href="http://todomvc.com">TodoMVC</a></p>
-	</footer>
+	</div>
   
 
 	<script type="text/template" id="item-template">


### PR DESCRIPTION
Backbone's index.html structure seemed to be broken (although it somehow worked in the browser).
The footer tag has been closed with a div and the "#info" div with a footer tag.
