### PR TITLE
fix broken link to unlicense.org in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,4 +140,4 @@ For applications that we feel don't quite match the goals of the project, but wh
 
 ## License
 
-[The Unlicense](unlicense.org) (i.e Public Domain)
+[The Unlicense](http://unlicense.org) (i.e Public Domain)


### PR DESCRIPTION
The link to unlicense.org in the README was missing the protocol part and thus was interpreted as a relative link by markdown. Fixed it by prepending protocol part. 
