### PR TITLE
Make all _gaq config options global (window)

### DIFF
--- a/architecture-examples/agilityjs/components/todomvc-common/base.js
+++ b/architecture-examples/agilityjs/components/todomvc-common/base.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (location.hostname === 'todomvc.com') {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 
 	function getSourcePath() {

--- a/architecture-examples/angularjs-perf/components/todomvc-common/base.js
+++ b/architecture-examples/angularjs-perf/components/todomvc-common/base.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (location.hostname === 'todomvc.com') {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 
 	function getSourcePath() {

--- a/architecture-examples/angularjs/components/todomvc-common/base.js
+++ b/architecture-examples/angularjs/components/todomvc-common/base.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (location.hostname === 'todomvc.com') {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 
 	function getSourcePath() {

--- a/architecture-examples/backbone/components/todomvc-common/base.js
+++ b/architecture-examples/backbone/components/todomvc-common/base.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (location.hostname === 'todomvc.com') {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 
 	function getSourcePath() {

--- a/architecture-examples/canjs/components/todomvc-common/base.js
+++ b/architecture-examples/canjs/components/todomvc-common/base.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (location.hostname === 'todomvc.com') {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 
 	function getSourcePath() {

--- a/architecture-examples/dart/web/assets/base.js
+++ b/architecture-examples/dart/web/assets/base.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (location.hostname === 'todomvc.com') {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 
 	function getSourcePath() {

--- a/architecture-examples/emberjs/components/todomvc-common/base.js
+++ b/architecture-examples/emberjs/components/todomvc-common/base.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (location.hostname === 'todomvc.com') {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 
 	function getSourcePath() {

--- a/architecture-examples/jquery/components/todomvc-common/base.js
+++ b/architecture-examples/jquery/components/todomvc-common/base.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (location.hostname === 'todomvc.com') {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 
 	function getSourcePath() {

--- a/architecture-examples/knockoutjs/components/todomvc-common/base.js
+++ b/architecture-examples/knockoutjs/components/todomvc-common/base.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (location.hostname === 'todomvc.com') {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 
 	function getSourcePath() {

--- a/architecture-examples/spine/components/todomvc-common/base.js
+++ b/architecture-examples/spine/components/todomvc-common/base.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (location.hostname === 'todomvc.com') {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 
 	function getSourcePath() {

--- a/assets/base.js
+++ b/assets/base.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (location.hostname === 'todomvc.com') {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 
 	function getSourcePath() {

--- a/dependency-examples/backbone_require/components/todomvc-common/base.js
+++ b/dependency-examples/backbone_require/components/todomvc-common/base.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (location.hostname === 'todomvc.com') {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 
 	function getSourcePath() {

--- a/labs/architecture-examples/backbone_marionette/components/todomvc-common/base.js
+++ b/labs/architecture-examples/backbone_marionette/components/todomvc-common/base.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (location.hostname === 'todomvc.com') {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 
 	function getSourcePath() {

--- a/labs/architecture-examples/meteor/client/lib/base.js
+++ b/labs/architecture-examples/meteor/client/lib/base.js
@@ -2,6 +2,6 @@
 	'use strict';
 
 	if ( location.hostname === 'todomvc.com' ) {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 })( window );

--- a/labs/architecture-examples/socketstream/client/code/libs/base.js
+++ b/labs/architecture-examples/socketstream/client/code/libs/base.js
@@ -2,6 +2,6 @@
 	'use strict';
 
 	if ( location.hostname === 'todomvc.com' ) {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 })( window );

--- a/labs/dependency-examples/angularjs_require/components/todomvc-common/base.js
+++ b/labs/dependency-examples/angularjs_require/components/todomvc-common/base.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (location.hostname === 'todomvc.com') {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 
 	function getSourcePath() {

--- a/labs/dependency-examples/thorax_lumbar/public/base.js
+++ b/labs/dependency-examples/thorax_lumbar/public/base.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if ( location.hostname === 'todomvc.com' ) {
-		var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		window._gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
 	}
 })( window );
 


### PR DESCRIPTION
I'm pretty sure the google analytics code (in base.js) doesn't fire because the config needs to be global.

Normally the object is set up with var in the global scope, but these are all in IFFE.

![Screen Shot 2013-04-02 at 16 29 03](https://f.cloud.github.com/assets/412116/329057/416bf56a-9baa-11e2-8011-5ecf7278e4c3.png)

As you can see there is no call to http://www.google-analytics.com/__utm.gif
