### PR TITLE
Fix r.js minification for angular_require

### DIFF
--- a/labs/dependency-examples/angularjs_require/js/app.js
+++ b/labs/dependency-examples/angularjs_require/js/app.js
@@ -1,5 +1,5 @@
 'use strict';
 
-define([], function () {
+define(['angular'], function (angular) {
     return angular.module('todomvc', []);
 });

--- a/labs/dependency-examples/angularjs_require/js/directives/todoFocus.js
+++ b/labs/dependency-examples/angularjs_require/js/directives/todoFocus.js
@@ -3,7 +3,7 @@
  * Directive that places focus on the element it is applied to when the expression it binds to evaluates to true.
  */
 define(['app'], function ( app ) {
-  app.directive('todoFocus', function( $timeout ) {
+  app.directive('todoFocus', ['$timeout', function( $timeout ) {
     return function( scope, elem, attrs ) {
       scope.$watch(attrs.todoFocus, function( newval ) {
         if ( newval ) {
@@ -13,5 +13,5 @@ define(['app'], function ( app ) {
         }
       });
     };
-  });
+  }]);
 });


### PR DESCRIPTION
I got a mail a few weeks ago from someone who wanted to use r.js to compress the angular_require app, but  couldn't get it to work because one directive wasn't correctly wrapped. Because of that minification would rename a parameter and interfere with the depedency injection.

This correctly wraps the directive and also explicitly requires the angular dependency in app.js.
