### PR TITLE
Update to derby/racer master

### DIFF
--- a/labs/architecture-examples/derby/package.json
+++ b/labs/architecture-examples/derby/package.json
@@ -4,8 +4,8 @@
 	"version": "0.1.0",
 	"main": "server.js",
 	"dependencies": {
-		"derby": "git://github.com/codeparty/derby#master",
-		"racer": "git://github.com/codeparty/racer#master",
+		"derby": "git://github.com/codeparty/derby#d1ac9c0fcd",
+		"racer": "git://github.com/codeparty/racer#8d3357582e",
 		"express": "~3.0.1",
 		"gzippo": "~0.2.0"
 	},


### PR DESCRIPTION
Switch to derby/racer master until there is a better option (lke a stable and supported release).

There was a recent update to a dependency which left the existing derby/racer modules not working (https://github.com/codeparty/derby/issues/220).
