### PR TITLE
cujo.js -> cujoJS

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,316 +1,316 @@
 <!doctype html>
 <html lang="en">
 <head>
-	<meta charset="utf-8">
-	<title>TodoMVC</title>
-	<meta name="description" content="Helping you select an MV* framework - Todo apps for Backbone.js, Ember.js, AngularJS, Spine and many more">
-	<meta name="viewport" content="width=device-width,initial-scale=1">
-	<meta name="twitter:card" content="summary">
-	<meta property="og:url" content="http://todomvc.com">
-	<meta property="og:title" content="TodoMVC">
-	<meta property="og:image" content="https://raw.github.com/tastejs/todomvc/gh-pages/screenshot.png">
-	<meta property="og:description" content="Helping you select an MV* framework - Todo apps for Backbone.js, Ember.js, AngularJS, Spine and many more">
-	<!--[if lt IE 9]>
-	<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-	<![endif]-->
-	<link rel="shortcut icon" href="site/favicon.ico">
-	<link rel="stylesheet" href="site/css/bootstrap.min.css">
-	<link rel="stylesheet" href="site/css/bootstrap-responsive.min.css">
-	<link rel="stylesheet" href="site/css/main.css">
+  <meta charset="utf-8">
+  <title>TodoMVC</title>
+  <meta name="description" content="Helping you select an MV* framework - Todo apps for Backbone.js, Ember.js, AngularJS, Spine and many more">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="twitter:card" content="summary">
+  <meta property="og:url" content="http://todomvc.com">
+  <meta property="og:title" content="TodoMVC">
+  <meta property="og:image" content="https://raw.github.com/tastejs/todomvc/gh-pages/screenshot.png">
+  <meta property="og:description" content="Helping you select an MV* framework - Todo apps for Backbone.js, Ember.js, AngularJS, Spine and many more">
+  <!--[if lt IE 9]>
+  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <![endif]-->
+  <link rel="shortcut icon" href="site/favicon.ico">
+  <link rel="stylesheet" href="site/css/bootstrap.min.css">
+  <link rel="stylesheet" href="site/css/bootstrap-responsive.min.css">
+  <link rel="stylesheet" href="site/css/main.css">
 </head>
 <body>
