### PR TITLE
Caching todo views & reuse them, so they dont remain as zombies 

### DIFF
--- a/architecture-examples/backbone/js/routers/router.js
+++ b/architecture-examples/backbone/js/routers/router.js
@@ -15,8 +15,8 @@ var app = app || {};
 			// Set the current filter to be used
 			window.app.TodoFilter = param.trim() || '';
 
-			// Trigger a collection reset/addAll
-			window.app.Todos.trigger('reset');
+			// Trigger a collection 'filter' event, causing hiding/unhiding of todo view items
+			window.app.Todos.trigger('filter');
 		}
 	});
 

--- a/architecture-examples/backbone/js/views/app.js
+++ b/architecture-examples/backbone/js/views/app.js
@@ -1,6 +1,6 @@
 var app = app || {};
 
-$(function( $ ) {
+$(function ($) {
 	'use strict';
 
 	// The Application
@@ -11,49 +11,49 @@ $(function( $ ) {
 
 		// Instead of generating a new element, bind to the existing skeleton of
 		// the App already present in the HTML.
-		el: '#todoapp',
+		el : '#todoapp',
 
 		// Our template for the line of statistics at the bottom of the app.
-		statsTemplate: _.template( $('#stats-template').html() ),
+		statsTemplate : _.template($('#stats-template').html()),
 
 		// Delegated events for creating new items, and clearing completed ones.
-		events: {
-			'keypress #new-todo': 'createOnEnter',
-			'click #clear-completed': 'clearCompleted',
-			'click #toggle-all': 'toggleAllComplete'
+		events : {
+			'keypress #new-todo' : 'createOnEnter',
+			'click #clear-completed' : 'clearCompleted',
+			'click #toggle-all' : 'toggleAllComplete'
 		},
 
 		// At initialization we bind to the relevant events on the `Todos`
 		// collection, when items are added or changed. Kick things off by
 		// loading any preexisting todos that might be saved in *localStorage*.
-		initialize: function() {
+		initialize : function () {
 			this.input = this.$('#new-todo');
 			this.allCheckbox = this.$('#toggle-all')[0];
-
-			window.app.Todos.on( 'add', this.addAll, this );
-			window.app.Todos.on( 'reset', this.addAll, this );
-			window.app.Todos.on( 'change:completed', this.addAll, this );
-			window.app.Todos.on( 'all', this.render, this );
-
 			this.$footer = this.$('#footer');
 			this.$main = this.$('#main');
+			
+			window.app.Todos.on('add', this.addOne, this);
+			window.app.Todos.on('reset', this.addAll, this);
+			window.app.Todos.on('change:completed', this.filterOne, this);
+			window.app.Todos.on("filter", this.filterAll, this);
+			window.app.Todos.on('all', this.render, this);
 
 			app.Todos.fetch();
 		},
 
 		// Re-rendering the App just means refreshing the statistics -- the rest
 		// of the app doesn't change.
-		render: function() {
+		render : function () {
 			var completed = app.Todos.completed().length;
 			var remaining = app.Todos.remaining().length;
 
-			if ( app.Todos.length ) {
+			if (app.Todos.length) {
 				this.$main.show();
 				this.$footer.show();
 
 				this.$footer.html(this.statsTemplate({
-					completed: completed,
-					remaining: remaining
+					completed : completed,
+					remaining : remaining
 				}));
 
 				this.$('#filters li a')
@@ -70,63 +70,60 @@ $(function( $ ) {
 
 		// Add a single todo item to the list by creating a view for it, and
 		// appending its element to the `<ul>`.
-		addOne: function( todo ) {
-			var view = new app.TodoView({ model: todo });
-			$('#todo-list').append( view.render().el );
+		addOne : function (todo) {
+			var view = new app.TodoView({ model : todo });
+			$('#todo-list').append(view.render().el);
 		},
 
 		// Add all items in the **Todos** collection at once.
-		addAll: function() {
+		addAll : function () {
 			this.$('#todo-list').html('');
+			app.Todos.each(this.addOne, this);
+		},
 
-			switch( app.TodoFilter ) {
-				case 'active':
-					_.each( app.Todos.remaining(), this.addOne );
-					break;
-				case 'completed':
-					_.each( app.Todos.completed(), this.addOne );
-					break;
-				default:
-					app.Todos.each( this.addOne, this );
-					break;
-			}
+		filterOne : function (todo) {
+			todo.trigger("visible");
+		},
+
+		filterAll : function () {
+			app.Todos.each(this.filterOne, this);
 		},
 
 		// Generate the attributes for a new Todo item.
-		newAttributes: function() {
+		newAttributes : function () {
 			return {
-				title: this.input.val().trim(),
-				order: app.Todos.nextOrder(),
-				completed: false
+				title : this.input.val().trim(),
+				order : app.Todos.nextOrder(),
+				completed : false
 			};
 		},
 
 		// If you hit return in the main input field, create new **Todo** model,
 		// persisting it to *localStorage*.
-		createOnEnter: function( e ) {
-			if ( e.which !== ENTER_KEY || !this.input.val().trim() ) {
+		createOnEnter : function (e) {
+			if (e.which !== ENTER_KEY || !this.input.val().trim()) {
 				return;
 			}
 
-			app.Todos.create( this.newAttributes() );
+			app.Todos.create(this.newAttributes());
 			this.input.val('');
 		},
 
 		// Clear all completed todo items, destroying their models.
-		clearCompleted: function() {
-			_.each( window.app.Todos.completed(), function( todo ) {
+		clearCompleted : function () {
+			_.each(window.app.Todos.completed(), function (todo) {
 				todo.destroy();
 			});
 
 			return false;
 		},
 
-		toggleAllComplete: function() {
+		toggleAllComplete : function () {
 			var completed = this.allCheckbox.checked;
 
-			app.Todos.each(function( todo ) {
+			app.Todos.each(function (todo) {
 				todo.save({
-					'completed': completed
+					'completed' : completed
 				});
 			});
 		}

--- a/architecture-examples/backbone/js/views/todos.js
+++ b/architecture-examples/backbone/js/views/todos.js
@@ -30,15 +30,28 @@ $(function() {
 		initialize: function() {
 			this.model.on( 'change', this.render, this );
 			this.model.on( 'destroy', this.remove, this );
+			this.model.on( 'visible', this.toggleVisible, this );
 		},
 
 		// Re-render the titles of the todo item.
-		render: function() {
+		render : function () {
 			this.$el.html( this.template( this.model.toJSON() ) );
 			this.$el.toggleClass( 'completed', this.model.get('completed') );
-
+			this.toggleVisible();
 			this.input = this.$('.edit');
 			return this;
+		},
+
+		toggleVisible : function () {
+			this.$el.toggleClass( 'hidden',  this.isHidden());
+		},
+
+		isHidden : function () {
+			var isCompleted = this.model.get('completed');
+			return ( // hidden cases only
+				(!isCompleted && app.TodoFilter === 'completed')
+				|| (isCompleted && app.TodoFilter === 'active')
+			);
 		},
 
 		// Toggle the `"completed"` state of the model.

--- a/assets/base.css
+++ b/assets/base.css
@@ -1,4 +1,5 @@
 html,
+html,
 body {
 	margin: 0;
 	padding: 0;
@@ -403,4 +404,8 @@ label[for='toggle-all'] {
 	#todo-list li .toggle {
 		background: none;
 	}
+}
+
+.hidden {
+    display: none;
 }

--- a/dependency-examples/backbone_require/js/routers/router.js
+++ b/dependency-examples/backbone_require/js/routers/router.js
@@ -14,8 +14,8 @@ define([
 			// Set the current filter to be used
 			Common.TodoFilter = param.trim() || '';
 
-			// Trigger a collection reset/addAll
-			Todos.trigger('reset');
+			// Trigger a collection 'filter' event, causing hiding/unhiding of todo view items
+			Todos.trigger('filter');
 		}
 	});
 

--- a/dependency-examples/backbone_require/js/views/app.js
+++ b/dependency-examples/backbone_require/js/views/app.js
@@ -33,10 +33,12 @@ define([
 			this.$footer = this.$('#footer');
 			this.$main = this.$('#main');
 
-			Todos.on( 'add', this.addAll, this );
+			Todos.on( 'add', this.addOne, this );
 			Todos.on( 'reset', this.addAll, this );
-			Todos.on( 'change:completed', this.addAll, this );
+			Todos.on( 'change:completed', this.filterOne, this );
+			Todos.on( "filter", this.filterAll, this);
 			Todos.on( 'all', this.render, this );
+
 			Todos.fetch();
 		},
 
@@ -69,26 +71,23 @@ define([
 
 		// Add a single todo item to the list by creating a view for it, and
 		// appending its element to the `<ul>`.
-		addOne: function( todo ) {
-			var view = new TodoView({ model: todo });
+		addOne: function (todo) {
+			var view = new TodoView({ model : todo });
 			$('#todo-list').append( view.render().el );
 		},
 
 		// Add all items in the **Todos** collection at once.
 		addAll: function() {
 			this.$('#todo-list').html('');
+			Todos.each(this.addOne, this);
+		},
 
-			switch( Common.TodoFilter ) {
-				case 'active':
-					_.each( Todos.remaining(), this.addOne );
-					break;
-				case 'completed':
-					_.each( Todos.completed(), this.addOne );
-					break;
-				default:
-					Todos.each( this.addOne, this );
-					break;
-			}
+		filterOne : function (todo) {
+			todo.trigger('visible');
+		},
+
+		filterAll : function () {
+			Todos.each(this.filterOne, this);
 		},
 
 		// Generate the attributes for a new Todo item.

--- a/dependency-examples/backbone_require/js/views/todos.js
+++ b/dependency-examples/backbone_require/js/views/todos.js
@@ -27,15 +27,28 @@ define([
 		initialize: function() {
 			this.model.on( 'change', this.render, this );
 			this.model.on( 'destroy', this.remove, this );
+			this.model.on( 'visible', this.toggleVisible, this );
 		},
 
 		// Re-render the titles of the todo item.
 		render: function() {
 			this.$el.html( this.template( this.model.toJSON() ) );
 			this.$el.toggleClass( 'completed', this.model.get('completed') );
-
+			this.toggleVisible();
 			this.input = this.$('.edit');
 			return this;
+		},
+
+		toggleVisible : function () {
+			this.$el.toggleClass( 'hidden',  this.isHidden());
+		},
+
+		isHidden : function () {
+			var isCompleted = this.model.get('completed');
+			return ( // hidden cases only
+					(!isCompleted && Common.TodoFilter === 'completed')
+					|| (isCompleted && Common.TodoFilter === 'active')
+				);
 		},
 
 		// Toggle the `"completed"` state of the model.


### PR DESCRIPTION
A simplistic non intrusive solution for the zombie views problem.

Zombie views are a very bad practice and most examples I've seen have this problem. 

Big-bone solutions like Marionette claim to solve it, but barebone backbone apps should show a way around this and at least make a note of the problem's existense.
## 

Fixes #259
