### PR TITLE
CanJS: Consistency fix for clear button

### DIFF
--- a/architecture-examples/canjs/views/todos.ejs
+++ b/architecture-examples/canjs/views/todos.ejs
@@ -34,7 +34,6 @@
     <li><a href="#!completed">Completed</a></li>
   </ul>
   <button id="clear-completed" class="<%= todos.completed() === 0 ? 'hidden' : '' %>">
-    Clear <%= todos.completed() %>
-    completed item<%= todos.completed() == 1 ? "" : "s" %>
+    Clear completed (<%= todos.completed() %>)
   </button>
 </footer>

--- a/architecture-examples/canjs/views/todos.mustache
+++ b/architecture-examples/canjs/views/todos.mustache
@@ -35,7 +35,7 @@
       <a href="#!completed">Completed</a>
     </li>
   </ul>
-  <a href="#!" id="clear-completed" class="{{^todos.completed}}hidden{{/todos.completed}}">
-    Clear {{todos.completed}} completed {{plural "item" todos.completed}}
-  </a>
+  <button id="clear-completed" class="{{^todos.completed}}hidden{{/todos.completed}}">
+    Clear completed ({{todos.completed}})
+   </button>
 </footer>

--- a/labs/dependency-examples/canjs_require/views/todos.ejs
+++ b/labs/dependency-examples/canjs_require/views/todos.ejs
@@ -31,7 +31,6 @@
     <li><a href="#!completed">Completed</a></li>
   </ul>
   <button id="clear-completed" class="<%= todos.completed() === 0 ? 'hidden' : '' %>">
-    Clear <%= todos.completed() %>
-    completed item<%= todos.completed() == 1 ? "" : "s" %>
+    Clear completed (<%= todos.completed() %>)
   </button>
 </footer>

--- a/labs/dependency-examples/canjs_require/views/todos.mustache
+++ b/labs/dependency-examples/canjs_require/views/todos.mustache
@@ -30,6 +30,6 @@
     <li><a href="#!completed">Completed</a></li>
   </ul>
   <button id="clear-completed" class="{{^todos.completed}}hidden{{/todos.completed}}">
-    Clear {{todos.completed}} completed {{plural "item" todos.completed}}
+    Clear completed ({{todos.completed}})
   </button>
 </footer>


### PR DESCRIPTION
Another small consistency fix. The CanJS apps had the old wording for clearing completed items. Also, the default architecture-example app had an anchor instead of a button.
