### PR TITLE
Appended a trailing slash to the links for dermis, backbone_marionette, thorax.

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
 						<a href="labs/architecture-examples/cujo/index.html" data-source="http://cujojs.com" data-content="Cujo.js is an architectural framework for building highly modular, scalable, maintainable applications in Javascript.  It provides architectural plumbing, such as modules (AMD and CommonJS), declarative application composition, declarative connections, and aspect oriented programming.">cujo.js</a>
 					</li>
 					<li class="routing labs">
-						<a href="labs/architecture-examples/dermis" data-source="https://github.com/wearefractal/dermis" data-content="dermis is a tiny framework that provides models, collections, controllers, and data-binding out of the box. dermis is designed to be the simplest possible solution for creating complex applications">dermis</a>
+						<a href="labs/architecture-examples/dermis/" data-source="https://github.com/wearefractal/dermis" data-content="dermis is a tiny framework that provides models, collections, controllers, and data-binding out of the box. dermis is designed to be the simplest possible solution for creating complex applications">dermis</a>
 					</li>
 					<li class="labs">
 						<a href="labs/architecture-examples/montage/" data-source="http://montagejs.org" data-content="Montage simplifies the development of rich HTML5 applications by providing modular components, real-time two-way data binding, CommonJS dependency management, and many more conveniences.">Montage</a>
@@ -157,10 +157,10 @@
 				<h2>MVC Extension Frameworks</h2>
 				<ul class="applist">
 				<li class="routing labs">
-						<a href="labs/architecture-examples/backbone_marionette" data-source="http://marionettejs.com" data-content="Backbone.Marionette is a composite application library for Backbone.js that aims to simplify the construction of large scale JavaScript applications.">MarionetteJS</a>
+						<a href="labs/architecture-examples/backbone_marionette/" data-source="http://marionettejs.com" data-content="Backbone.Marionette is a composite application library for Backbone.js that aims to simplify the construction of large scale JavaScript applications.">MarionetteJS</a>
 					</li>
 					<li class="routing labs">
-						<a href="labs/architecture-examples/thorax" data-source="http://thoraxjs.org" data-content="An opinionated, battle tested Backbone + Handlebars framework to build large scale web applications.">Thorax</a>
+						<a href="labs/architecture-examples/thorax/" data-source="http://thoraxjs.org" data-content="An opinionated, battle tested Backbone + Handlebars framework to build large scale web applications.">Thorax</a>
 					</li>
 					<li class="routing labs">
 						<a href="labs/dependency-examples/chaplin-brunch/public/" data-source="http://chaplinjs.org" data-content="Chaplin is an architecture for JavaScript applications using the Backbone.js library. Chaplin addresses Backbone’s limitations by providing a lightweight and flexible structure that features well-proven design patterns and best practises.">Chaplin + Brunch</a>


### PR DESCRIPTION
I noticed this when I was running todomvc locally with nodeapps' http-server. When I'd click on the link for http://localhost:8080/labs/architecture-examples/thorax, it wouldn't redirect the browser to http://localhost:8080/labs/architecture-examples/thorax/, which caused a 404 for the resources that are referenced relatively. I noticed that most of the framework links on the homepage contain the trailing slash so I added a few that were missing.
