### PR TITLE
Marionette: Escape HTML in item titles

### DIFF
--- a/labs/architecture-examples/backbone_marionette/index.html
+++ b/labs/architecture-examples/backbone_marionette/index.html
@@ -31,10 +31,10 @@
 		<script type="text/html" id="template-todoItemView">
 			<div class="view">
 				<input class="toggle" type="checkbox" <% if (completed) { %>checked<% } %>>
-				<label><%= title %></label>
+				<label><%- title %></label>
 				<button class="destroy"></button>
 			</div>
-			<input class="edit" value="<%= title %>">
+			<input class="edit" value="<%- title %>">
 		</script>
 		<script type="text/html" id="template-todoListCompositeView">
 			<input id="toggle-all" type="checkbox">


### PR DESCRIPTION
Sorry, I forgot to mention this in #391. Here's the XSS fix for #397.