-	<div class="container">
-		<header class="row">
-			<div class="span8">
-				<img class="logo" src="site/img/logo.svg" width="500" height="86" alt="TodoMVC">
-				<p>Helping you <strong>select</strong> an MV* framework</p>
-				<nav>
-					<a href="https://github.com/tastejs/todomvc/zipball/1.1.0" class="zocial red">Download (1.1)</a>
-					<a href="https://github.com/tastejs/todomvc" class="zocial red">View project on GitHub</a>
-					<a href="https://www.gittip.com/tastejs/" class="zocial ltgray">
-						We receive <strong>$<var class="gittip-amount">0.00</var> / wk</strong>
-						on <strong>Gittip</strong>
-					</a>
-				</nav>
-			</div>
-			<div class="span4">
-				<img class="logo-icon" src="site/img/logo-icon.png" width="330" height="330" alt="TodoMVC">
-			</div>
-		</header>
-		<div class="row">
-			<div class="span4">
-				<h2>Introduction</h2>
-				<p>Developers these days are spoiled with choice when it comes to <a href="http://coding.smashingmagazine.com/2012/07/27/journey-through-the-javascript-mvc-jungle/">selecting</a> an <strong>MV* framework</strong> for structuring and organizing their JavaScript web apps.</p>
-				<p>Backbone, Ember, AngularJS, Spine... the list of new and stable solutions continues to grow, but just how do you decide on which to use in a sea of so many options?</p>
-				<p>To help solve this problem, we created <a href="https://github.com/tastejs/todomvc">TodoMVC</a> - a project which offers the same Todo application implemented using MV* concepts in most of the popular JavaScript MV* frameworks of today.</p>
-				<a href="https://twitter.com/tastejs" class="twitter-follow-button" data-show-count="false" data-show-screen-name="false"></a>
-				<a href="https://twitter.com/share" class="twitter-share-button" data-via="tastejs" data-url="http://todomvc.com" data-text="TodoMVC - Helping you select an MV* framework - Todo apps for Backbone.js, Ember.js, AngularJS, and more"></a>
-				<div class="g-plusone" data-size="medium" data-annotation="none" data-href="http://todomvc.com"></div>
-			</div>
-			<div class="span8">
-				<h2>JavaScript Apps</h2>
-				<ul class="applist">
-					<li class="routing">
-						<a href="architecture-examples/backbone/" data-source="http://documentcloud.github.com/backbone/" data-content="Backbone.js gives structure to web applications by providing models with key-value binding and custom events, collections with a rich API of enumerable functions, views with declarative event handling, and connects it all to your existing API over a RESTful JSON interface.">Backbone.js</a>
-					</li>
-					<li class="routing">
-						<a href="architecture-examples/angularjs/" data-source="http://angularjs.org" data-content="What HTML would have been had it been designed for web apps">AngularJS</a>
-					</li>
-					<li class="routing">
-						<a href="architecture-examples/emberjs/" data-source="http://emberjs.com" data-content="Ember is a JavaScript framework for creating ambitious web applications that eliminates boilerplate and provides a standard application architecture.">Ember.js</a>
-					</li>
-					<li class="routing">
-						<a href="architecture-examples/knockoutjs/" data-source="http://knockoutjs.com" data-content="Simplify dynamic JavaScript UIs by applying the Model-View-View Model (MVVM) pattern">KnockoutJS</a>
-					</li>
-					<li class="routing">
-						<a href="architecture-examples/dojo/" data-source="http://dojotoolkit.org" data-content="Dojo saves you time and scales with your development process, using web standards as its platform. It’s the toolkit experienced developers turn to for building high quality desktop and mobile web applications.">Dojo</a>
-					</li>
-					<li class="routing">
-						<a href="architecture-examples/yui/" data-source="http://yuilibrary.com" data-content="YUI's lightweight core and modular architecture make it scalable, fast, and robust. Built by frontend engineers at Yahoo!, YUI powers the most popular websites in the world.">YUI</a>
-					</li>
-					<li class="routing">
-						<a href="architecture-examples/agilityjs/" data-source="http://agilityjs.com" data-content="Agility.js is an MVC library for Javascript that lets you write maintainable and reusable browser code without the infrastructural overhead found in other MVC libraries. The goal is to enable developers to write web apps at least as quickly as with jQuery, while simplifying long-term maintainability through MVC objects.">Agility.js</a>
-					</li>
-					<li class="routing">
-						<a href="architecture-examples/knockback/" data-source="http://kmalakoff.github.com/knockback/" data-content="Knockback.js provides Knockout.js magic for Backbone.js Models and Collections.">Knockback.js</a>
-					</li>
-					<li class="routing">
-						<a href="architecture-examples/canjs/" data-source="http://canjs.us" data-content="CanJS with jQuery. CanJS is a client-side, JavaScript framework that makes building rich web applications easy. It provides can.Model (for connecting to RESTful JSON interfaces), can.View (for template loading and caching), can.Observe (for key-value binding), can.EJS (live binding templates), can.Control (declarative event bindings) and can.route (routing support).">CanJS</a>
-					</li>
-					<li class="routing">
-						<a href="architecture-examples/maria/" data-source="https://github.com/petermichaux/maria" data-content="An MVC framework for JavaScript applications. The real MVC. The Smalltalk MVC. The Gang of Four MVC. The three core design patterns of MVC (observer, composite, and strategy) are embedded in Maria's Model, View, and Controller objects. Other patterns traditionally included in MVC implementations (e.g. factory method and template) make appearances too.">Maria</a>
-					</li>
-					<li class="labs">
-						<a href="labs/architecture-examples/cujo/index.html" data-source="http://cujojs.com" data-content="Cujo.js is an architectural framework for building highly modular, scalable, maintainable applications in Javascript.  It provides architectural plumbing, such as modules (AMD and CommonJS), declarative application composition, declarative connections, and aspect oriented programming.">cujo.js</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/architecture-examples/dermis/" data-source="https://github.com/wearefractal/dermis" data-content="dermis is a tiny framework that provides models, collections, controllers, and data-binding out of the box. dermis is designed to be the simplest possible solution for creating complex applications">dermis</a>
-					</li>
-					<li class="labs">
-						<a href="labs/architecture-examples/montage/" data-source="http://montagejs.org" data-content="Montage simplifies the development of rich HTML5 applications by providing modular components, real-time two-way data binding, CommonJS dependency management, and many more conveniences.">Montage</a>
-					</li>
-					<li class="labs">
-						<a href="labs/architecture-examples/extjs/" data-source="http://www.sencha.com/products/extjs" data-content="Ext JS 4 is the next major advancement in our JavaScript framework. Featuring expanded functionality, plugin-free charting, and a new MVC architecture it's the best Ext JS yet. Create incredible web apps for every browser.">Ext.js</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/architecture-examples/sammyjs/" data-source="http://sammyjs.org" data-content="Sammy.js is a tiny JavaScript framework developed to ease the pain and provide a basic structure for developing JavaScript applications.">Sammy.js</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/architecture-examples/stapes/" data-source="http://hay.github.com/stapes" data-content="Stapes is a (really) tiny Javascript MVC micro-framework (1.7kb) that has all the building blocks you need when writing an MVC app. It includes a powerful event system, support for inheritance, use with AMD, plugin support and more. A RequireJS Todo application is <a href='labs/dependency-examples/stapes_require/index.html'>also</a> available.">Stapes</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/architecture-examples/epitome/" data-source="http://dimitarchristoff.github.com/Epitome" data-content="Epitome is a new extensible and modular open-source MVP* framework, built out of MooTools Classes and Events.">Epitome</a>
-					</li>
+  <div class="container">
+    <header class="row">
+      <div class="span8">
+        <img class="logo" src="site/img/logo.svg" width="500" height="86" alt="TodoMVC">
+        <p>Helping you <strong>select</strong> an MV* framework</p>
+        <nav>
+          <a href="https://github.com/tastejs/todomvc/zipball/1.1.0" class="zocial red">Download (1.1)</a>
+          <a href="https://github.com/tastejs/todomvc" class="zocial red">View project on GitHub</a>
+          <a href="https://www.gittip.com/tastejs/" class="zocial ltgray">
+            We receive <strong>$<var class="gittip-amount">0.00</var> / wk</strong>
+            on <strong>Gittip</strong>
+          </a>
+        </nav>
+      </div>
+      <div class="span4">
+        <img class="logo-icon" src="site/img/logo-icon.png" width="330" height="330" alt="TodoMVC">
+      </div>
+    </header>
+    <div class="row">
+      <div class="span4">
+        <h2>Introduction</h2>
+        <p>Developers these days are spoiled with choice when it comes to <a href="http://coding.smashingmagazine.com/2012/07/27/journey-through-the-javascript-mvc-jungle/">selecting</a> an <strong>MV* framework</strong> for structuring and organizing their JavaScript web apps.</p>
+        <p>Backbone, Ember, AngularJS, Spine... the list of new and stable solutions continues to grow, but just how do you decide on which to use in a sea of so many options?</p>
+        <p>To help solve this problem, we created <a href="https://github.com/tastejs/todomvc">TodoMVC</a> - a project which offers the same Todo application implemented using MV* concepts in most of the popular JavaScript MV* frameworks of today.</p>
+        <a href="https://twitter.com/tastejs" class="twitter-follow-button" data-show-count="false" data-show-screen-name="false"></a>
+        <a href="https://twitter.com/share" class="twitter-share-button" data-via="tastejs" data-url="http://todomvc.com" data-text="TodoMVC - Helping you select an MV* framework - Todo apps for Backbone.js, Ember.js, AngularJS, and more"></a>
+        <div class="g-plusone" data-size="medium" data-annotation="none" data-href="http://todomvc.com"></div>
+      </div>
+      <div class="span8">
+        <h2>JavaScript Apps</h2>
+        <ul class="applist">
+          <li class="routing">
+            <a href="architecture-examples/backbone/" data-source="http://documentcloud.github.com/backbone/" data-content="Backbone.js gives structure to web applications by providing models with key-value binding and custom events, collections with a rich API of enumerable functions, views with declarative event handling, and connects it all to your existing API over a RESTful JSON interface.">Backbone.js</a>
+          </li>
+          <li class="routing">
+            <a href="architecture-examples/angularjs/" data-source="http://angularjs.org" data-content="What HTML would have been had it been designed for web apps">AngularJS</a>
+          </li>
+          <li class="routing">
+            <a href="architecture-examples/emberjs/" data-source="http://emberjs.com" data-content="Ember is a JavaScript framework for creating ambitious web applications that eliminates boilerplate and provides a standard application architecture.">Ember.js</a>
+          </li>
+          <li class="routing">
+            <a href="architecture-examples/knockoutjs/" data-source="http://knockoutjs.com" data-content="Simplify dynamic JavaScript UIs by applying the Model-View-View Model (MVVM) pattern">KnockoutJS</a>
+          </li>
+          <li class="routing">
+            <a href="architecture-examples/dojo/" data-source="http://dojotoolkit.org" data-content="Dojo saves you time and scales with your development process, using web standards as its platform. It’s the toolkit experienced developers turn to for building high quality desktop and mobile web applications.">Dojo</a>
+          </li>
+          <li class="routing">
+            <a href="architecture-examples/yui/" data-source="http://yuilibrary.com" data-content="YUI's lightweight core and modular architecture make it scalable, fast, and robust. Built by frontend engineers at Yahoo!, YUI powers the most popular websites in the world.">YUI</a>
+          </li>
+          <li class="routing">
+            <a href="architecture-examples/agilityjs/" data-source="http://agilityjs.com" data-content="Agility.js is an MVC library for Javascript that lets you write maintainable and reusable browser code without the infrastructural overhead found in other MVC libraries. The goal is to enable developers to write web apps at least as quickly as with jQuery, while simplifying long-term maintainability through MVC objects.">Agility.js</a>
+          </li>
+          <li class="routing">
+            <a href="architecture-examples/knockback/" data-source="http://kmalakoff.github.com/knockback/" data-content="Knockback.js provides Knockout.js magic for Backbone.js Models and Collections.">Knockback.js</a>
+          </li>
+          <li class="routing">
+            <a href="architecture-examples/canjs/" data-source="http://canjs.us" data-content="CanJS with jQuery. CanJS is a client-side, JavaScript framework that makes building rich web applications easy. It provides can.Model (for connecting to RESTful JSON interfaces), can.View (for template loading and caching), can.Observe (for key-value binding), can.EJS (live binding templates), can.Control (declarative event bindings) and can.route (routing support).">CanJS</a>
+          </li>
+          <li class="routing">
+            <a href="architecture-examples/maria/" data-source="https://github.com/petermichaux/maria" data-content="An MVC framework for JavaScript applications. The real MVC. The Smalltalk MVC. The Gang of Four MVC. The three core design patterns of MVC (observer, composite, and strategy) are embedded in Maria's Model, View, and Controller objects. Other patterns traditionally included in MVC implementations (e.g. factory method and template) make appearances too.">Maria</a>
+          </li>
+          <li class="labs">
+            <a href="labs/architecture-examples/cujo/index.html" data-source="http://cujojs.com" data-content="cujoJS is an architectural framework for building highly modular, scalable, maintainable applications in Javascript.  It provides architectural plumbing, such as modules (AMD and CommonJS), declarative application composition, declarative connections, and aspect oriented programming.">cujoJS</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/architecture-examples/dermis/" data-source="https://github.com/wearefractal/dermis" data-content="dermis is a tiny framework that provides models, collections, controllers, and data-binding out of the box. dermis is designed to be the simplest possible solution for creating complex applications">dermis</a>
+          </li>
+          <li class="labs">
+            <a href="labs/architecture-examples/montage/" data-source="http://montagejs.org" data-content="Montage simplifies the development of rich HTML5 applications by providing modular components, real-time two-way data binding, CommonJS dependency management, and many more conveniences.">Montage</a>
+          </li>
+          <li class="labs">
+            <a href="labs/architecture-examples/extjs/" data-source="http://www.sencha.com/products/extjs" data-content="Ext JS 4 is the next major advancement in our JavaScript framework. Featuring expanded functionality, plugin-free charting, and a new MVC architecture it's the best Ext JS yet. Create incredible web apps for every browser.">Ext.js</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/architecture-examples/sammyjs/" data-source="http://sammyjs.org" data-content="Sammy.js is a tiny JavaScript framework developed to ease the pain and provide a basic structure for developing JavaScript applications.">Sammy.js</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/architecture-examples/stapes/" data-source="http://hay.github.com/stapes" data-content="Stapes is a (really) tiny Javascript MVC micro-framework (1.7kb) that has all the building blocks you need when writing an MVC app. It includes a powerful event system, support for inheritance, use with AMD, plugin support and more. A RequireJS Todo application is <a href='labs/dependency-examples/stapes_require/index.html'>also</a> available.">Stapes</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/architecture-examples/epitome/" data-source="http://dimitarchristoff.github.com/Epitome" data-content="Epitome is a new extensible and modular open-source MVP* framework, built out of MooTools Classes and Events.">Epitome</a>
+          </li>
 
