### PR TITLE
Consistency fix for double-click hint

### DIFF
--- a/architecture-examples/angularjs-perf/index.html
+++ b/architecture-examples/angularjs-perf/index.html
@@ -54,7 +54,7 @@
     </footer>
   </section>
   <footer id="info">
-    <p>Double-click to edit a todo.</p>
+    <p>Double-click to edit a todo</p>
     <p>Credits:
       <a href="http://twitter.com/cburgdorf">Christoph Burgdorf</a>,
       <a href="http://ericbidelman.com">Eric Bidelman</a>,

--- a/architecture-examples/angularjs/index.html
+++ b/architecture-examples/angularjs/index.html
@@ -54,7 +54,7 @@
     </footer>
   </section>
   <footer id="info">
-    <p>Double-click to edit a todo.</p>
+    <p>Double-click to edit a todo</p>
     <p>Credits:
         <a href="http://twitter.com/cburgdorf">Christoph Burgdorf</a>,
         <a href="http://ericbidelman.com">Eric Bidelman</a>,

--- a/architecture-examples/knockoutjs/index.html
+++ b/architecture-examples/knockoutjs/index.html
@@ -51,7 +51,7 @@
 			</footer>
 		</section>
 		<footer id="info">
-			<span data-bind="visible: todos().length">Double-click to edit a todo</span>
+			<p>Double-click to edit a todo</p>
 			<p>Original Knockout version from <a href="https://github.com/ashish01/knockoutjs-todos">Ashish Sharma</a></p>
 			<p>Rewritten to use Knockout 2.0 and standard template by <a href="http://knockmeout.net">Ryan Niemeyer</a></p>
 			<p>Patches/fixes for cross-browser compat: <a href="http://twitter.com/addyosmani">Addy Osmani</a></p>

--- a/labs/architecture-examples/knockoutjs_classBindingProvider/index.html
+++ b/labs/architecture-examples/knockoutjs_classBindingProvider/index.html
@@ -51,7 +51,7 @@
 			</footer>
 		</section>
 		<footer id="info">
-			<span data-class="todos.listVisible">Double-click to edit a todo</span>
+			<p>Double-click to edit a todo</p>
 			<p>Original Knockout version from <a href="https://github.com/ashish01/knockoutjs-todos" target="_blank">Ashish Sharma</a></p>
 			<p>Rewritten to use Knockout 2.0 and standard template by <a href="http://knockmeout.net" target="_blank">Ryan Niemeyer</a></p>
 			<p>Patches/fixes for cross-browser compat: <a href="http://twitter.com/addyosmani" target="_blank">Addy Osmani</a></p>

--- a/labs/architecture-examples/rappidjs/app/Todo.xml
+++ b/labs/architecture-examples/rappidjs/app/Todo.xml
@@ -53,7 +53,7 @@
 		</footer>
 	</section>
 	<footer id="info">
-		<p visible="{todoList.hasItems()}">Double-click to edit a todo</p>
+		<p>Double-click to edit a todo</p>
 		<p>
 			Created by <a href="http://github.com/krebbl">Marcus Krejpowicz</a> with<a href="http://rappidjs.com">&lt; rAppid:js/&gt;</a>
 			<br/>

--- a/labs/architecture-examples/typescript-angular/index.html
+++ b/labs/architecture-examples/typescript-angular/index.html
@@ -54,7 +54,7 @@
     </footer>
   </section>
   <footer id="info">
-    <p>Double-click to edit a todo.</p>
+    <p>Double-click to edit a todo</p>
     <p>Credits:
         <a href="http://twitter.com/cburgdorf">Christoph Burgdorf</a>,
         <a href="http://ericbidelman.com">Eric Bidelman</a>,

--- a/labs/dependency-examples/angularjs_require/index.html
+++ b/labs/dependency-examples/angularjs_require/index.html
@@ -63,7 +63,7 @@
     </footer>
   </section>
   <footer id="info">
-    <p>Double-click to edit a todo.</p>
+    <p>Double-click to edit a todo</p>
     <p>Credits:
         <a href="http://twitter.com/cburgdorf">Christoph Burgdorf</a>,
         <a href="http://ericbidelman.com">Eric Bidelman</a>,

--- a/labs/dependency-examples/knockoutjs_require/index.html
+++ b/labs/dependency-examples/knockoutjs_require/index.html
@@ -41,7 +41,7 @@
 		</footer>
 	</section>
 	<footer id="info">
-		<span data-bind="visible: todos().length">Double-click to edit a todo.</span>
+		<p>Double-click to edit a todo</p>
 		<p>Original Knockout version from <a href="https://github.com/ashish01/knockoutjs-todos">Ashish Sharma</a></p>
 		<p>Rewritten to use Knockout 2.0 and standard template by <a href="http://knockmeout.net">Ryan Niemeyer</a></p>
 		<p>Patches/fixes for cross-browser compat: <a href="http://twitter.com/addyosmani">Addy Osmani</a></p>


### PR DESCRIPTION
I fixed a few inconsistencies with the double-click hint below the list. Some apps hid the hint if there were no entries in the list, which is not a bad idea per se, but isn't part of the spec.
