### PR TITLE
Switch back to current codeparty master.

### DIFF
--- a/labs/architecture-examples/derby/package.json
+++ b/labs/architecture-examples/derby/package.json
@@ -4,7 +4,8 @@
 	"version": "0.1.0",
 	"main": "server.js",
 	"dependencies": {
-		"derby": "git://github.com/lefnire/derby#master",
+		"derby": "git://github.com/codeparty/derby#ae29fac69d",
+		"racer": "git://github.com/codeparty/racer#484b170ee5",
 		"express": "~3.0.1",
 		"gzippo": "~0.2.0"
 	},


### PR DESCRIPTION
Updates the packages.json, switching to depend on codeparty derby and racer, as per:

https://github.com/codeparty/derby/wiki/Using-Derby-%22Edge%22

albeit at the most recent commit on 20130110-0830. Tested that `make run` results in a server with the expected functionality using Chromium 22.0.1229.94 Ubuntu 12.10 (161065).