-					<li class="labs">
-						<a href="labs/architecture-examples/somajs/" data-source="http://somajs.github.com/somajs" data-content="soma.js is a JavaScript Model-View-Controller (MVC) framework that is meant to help developers to write loosely-coupled applications to increase scalability and maintainability.">soma.js</a>
-					</li>
-					<li class="labs">
-						<a href="labs/architecture-examples/duel/www/" data-source="https://bitbucket.org/mckamey/duel/wiki/Home" data-content="DUEL is a dual-side templating engine using HTML for layout and 100% pure JavaScript as the binding language. The same views may be executed both directly in the browser (client-side template) and on the server (server-side template).">DUEL</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/architecture-examples/kendo/" data-source="http://www.kendoui.com/" data-content="Kendo UI is a comprehensive HTML5, JavaScript framework for modern web and mobile app development">Kendo UI</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/architecture-examples/puremvc/" data-source="http://puremvc.github.com" data-content="PureMVC is a lightweight framework for creating applications based upon the classic Model-View-Controller design meta-pattern.">PureMVC</a>
-					</li>
-					<li class="labs">
-						<a href="labs/architecture-examples/olives/" data-source="https://github.com/flams/olives" data-content="Olives is a JS MVC framework that helps you create realtime UIs. It includes a set of AMD/CommonJS modules that are easily extensive, a high level of abstraction to reduce boilerplate and is based on socket.io, to provide a powerful means to communicate with node.js.">Olives</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/architecture-examples/plastronjs/" data-source="https://github.com/rhysbrettbowen/PlastronJS" data-content="PlastronJS is an mvc framework built on top of the Closure Library and built to compile with projects that use the Closure Compiler.">PlastronJS</a>
-					</li>
-					<li class="labs">
-						<a href="labs/architecture-examples/dijon/" data-source="https://github.com/creynders/dijon-framework" data-content="Dijon is an IOC and DI micro-framework for Javascript. Originally it was meant to be a port of Robotlegs, but deviated to something quite different. It remains however heavily inspired by Robotlegs, and more specifically Swiftsuspenders.">Dijon</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/architecture-examples/rappidjs/" data-source="http://www.rappidjs.com" data-content="rAppid.js is a declarative JavaScript framework for rapid web application development. It supports dependency loading, Model-View binding, View-Model binding, dependency injection and i18n.">rAppid.js</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/architecture-examples/o_O/" data-source="http://weepy.github.com/o_O/" data-content="o_O: HTML binding &lt;br> - Elegantly binds objects to HTML&lt;br>- Proxies through jQuery, Ender, etc&lt;br>- Automatic dependency resolution&lt;br>- Plays well with others">Funnyface.js</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/architecture-examples/knockoutjs_classBindingProvider/" data-source="https://github.com/rniemeyer/knockout-classBindingProvider" data-content="This project is an adaptation of /architecture-examples/knockoutjs with Ryan Niemeyer's Class Binding Provider.">Knockout +<br> ClassBinding</a>
-					</li>
-					<li class="labs">
-						<a href="labs/architecture-examples/extjs_deftjs/" data-source="http://deftjs.org/" data-content="Essential extensions for enterprise web and mobile application development with Ext JS and Sencha Touch">DeftJS + ExtJS</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/architecture-examples/ariatemplates/" data-source="http://ariatemplates.com/" data-content="Aria Templates has been designed for web apps that are used 8+ hours a day, and that need to display and process high amount of data with a minimum of bandwidth consumption.">Aria Templates</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/dependency-examples/enyo_backbone/" data-source="http://enyojs.com/" data-content="Enyo is a simple but powerful encapsulation model, which helps you factor application functionality into self-contained building blocks that are easy to reuse and maintain.">Enyo +<br>Backbone.js</a>
-					</li>
-					<li class="routing labs">
-						<a href="architecture-examples/angularjs-perf/" data-source="http://angularjs.org" data-content="What HTML would have been had it been designed for web apps. A version with several performance optimizations.">AngularJS <br>(optimized)</a>
-					</li>
-				</ul>
-				<hr>
-				<h2>Compile To JavaScript</h2>
-				<ul class="applist ctojs">
-					<li class="routing">
-						<a href="architecture-examples/spine/" data-source="http://spinejs.com" data-content="Spine is a lightweight framework for building JavaScript web applications. Spine gives you an MVC structure and then gets out of your way, allowing you to concentrate on the fun stuff, building awesome web applications.">Spine</a>
-					</li>
-					<li class="routing">
-						<a href="architecture-examples/dart/web/" data-source="http://dartlang.org" data-content="Dart firstly targets the development of modern and large scale browser-side web apps. It's an object oriented language with a C-style syntax. It has two run modes : it can be compiled to JS, and will later run in native VM in compliant browsers (just in a dedicated Chromium provided with Dart SDK for the moment).">Dart</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/architecture-examples/batman/" data-source="http://batmanjs.org" data-content="Batman.js is a framework for building rich web applications with CoffeeScript or JavaScript. App code is concise and declarative, thanks to a powerful system of view bindings and observable properties. The API is designed with developer and designer happiness as its first priority.">Batman.js</a>
-					</li>
-					<li class="routing">
-						<a href="architecture-examples/gwt/" data-source="https://developers.google.com/web-toolkit/" data-content="Google Web Toolkit (GWT) is an MVP development toolkit for building and optimizing complex browser-based applications. GWT is used by many products at Google, including Google AdWords.">GWT</a>
-					</li>
-					<li class="labs">
-						<a href="labs/architecture-examples/typescript-backbone/" data-source="http://typescriptlang.org" data-content="TypeScript is a language for application-scale JavaScript development. It offers classes, modules, interfaces and type-checking at compile time to help you build robust components.">TypeScript <br>+ Backbone.js</a>
-					</li>
-					<li class="labs routing">
-						<a href="labs/architecture-examples/typescript-angular/" data-source="http://typescriptlang.org" data-content="An AngularJS + TypeScript implementation of TodoMVC. The only significant difference between this and the vanilla Angular app is that dependency injection is done via annotated constructors, which allows minification of JavaScript.">TypeScript <br>+ AngularJS</a>
-					</li>
-					<li class="routing">
-						<a href="architecture-examples/closure/" data-source="http://code.google.com/closure/library/" data-content="The Closure Library is a broad, well-tested, modular, and cross-browser JavaScript library. You can pull just what you need from a large set of reusable UI widgets and controls, and from lower-level utilities for DOM manipulation, server communication, animation, data structures, unit testing, rich-text editing, and more.">Closure</a>
-					</li>
-					<li class="labs">
-						<a href="labs/architecture-examples/serenadejs/" data-source="https://github.com/elabs/serenade.js" data-content="Serenade.js is yet another MVC client side JavaScript framework. Why do we indulge in recreating the wheel? We believe that Serenade.js more closely follows the ideas of classical MVC than competing frameworks.">Serenade.js</a>
-					</li>
-				</ul>
-				<hr>
-				<h2>MVC Extension Frameworks</h2>
-				<ul class="applist">
-					<li class="routing labs">
-						<a href="labs/architecture-examples/backbone_marionette/" data-source="http://marionettejs.com" data-content="Backbone.Marionette is a composite application library for Backbone.js that aims to simplify the construction of large scale JavaScript applications.">MarionetteJS</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/architecture-examples/thorax/" data-source="http://thoraxjs.org" data-content="An opinionated, battle tested Backbone + Handlebars framework to build large scale web applications.">Thorax</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/dependency-examples/chaplin-brunch/public/" data-source="http://chaplinjs.org" data-content="Chaplin is an architecture for JavaScript applications using the Backbone.js library. Chaplin addresses Backbone’s limitations by providing a lightweight and flexible structure that features well-proven design patterns and best practises.">Chaplin + Brunch</a>
-					</li>
-				</ul>
-				<hr>
-				<h2>Module Loaders</h2>
-				<ul class="applist amd">
-					<li class="routing">
-						<a href="dependency-examples/backbone_require/" data-source="http://requirejs.org" data-content="RequireJS is a JavaScript file and module loader. It is optimized for in-browser use, but it can be used in other JavaScript environments, like Rhino and Node. Using a modular script loader like RequireJS will improve the speed and quality of your code.">Backbone.js + RequireJS</a>
-					</li>
-					<li>
-						<a href="labs/dependency-examples/knockoutjs_require/" data-source="http://knockoutjs.com" data-content="This project is an adaptation of /architecture-examples/knockoutjs with require.js.">Knockout + RequireJS</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/dependency-examples/angularjs_require/" data-source="http://angularjs.org" data-content="What HTML would have been had it been designed for web apps. This is an example of using it with AMD modules.">AngularJS + RequireJS</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/dependency-examples/canjs_require/" data-source="http://canjs.us" data-content="CanJS is a client-side, JavaScript framework that makes building rich web applications easy. The AMD version lets you use the framework in a fully modular fashion and will only what you actually need.">CanJS + RequireJS</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/dependency-examples/troopjs/" data-source="https://github.com/troopjs/" data-content="TroopJS attempts to package popular front-end technologies and bind them with minimal effort for the developer. It includes jQuery for DOM manipulation, ComposeJS for object composition, RequireJS for modularity and Has.js for feature detection. On top, it includes Pub/Sub support, templating, weaving (widgets to DOM) and auto-wiring.">TroopJS</a>
-					</li>
-					<li class="routing labs">
-						<a href="labs/dependency-examples/thorax_lumbar/public/" data-source="http://walmartlabs.github.com/lumbar" data-content="An opinionated, battle tested Backbone + Handlebars framework to build large scale web applications. This implementation uses Lumbar, a route based module loader.">Thorax + Lumbar</a>
-					</li>
-					<li class="routing">
-						<a href="dependency-examples/flight/" data-source="http://twitter.github.com/flight" data-content="Flight is a lightweight, component-based JavaScript framework that maps behavior to DOM nodes. Twitter uses it for their web applications.">Flight</a>
-					</li>
-				</ul>
-				<hr>
-				<h2>Real-time</h2>
-				<ul class="applist">
-					<li class="labs">
-						<a href="http://todomvcapp.meteor.com" data-source="http://meteor.com" data-content="Meteor is an ultra-simple environment for building modern websites.A Meteor application is a mix of JavaScript that runs inside a client web browser, JavaScript that runs on the Meteor server inside a Node.js container, and all the supporting HTML fragments, CSS rules, and static assets. Meteor automates the packaging and transmission of these different components. And, it is quite flexible about how you choose to structure those components in your file tree.">Meteor</a>
-					</li>
-					<li class="labs">
-						<a href="http://todomvc.derbyjs.com" data-source="http://derbyjs.com" data-content="MVC framework making it easy to write realtime, collaborative applications that run in both Node.js and browsers.">Derby</a>
-					</li>
-					<li class="labs">
-						<a href="https://github.com/tastejs/todomvc/blob/gh-pages/labs/architecture-examples/socketstream/README.md" data-source="http://www.socketstream.org" data-content="SocketStream is a fast, modular Node.js web framework dedicated to building realtime single-page apps">SocketStream</a>
-					</li>
-					<!--
-					// Link is currently not working.
-					<li class="routing labs">
-						<a href="http://todomvc.crypho.com" data-source="https://github.com/ggozad/Backbone.xmpp" data-content="Backbone.xmpp is a drop-in replacement for Backbone’s RESTful API, allowing models/collections to be persisted on XMPP Pub-Sub nodes providing real-time updates.">Backbone.xmpp</a>
-					</li>
-					-->
-				</ul>
-				<hr>
-				<h2>Compare these to a non-framework implementation</h2>
-				<ul class="applist">
-					<li>
-						<a href="vanilla-examples/vanillajs/" data-source="https://developer.mozilla.org/en/JavaScript" data-content="You know JavaScript right? :P">Vanilla JS</a>
-					</li>
-					<li>
-						<a href="architecture-examples/jquery/" data-source="http://jquery.com" data-content="jQuery is a fast and concise JavaScript Library that simplifies HTML document traversing, event handling, animating, and Ajax interactions for rapid web development. jQuery is designed to change the way that you write JavaScript.">jQuery</a>
-					</li>
-				</ul>
-				<p>* <span class="label">R</span> = App also demonstrates routing</p>
-				<p>* Maroon = App requires further work to be spec-compliant</p>
-			</div>
-		</div>
-		<hr>
-		<div class="row">
-			<div class="span6 quotes">
-				<blockquote class="quote speech-bubble">
-					<p></p>
-					<footer>
-						<img width="40" height="40" alt="">
-						<a></a>
-					</footer>
-				</blockquote>
-			</div>
-			<div class="span6">
-				<img class="screenshot" src="site/img/screenshot.png" width="558" height="246" alt="Todo app screenshot">
-			</div>
-		</div>
-		<hr>
-		<div class="row">
-			<div class="span4">
-			<h2>New in 1.1 - 2013-02-14</h2>
-			<ul class="whats-new">
-			<li>We now have 18 stable apps and 36 in labs.
-				<label for="news-expander"><a>New since 1.0.1 ▼</a></label>
-				<input type="checkbox" id="news-expander">
-				<ul class="collapsed" id="new-apps">
-				<li><a href="architecture-examples/dart/web/">Dart</a></li>
-				<li><a href="labs/architecture-examples/typescript-backbone/">TypeScript + Backbone.js</a></li>
-				<li><a href="labs/architecture-examples/typescript-angular/">TypeScript + AngularJS</a></li>
-				<li><a href="labs/architecture-examples/serenadejs/">Serenade.js</a></li>
-				<li><a href="labs/dependency-examples/canjs_require/">CanJS + RequireJS</a></li>
-				<li><a href="labs/dependency-examples/chaplin-brunch/public/">Chaplin + Brunch</a></li>
-				<li><a href="labs/dependency-examples/thorax_lumbar/public/">Thorax + Lumbar</a></li>
-				<li><a href="labs/architecture-examples/kendo/">Kendo UI</a></li>
-				<li><a href="architecture-examples/canjs/">CanJS</a> replaced the JavaScriptMVC app</li>
-				</ul>
-			</li>
-			<li>Many app frameworks and libraries have been upgraded to the latest version</li>
-			<li>XSS issues in several apps have been resolved</li>
-			<li>The homepage got reorganized with new categories</li>
-			<li>Various consistency fixes across all apps</li>
-			</ul>
-			</div>
-			<div class="span4">
-				<h2>Selecting a Framework</h2>
-				<p>Once you've downloaded the latest release and played around with the apps, you'll want to decide on a specific framework to try out.</p>
-				<p>Study the syntax required for defining models, views and (where applicable) controllers and classes in the frameworks you're interested in and try your hand at editing the code to see how it feels using it first-hand.</p>
-				<p>Please ensure that if you're happy with this, you do spend more time investigating the framework (including reading the official docs, the source and its complete feature list). There's often a lot more to a framework than what we present in our examples.</p>
-			</div>
-			<div class="span4">
-				<h2>Getting Involved</h2>
-				<p>Is there a bug we haven't fixed or an MV* framework you feel would benefit from being included in TodoMVC?</p>
-				<p>If so, feel free to fork the repo, read our <a href="https://github.com/tastejs/todomvc/wiki">contribution guidelines</a>, and submit a pull request &mdash; we'll be happy to review it for inclusion.</p>
-				<p>Make sure you use the <a href="https://github.com/tastejs/todomvc/tree/gh-pages/template">template</a> as a starting point and read the <a href="https://github.com/tastejs/todomvc/wiki/App-Specification">app specification</a>.</p>
-				<p>
-					<a class="zocial small gray" href="https://github.com/tastejs/todomvc/wiki">Submit Pull Request &raquo;</a>
-				</p>
-			</div>
-		</div>
-		<hr>
-		<footer class="credit">
-			<p>Brought to you by<a href="https://github.com/addyosmani"><img src="http://gravatar.com/avatar/96270e4c3e5e9806cf7245475c00b275?s=80" width="40" height="40" alt="Addy Osmani">Addy Osmani</a> and <a href="https://github.com/sindresorhus"><img src="http://gravatar.com/avatar/d36a92237c75c5337c17b60d90686bf9.png?s=80" width="40" height="40" alt="Sindre Sorhus">Sindre Sorhus</a></p>
-		</footer>
-	</div>
-	<script src="assets/jquery.min.js"></script>
-	<script src="site/js/bootstrap.min.js"></script>
-	<script src="site/js/main.js"></script>
-	<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-	<script>(function(){var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;po.src = 'https://apis.google.com/js/plusone.js';var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);})();</script>
-	<script>var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));</script>
+          <li class="labs">
+            <a href="labs/architecture-examples/somajs/" data-source="http://somajs.github.com/somajs" data-content="soma.js is a JavaScript Model-View-Controller (MVC) framework that is meant to help developers to write loosely-coupled applications to increase scalability and maintainability.">soma.js</a>
+          </li>
+          <li class="labs">
+            <a href="labs/architecture-examples/duel/www/" data-source="https://bitbucket.org/mckamey/duel/wiki/Home" data-content="DUEL is a dual-side templating engine using HTML for layout and 100% pure JavaScript as the binding language. The same views may be executed both directly in the browser (client-side template) and on the server (server-side template).">DUEL</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/architecture-examples/kendo/" data-source="http://www.kendoui.com/" data-content="Kendo UI is a comprehensive HTML5, JavaScript framework for modern web and mobile app development">Kendo UI</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/architecture-examples/puremvc/" data-source="http://puremvc.github.com" data-content="PureMVC is a lightweight framework for creating applications based upon the classic Model-View-Controller design meta-pattern.">PureMVC</a>
+          </li>
+          <li class="labs">
+            <a href="labs/architecture-examples/olives/" data-source="https://github.com/flams/olives" data-content="Olives is a JS MVC framework that helps you create realtime UIs. It includes a set of AMD/CommonJS modules that are easily extensive, a high level of abstraction to reduce boilerplate and is based on socket.io, to provide a powerful means to communicate with node.js.">Olives</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/architecture-examples/plastronjs/" data-source="https://github.com/rhysbrettbowen/PlastronJS" data-content="PlastronJS is an mvc framework built on top of the Closure Library and built to compile with projects that use the Closure Compiler.">PlastronJS</a>
+          </li>
+          <li class="labs">
+            <a href="labs/architecture-examples/dijon/" data-source="https://github.com/creynders/dijon-framework" data-content="Dijon is an IOC and DI micro-framework for Javascript. Originally it was meant to be a port of Robotlegs, but deviated to something quite different. It remains however heavily inspired by Robotlegs, and more specifically Swiftsuspenders.">Dijon</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/architecture-examples/rappidjs/" data-source="http://www.rappidjs.com" data-content="rAppid.js is a declarative JavaScript framework for rapid web application development. It supports dependency loading, Model-View binding, View-Model binding, dependency injection and i18n.">rAppid.js</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/architecture-examples/o_O/" data-source="http://weepy.github.com/o_O/" data-content="o_O: HTML binding &lt;br> - Elegantly binds objects to HTML&lt;br>- Proxies through jQuery, Ender, etc&lt;br>- Automatic dependency resolution&lt;br>- Plays well with others">Funnyface.js</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/architecture-examples/knockoutjs_classBindingProvider/" data-source="https://github.com/rniemeyer/knockout-classBindingProvider" data-content="This project is an adaptation of /architecture-examples/knockoutjs with Ryan Niemeyer's Class Binding Provider.">Knockout +<br> ClassBinding</a>
+          </li>
+          <li class="labs">
+            <a href="labs/architecture-examples/extjs_deftjs/" data-source="http://deftjs.org/" data-content="Essential extensions for enterprise web and mobile application development with Ext JS and Sencha Touch">DeftJS + ExtJS</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/architecture-examples/ariatemplates/" data-source="http://ariatemplates.com/" data-content="Aria Templates has been designed for web apps that are used 8+ hours a day, and that need to display and process high amount of data with a minimum of bandwidth consumption.">Aria Templates</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/dependency-examples/enyo_backbone/" data-source="http://enyojs.com/" data-content="Enyo is a simple but powerful encapsulation model, which helps you factor application functionality into self-contained building blocks that are easy to reuse and maintain.">Enyo +<br>Backbone.js</a>
+          </li>
+          <li class="routing labs">
+            <a href="architecture-examples/angularjs-perf/" data-source="http://angularjs.org" data-content="What HTML would have been had it been designed for web apps. A version with several performance optimizations.">AngularJS <br>(optimized)</a>
+          </li>
+        </ul>
+        <hr>
+        <h2>Compile To JavaScript</h2>
+        <ul class="applist ctojs">
+          <li class="routing">
+            <a href="architecture-examples/spine/" data-source="http://spinejs.com" data-content="Spine is a lightweight framework for building JavaScript web applications. Spine gives you an MVC structure and then gets out of your way, allowing you to concentrate on the fun stuff, building awesome web applications.">Spine</a>
+          </li>
+          <li class="routing">
+            <a href="architecture-examples/dart/web/" data-source="http://dartlang.org" data-content="Dart firstly targets the development of modern and large scale browser-side web apps. It's an object oriented language with a C-style syntax. It has two run modes : it can be compiled to JS, and will later run in native VM in compliant browsers (just in a dedicated Chromium provided with Dart SDK for the moment).">Dart</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/architecture-examples/batman/" data-source="http://batmanjs.org" data-content="Batman.js is a framework for building rich web applications with CoffeeScript or JavaScript. App code is concise and declarative, thanks to a powerful system of view bindings and observable properties. The API is designed with developer and designer happiness as its first priority.">Batman.js</a>
+          </li>
+          <li class="routing">
+            <a href="architecture-examples/gwt/" data-source="https://developers.google.com/web-toolkit/" data-content="Google Web Toolkit (GWT) is an MVP development toolkit for building and optimizing complex browser-based applications. GWT is used by many products at Google, including Google AdWords.">GWT</a>
+          </li>
+          <li class="labs">
+            <a href="labs/architecture-examples/typescript-backbone/" data-source="http://typescriptlang.org" data-content="TypeScript is a language for application-scale JavaScript development. It offers classes, modules, interfaces and type-checking at compile time to help you build robust components.">TypeScript <br>+ Backbone.js</a>
+          </li>
+          <li class="labs routing">
+            <a href="labs/architecture-examples/typescript-angular/" data-source="http://typescriptlang.org" data-content="An AngularJS + TypeScript implementation of TodoMVC. The only significant difference between this and the vanilla Angular app is that dependency injection is done via annotated constructors, which allows minification of JavaScript.">TypeScript <br>+ AngularJS</a>
+          </li>
+          <li class="routing">
+            <a href="architecture-examples/closure/" data-source="http://code.google.com/closure/library/" data-content="The Closure Library is a broad, well-tested, modular, and cross-browser JavaScript library. You can pull just what you need from a large set of reusable UI widgets and controls, and from lower-level utilities for DOM manipulation, server communication, animation, data structures, unit testing, rich-text editing, and more.">Closure</a>
+          </li>
+          <li class="labs">
+            <a href="labs/architecture-examples/serenadejs/" data-source="https://github.com/elabs/serenade.js" data-content="Serenade.js is yet another MVC client side JavaScript framework. Why do we indulge in recreating the wheel? We believe that Serenade.js more closely follows the ideas of classical MVC than competing frameworks.">Serenade.js</a>
+          </li>
+        </ul>
+        <hr>
+        <h2>MVC Extension Frameworks</h2>
+        <ul class="applist">
+          <li class="routing labs">
+            <a href="labs/architecture-examples/backbone_marionette/" data-source="http://marionettejs.com" data-content="Backbone.Marionette is a composite application library for Backbone.js that aims to simplify the construction of large scale JavaScript applications.">MarionetteJS</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/architecture-examples/thorax/" data-source="http://thoraxjs.org" data-content="An opinionated, battle tested Backbone + Handlebars framework to build large scale web applications.">Thorax</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/dependency-examples/chaplin-brunch/public/" data-source="http://chaplinjs.org" data-content="Chaplin is an architecture for JavaScript applications using the Backbone.js library. Chaplin addresses Backbone’s limitations by providing a lightweight and flexible structure that features well-proven design patterns and best practises.">Chaplin + Brunch</a>
+          </li>
+        </ul>
+        <hr>
+        <h2>Module Loaders</h2>
+        <ul class="applist amd">
+          <li class="routing">
+            <a href="dependency-examples/backbone_require/" data-source="http://requirejs.org" data-content="RequireJS is a JavaScript file and module loader. It is optimized for in-browser use, but it can be used in other JavaScript environments, like Rhino and Node. Using a modular script loader like RequireJS will improve the speed and quality of your code.">Backbone.js + RequireJS</a>
+          </li>
+          <li>
+            <a href="labs/dependency-examples/knockoutjs_require/" data-source="http://knockoutjs.com" data-content="This project is an adaptation of /architecture-examples/knockoutjs with require.js.">Knockout + RequireJS</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/dependency-examples/angularjs_require/" data-source="http://angularjs.org" data-content="What HTML would have been had it been designed for web apps. This is an example of using it with AMD modules.">AngularJS + RequireJS</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/dependency-examples/canjs_require/" data-source="http://canjs.us" data-content="CanJS is a client-side, JavaScript framework that makes building rich web applications easy. The AMD version lets you use the framework in a fully modular fashion and will only what you actually need.">CanJS + RequireJS</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/dependency-examples/troopjs/" data-source="https://github.com/troopjs/" data-content="TroopJS attempts to package popular front-end technologies and bind them with minimal effort for the developer. It includes jQuery for DOM manipulation, ComposeJS for object composition, RequireJS for modularity and Has.js for feature detection. On top, it includes Pub/Sub support, templating, weaving (widgets to DOM) and auto-wiring.">TroopJS</a>
+          </li>
+          <li class="routing labs">
+            <a href="labs/dependency-examples/thorax_lumbar/public/" data-source="http://walmartlabs.github.com/lumbar" data-content="An opinionated, battle tested Backbone + Handlebars framework to build large scale web applications. This implementation uses Lumbar, a route based module loader.">Thorax + Lumbar</a>
+          </li>
+          <li class="routing">
+            <a href="dependency-examples/flight/" data-source="http://twitter.github.com/flight" data-content="Flight is a lightweight, component-based JavaScript framework that maps behavior to DOM nodes. Twitter uses it for their web applications.">Flight</a>
+          </li>
+        </ul>
+        <hr>
+        <h2>Real-time</h2>
+        <ul class="applist">
+          <li class="labs">
+            <a href="http://todomvcapp.meteor.com" data-source="http://meteor.com" data-content="Meteor is an ultra-simple environment for building modern websites.A Meteor application is a mix of JavaScript that runs inside a client web browser, JavaScript that runs on the Meteor server inside a Node.js container, and all the supporting HTML fragments, CSS rules, and static assets. Meteor automates the packaging and transmission of these different components. And, it is quite flexible about how you choose to structure those components in your file tree.">Meteor</a>
+          </li>
+          <li class="labs">
+            <a href="http://todomvc.derbyjs.com" data-source="http://derbyjs.com" data-content="MVC framework making it easy to write realtime, collaborative applications that run in both Node.js and browsers.">Derby</a>
+          </li>
+          <li class="labs">
+            <a href="https://github.com/tastejs/todomvc/blob/gh-pages/labs/architecture-examples/socketstream/README.md" data-source="http://www.socketstream.org" data-content="SocketStream is a fast, modular Node.js web framework dedicated to building realtime single-page apps">SocketStream</a>
+          </li>
+          <!--
+          // Link is currently not working.
+          <li class="routing labs">
+            <a href="http://todomvc.crypho.com" data-source="https://github.com/ggozad/Backbone.xmpp" data-content="Backbone.xmpp is a drop-in replacement for Backbone’s RESTful API, allowing models/collections to be persisted on XMPP Pub-Sub nodes providing real-time updates.">Backbone.xmpp</a>
+          </li>
+          -->
+        </ul>
+        <hr>
+        <h2>Compare these to a non-framework implementation</h2>
+        <ul class="applist">
+          <li>
+            <a href="vanilla-examples/vanillajs/" data-source="https://developer.mozilla.org/en/JavaScript" data-content="You know JavaScript right? :P">Vanilla JS</a>
+          </li>
+          <li>
+            <a href="architecture-examples/jquery/" data-source="http://jquery.com" data-content="jQuery is a fast and concise JavaScript Library that simplifies HTML document traversing, event handling, animating, and Ajax interactions for rapid web development. jQuery is designed to change the way that you write JavaScript.">jQuery</a>
+          </li>
+        </ul>
+        <p>* <span class="label">R</span> = App also demonstrates routing</p>
+        <p>* Maroon = App requires further work to be spec-compliant</p>
+      </div>
+    </div>
+    <hr>
+    <div class="row">
+      <div class="span6 quotes">
+        <blockquote class="quote speech-bubble">
+          <p></p>
+          <footer>
+            <img width="40" height="40" alt="">
+            <a></a>
+          </footer>
+        </blockquote>
+      </div>
+      <div class="span6">
+        <img class="screenshot" src="site/img/screenshot.png" width="558" height="246" alt="Todo app screenshot">
+      </div>
+    </div>
+    <hr>
+    <div class="row">
+      <div class="span4">
+      <h2>New in 1.1 - 2013-02-14</h2>
+      <ul class="whats-new">
+      <li>We now have 18 stable apps and 36 in labs.
+        <label for="news-expander"><a>New since 1.0.1 ▼</a></label>
+        <input type="checkbox" id="news-expander">
+        <ul class="collapsed" id="new-apps">
+        <li><a href="architecture-examples/dart/web/">Dart</a></li>
+        <li><a href="labs/architecture-examples/typescript-backbone/">TypeScript + Backbone.js</a></li>
+        <li><a href="labs/architecture-examples/typescript-angular/">TypeScript + AngularJS</a></li>
+        <li><a href="labs/architecture-examples/serenadejs/">Serenade.js</a></li>
+        <li><a href="labs/dependency-examples/canjs_require/">CanJS + RequireJS</a></li>
+        <li><a href="labs/dependency-examples/chaplin-brunch/public/">Chaplin + Brunch</a></li>
+        <li><a href="labs/dependency-examples/thorax_lumbar/public/">Thorax + Lumbar</a></li>
+        <li><a href="labs/architecture-examples/kendo/">Kendo UI</a></li>
+        <li><a href="architecture-examples/canjs/">CanJS</a> replaced the JavaScriptMVC app</li>
+        </ul>
+      </li>
+      <li>Many app frameworks and libraries have been upgraded to the latest version</li>
+      <li>XSS issues in several apps have been resolved</li>
+      <li>The homepage got reorganized with new categories</li>
+      <li>Various consistency fixes across all apps</li>
+      </ul>
+      </div>
+      <div class="span4">
+        <h2>Selecting a Framework</h2>
+        <p>Once you've downloaded the latest release and played around with the apps, you'll want to decide on a specific framework to try out.</p>
+        <p>Study the syntax required for defining models, views and (where applicable) controllers and classes in the frameworks you're interested in and try your hand at editing the code to see how it feels using it first-hand.</p>
+        <p>Please ensure that if you're happy with this, you do spend more time investigating the framework (including reading the official docs, the source and its complete feature list). There's often a lot more to a framework than what we present in our examples.</p>
+      </div>
+      <div class="span4">
+        <h2>Getting Involved</h2>
+        <p>Is there a bug we haven't fixed or an MV* framework you feel would benefit from being included in TodoMVC?</p>
+        <p>If so, feel free to fork the repo, read our <a href="https://github.com/tastejs/todomvc/wiki">contribution guidelines</a>, and submit a pull request &mdash; we'll be happy to review it for inclusion.</p>
+        <p>Make sure you use the <a href="https://github.com/tastejs/todomvc/tree/gh-pages/template">template</a> as a starting point and read the <a href="https://github.com/tastejs/todomvc/wiki/App-Specification">app specification</a>.</p>
+        <p>
+          <a class="zocial small gray" href="https://github.com/tastejs/todomvc/wiki">Submit Pull Request &raquo;</a>
+        </p>
+      </div>
+    </div>
+    <hr>
+    <footer class="credit">
+      <p>Brought to you by<a href="https://github.com/addyosmani"><img src="http://gravatar.com/avatar/96270e4c3e5e9806cf7245475c00b275?s=80" width="40" height="40" alt="Addy Osmani">Addy Osmani</a> and <a href="https://github.com/sindresorhus"><img src="http://gravatar.com/avatar/d36a92237c75c5337c17b60d90686bf9.png?s=80" width="40" height="40" alt="Sindre Sorhus">Sindre Sorhus</a></p>
+    </footer>
+  </div>
+  <script src="assets/jquery.min.js"></script>
+  <script src="site/js/bootstrap.min.js"></script>
+  <script src="site/js/main.js"></script>
+  <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+  <script>(function(){var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;po.src = 'https://apis.google.com/js/plusone.js';var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);})();</script>
+  <script>var _gaq=[['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));</script>
 </body>
 </html>


### PR DESCRIPTION
I believe they now prefer the "cujoJS" phrasing over "cujo.js". I just made a wee update to the index.html file.
