### PR TITLE
#568 Fix - insertAdjacentElement

### DIFF
--- a/architecture-examples/agilityjs/bower_components/todomvc-common/base.js
+++ b/architecture-examples/agilityjs/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/architecture-examples/angularjs-perf/bower_components/todomvc-common/base.js
+++ b/architecture-examples/angularjs-perf/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/architecture-examples/angularjs/bower_components/todomvc-common/base.js
+++ b/architecture-examples/angularjs/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/architecture-examples/backbone/bower_components/todomvc-common/base.js
+++ b/architecture-examples/backbone/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/architecture-examples/canjs/bower_components/todomvc-common/base.js
+++ b/architecture-examples/canjs/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/architecture-examples/closure/bower_components/todomvc-common/base.js
+++ b/architecture-examples/closure/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/architecture-examples/dart/web/bower_components/todomvc-common/base.js
+++ b/architecture-examples/dart/web/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/architecture-examples/dojo/bower_components/todomvc-common/base.js
+++ b/architecture-examples/dojo/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/architecture-examples/emberjs/bower_components/todomvc-common/base.js
+++ b/architecture-examples/emberjs/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/architecture-examples/gwt/bower_components/todomvc-common/base.js
+++ b/architecture-examples/gwt/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/architecture-examples/jquery/bower_components/todomvc-common/base.js
+++ b/architecture-examples/jquery/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/architecture-examples/knockback/bower_components/todomvc-common/base.js
+++ b/architecture-examples/knockback/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/architecture-examples/knockoutjs/bower_components/todomvc-common/base.js
+++ b/architecture-examples/knockoutjs/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/architecture-examples/maria/bower_components/todomvc-common/base.js
+++ b/architecture-examples/maria/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/architecture-examples/spine/bower_components/todomvc-common/base.js
+++ b/architecture-examples/spine/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/architecture-examples/yui/bower_components/todomvc-common/base.js
+++ b/architecture-examples/yui/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/dependency-examples/backbone_require/bower_components/todomvc-common/base.js
+++ b/dependency-examples/backbone_require/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/dependency-examples/flight/bower_components/todomvc-common/base.js
+++ b/dependency-examples/flight/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/ariatemplates/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/ariatemplates/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/backbone.xmpp/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/backbone.xmpp/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/backbone_marionette/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/backbone_marionette/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/batman/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/batman/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/cujo/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/cujo/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/derby/public/components/todomvc-common/base.js
+++ b/labs/architecture-examples/derby/public/components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/dermis/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/dermis/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/dijon/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/dijon/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/duel/src/main/webapp/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/duel/src/main/webapp/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/epitome/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/epitome/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/extjs/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/extjs/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/extjs_deftjs/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/extjs_deftjs/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/kendo/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/kendo/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/knockoutjs_classBindingProvider/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/knockoutjs_classBindingProvider/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/meteor/client/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/meteor/client/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/montage/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/montage/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/o_O/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/o_O/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/olives/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/olives/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/plastronjs/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/plastronjs/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/puremvc/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/puremvc/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/rappidjs/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/rappidjs/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/sammyjs/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/sammyjs/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/serenadejs/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/serenadejs/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/socketstream/client/code/libs/todomvc-common/base.js
+++ b/labs/architecture-examples/socketstream/client/code/libs/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/somajs/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/somajs/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/stapes/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/stapes/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/thorax/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/thorax/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/typescript-angular/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/typescript-angular/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/architecture-examples/typescript-backbone/bower_components/todomvc-common/base.js
+++ b/labs/architecture-examples/typescript-backbone/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/dependency-examples/angularjs_require/bower_components/todomvc-common/base.js
+++ b/labs/dependency-examples/angularjs_require/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/dependency-examples/backbone_marionette_require/bower_components/todomvc-common/base.js
+++ b/labs/dependency-examples/backbone_marionette_require/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/dependency-examples/canjs_require/bower_components/todomvc-common/base.js
+++ b/labs/dependency-examples/canjs_require/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/dependency-examples/chaplin-brunch/bower_components/todomvc-common/base.js
+++ b/labs/dependency-examples/chaplin-brunch/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/dependency-examples/enyo_backbone/bower_components/todomvc-common/base.js
+++ b/labs/dependency-examples/enyo_backbone/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/dependency-examples/knockoutjs_require/bower_components/todomvc-common/base.js
+++ b/labs/dependency-examples/knockoutjs_require/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/dependency-examples/stapes_require/bower_components/todomvc-common/base.js
+++ b/labs/dependency-examples/stapes_require/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/dependency-examples/thorax_lumbar/bower_components/todomvc-common/base.js
+++ b/labs/dependency-examples/thorax_lumbar/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/labs/dependency-examples/troopjs/bower_components/todomvc-common/base.js
+++ b/labs/dependency-examples/troopjs/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/template/bower_components/todomvc-common/base.js
+++ b/template/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();

--- a/vanilla-examples/vanillajs/bower_components/todomvc-common/base.js
+++ b/vanilla-examples/vanillajs/bower_components/todomvc-common/base.js
@@ -173,7 +173,7 @@
 		aside.className = 'learn';
 
 		document.body.className = (document.body.className + ' learn-bar').trim();
-		document.body.insertAdjacentElement('afterBegin', aside);
+		document.body.insertAdjacentHTML('afterBegin', aside.outerHTML);
 	};
 
 	appendSourceLink();


### PR DESCRIPTION
(#568)

I used insertAdjacentElement in the initial todomvc-common sidebar implementation without realizing FF doesn't like that.

This PR replaces that call with insertAdjacentHTML, which seems to have support across the supported browsers.
