### PR TITLE
Olives: Escape todo title in list rendering (#397)

### DIFF
--- a/labs/architecture-examples/olives/index.html
+++ b/labs/architecture-examples/olives/index.html
@@ -23,7 +23,7 @@
 				<li data-model="bind:toggleClass,completed,completed;">
 					<div class="view">
 						<input class="toggle" type="checkbox" data-model="bind:checked,completed">
-						<label data-model="bind:innerHTML,title" data-event="listen:dblclick,startEdit"></label>
+						<label data-model="bind:textContent,title" data-event="listen:dblclick,startEdit"></label>
 						<button class="destroy" data-event="listen:click,remove"></button>
 					</div>
 					<input class="edit" data-model="bind:value,title" data-event="listen:keydown,stopEdit; listen:blur,stopEdit">


### PR DESCRIPTION
This fixes the HTML escaping in the titles for the Olives example. See #397.

I opted for textContent, which obviously doesn't work in < IE 9. Olives seems to rely on some features like element.classList though which are only available in IE 10, so that shouldn't matter.
