### PR TITLE
Fixing footer issues in YUI TodoMVC

### DIFF
--- a/architecture-examples/yui/index.html
+++ b/architecture-examples/yui/index.html
@@ -17,7 +17,7 @@
 			<label for="toggle-all">Mark all as complete</label>
 			<ul id="todo-list"></ul>
 		</section>
-        <footer id="footer"></footer>
+        	<footer id="footer"></footer>
 	</section>
 	<footer id="info">
 		<p>Double-click to edit a todo</p>


### PR DESCRIPTION
Looks like the last HTML update eliminated the footer from the app, and gave the footer for the credits the wrong ID.  The display is a bit messed up on the gh-pages branch right now, so this quick change should fix it.
