### PR TITLE
Removing double-escaping function call in YUI

### DIFF
--- a/architecture-examples/yui/js/views/todoview.js
+++ b/architecture-examples/yui/js/views/todoview.js
@@ -63,8 +63,7 @@ YUI.add('todo-view', function (Y) {
 		// Get the value from our input field while hiding it, and
 		// save it to our Todo when focus is lost from the field.
 		close: function () {
-			var value = this.get('inputNode').get('value');
-			var editedValue = Y.Escape.html(Y.Lang.trim(value));
+			var editedValue = this.get('inputNode').get('value');
 
 			this.get('container').removeClass('editing');
 


### PR DESCRIPTION
Real fix for #397.  

Thanks to @passy for catching it, I swear I saw it when I was `grep`ing, but forgot to remove the second double-escape.
