### PR TITLE
canjs_require: Fixed remaining item count

### DIFF
--- a/labs/dependency-examples/canjs_require/js/app.js
+++ b/labs/dependency-examples/canjs_require/js/app.js
@@ -16,8 +16,8 @@ require(['can/util/library', 'can/route', 'app/todos', 'app/models/todo', 'can/v
 		route.ready(false);
 
 		// View helper for pluralizing strings
-		can.Mustache.registerHelper('plural', function (str, count) {
-			return str + (count !== 1 ? 's' : '');
+		can.Mustache.registerHelper('todoPlural', function (str, attr) {
+			return str + (attr.call(this.todos) !== 1 ? 's' : '');
 		});
 
 		// Find all Todos

--- a/labs/dependency-examples/canjs_require/views/todos.mustache
+++ b/labs/dependency-examples/canjs_require/views/todos.mustache
@@ -22,7 +22,7 @@
 
 <footer id="footer" class="{{^todos}}hidden{{/todos}}">
   <span id="todo-count">
-    <strong>{{todos.remaining}}</strong> {{plural "item" todos.remaining}} left
+    <strong>{{todos.remaining}}</strong> {{todoPlural "item" todos.remaining}} left
   </span>
   <ul id="filters">
     <li><a class="selected" href="#!">All</a></li>


### PR DESCRIPTION
`count` is a function, so `count !== 1` always evaluated to true. Fixes #441
