### PR TITLE
Backbone remaining items counter does not update

### DIFF
--- a/architecture-examples/backbone/js/collections/todos.js
+++ b/architecture-examples/backbone/js/collections/todos.js
@@ -25,7 +25,7 @@ var app = app || {};
 
 		// Filter down the list to only todo items that are still not finished.
 		remaining: function() {
-			return this.without(this.completed());
+			return this.without.apply( this, this.completed() );
 		},
 
 		// We keep the Todos in sequential order, despite being saved by unordered


### PR DESCRIPTION
This reverts the commit that caused it.

The end-to-end tests (#255) also pass with this patch applied. :)
