### PR TITLE
Add Gittip button to the top

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,10 @@
 				<nav>
 					<a href="https://github.com/addyosmani/todomvc/zipball/1.1.0" class="zocial red">Download (1.1)</a>
 					<a href="https://github.com/addyosmani/todomvc" class="zocial red">View project on GitHub</a>
+					<a href="https://www.gittip.com/tastejs/" class="zocial ltgray">
+						We receive <strong>$<var class="gittip-amount">0.00</var> / wk</strong>
+						on <strong>Gittip</strong>
+					</a>
 				</nav>
 			</div>
 			<div class="span4">

--- a/site/css/main.css
+++ b/site/css/main.css
@@ -36,7 +36,7 @@ h2 {
 
 a {
 	color: #B83F45;
-	font-weight:bold;
+	font-weight: bold;
 }
 
 a:hover {
@@ -54,6 +54,10 @@ hr {
 	border-bottom: 1px dashed #F7F7F7;
 }
 
+var {
+	font-style: normal;
+}
+
 header p {
 	font-size: 30px;
 	line-height: 1.2;
@@ -64,7 +68,7 @@ header nav {
 	margin-top: 20px;
 }
 
-header nav a:first-child {
+header nav a:not(:last-child) {
 	margin-right: 5px;
 	margin-bottom: 5px;
 }
@@ -304,6 +308,15 @@ p .label {
 
 .zocial.gray {
 	background-color: rgba(0, 0, 0, .5);
+}
+
+.zocial.ltgray {
+	color: inherit;
+	text-shadow: none;
+}
+
+.zocial.ltgray strong {
+	color: #B83F45;
 }
 
 .zocial.small {

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -2,6 +2,13 @@
 (function () {
 	'use strict';
 
+	$.fn.gittip = function (username) {
+		var $this = $(this);
+		$.getJSON('https://www.gittip.com/' + username + '/public.json', function (response) {
+			$this.text(response.receiving);
+		});
+	};
+
 	$.fn.persistantPopover = function () {
 		var popoverTimeout;
 
@@ -143,6 +150,8 @@
 
 	// Apps popover
 	$('.applist a').persistantPopover();
+
+	$('.gittip-amount').gittip('tastejs');
 
 	// Quotes
 	$('.quotes').quote([{


### PR DESCRIPTION
![Screenshot from 2013-04-23 10:17:59](https://f.cloud.github.com/assets/9906/413340/6e8cbec2-abee-11e2-86da-a46a9a9a0551.png)

Turns out Gittip has CORS enabled, so no need for ugly `!important` hacks.
