### PR TITLE
Relative paths in DUEL example

### DIFF
--- a/labs/architecture-examples/duel/src/main/resources/views/HomePage.duel
+++ b/labs/architecture-examples/duel/src/main/resources/views/HomePage.duel
@@ -6,7 +6,7 @@
 	<title>DUEL • TodoMVC</title>
 	<link rel="stylesheet" href="/css/styles.merge">
 	<!--[if IE]>
-	<script src="../../../assets/ie.js"></script>
+	<script src="../../../../assets/ie.js"></script>
 	<![endif]-->
 </head>
 <body>
@@ -15,7 +15,7 @@
 		<p>Ported to <a href="http://duelengine.org">DUEL</a> by <a href="http://mck.me">Stephen McKamey</a></p>
 		<p>Part of <a href="http://todomvc.com">TodoMVC</a></p>
 	</footer>
-	<script src="../../../assets/base.js"></script>
+	<script src="../../../../assets/base.js"></script>
 	<script src="/js/scripts.merge"></script>
 </body>
 </html>

--- a/labs/architecture-examples/duel/www/index.html
+++ b/labs/architecture-examples/duel/www/index.html
@@ -3,21 +3,19 @@
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-
-	<title>DUEL &bull; TodoMVC</title>
-
+	<title>DUEL &#x2022; TodoMVC</title>
 	<link rel="stylesheet" href="./cdn/502117dcda6b1a71004e818c348c9de5fc80966a.css" />
 	<!--[if IE]>
-	<script src="../../../assets/ie.js"></script>
+	<script src="../../../../assets/ie.js"></script>
 	<![endif]-->
 </head>
 <body>
 	<footer id="info">
 		<p>Double-click to edit a todo</p>
 		<p>Ported to <a href="http://duelengine.org">DUEL</a> by <a href="http://mck.me">Stephen McKamey</a></p>
-		<p>Part of <a href="http://todomvc.com">TodoMVC</a>.</p>
+		<p>Part of <a href="http://todomvc.com">TodoMVC</a></p>
 	</footer>
-	<script src="../../../assets/base.js"></script>
+	<script src="../../../../assets/base.js"></script>
 	<script src="./cdn/1de7392f10ea2465d68b839144090d158ba7730f.js"></script>
 
 </body>


### PR DESCRIPTION
During the move to labs the paths for `base.js` and `ie.js` broke. I updated them and recompiled the templates, but manually reverted the paths to the compressed assets to keep the commit lean.
