### PR TITLE
Updated Dart and ExtJS to use <strong> instead of <b>

### DIFF
--- a/architecture-examples/dart/web/dart/TodoApp.dart
+++ b/architecture-examples/dart/web/dart/TodoApp.dart
@@ -99,7 +99,7 @@ class TodoApp {
 		}
 		checkAllCheckboxElement.checked = (complete == todoWidgets.length);
 		var left = todoWidgets.length - complete;
-		countElement.innerHtml = '<b>${left}</b> item${left != 1 ? 's' : ''} left';
+		countElement.innerHtml = '<strong>${left}</strong> item${left != 1 ? 's' : ''} left';
 		if (complete == 0) {
 			clearCompletedElement.style.display = 'none';
 		} else {

--- a/labs/architecture-examples/extjs/js/controller/Tasks.js
+++ b/labs/architecture-examples/extjs/js/controller/Tasks.js
@@ -126,7 +126,7 @@ Ext.define('Todo.controller.Tasks', {
 		checkedCount = totalCount - count;
 
 		if (count) {
-			info = '<b>' + count + '</b> item' + (count > 1 ? 's' : '') + ' left.';
+			info = '<strong>' + count + '</strong> item' + (count > 1 ? 's' : '') + ' left.';
 		}
 
 		if (checkedCount) {


### PR DESCRIPTION
For the Dart version, I did not yet include the updated compiled code. Using dart2js from the SDK created quite a big diff and changing the compiled code would probably mess up the source map.
