### PR TITLE
Homepage: point SocketStream link to GitHub's readme.

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
 						<a href="http://todomvc.derbyjs.com" data-source="http://derbyjs.com" data-content="MVC framework making it easy to write realtime, collaborative applications that run in both Node.js and browsers.">Derby</a>
 					</li>
 					<li class="labs">
-						<a href="labs/architecture-examples/socketstream/README.md" data-source="http://www.socketstream.org" data-content="SocketStream is a fast, modular Node.js web framework dedicated to building realtime single-page apps">SocketStream</a>
+						<a href="https://github.com/addyosmani/todomvc/blob/gh-pages/labs/architecture-examples/socketstream/README.md" data-source="http://www.socketstream.org" data-content="SocketStream is a fast, modular Node.js web framework dedicated to building realtime single-page apps">SocketStream</a>
 					</li>
 					<!--
 					// Link is currently not working.


### PR DESCRIPTION
The current SocketStream example is pointing to a plain text representation of the markdown at [todomvc.com/labs/architecture-examples/socketstream/README.md](http://todomvc.com/labs/architecture-examples/socketstream/README.md)

I switched the link to point to [github.com/addyosmani/todomvc/blob/gh-pages/labs/architecture-examples/socketstream/README.md](https://github.com/addyosmani/todomvc/blob/gh-pages/labs/architecture-examples/socketstream/README.md), so the user is in the right spot to see the code being discussed.
