### PR TITLE
Updated Enyo/Backbone lab to not remove the Learn sidebar.

### DIFF
--- a/labs/dependency-examples/enyo_backbone/index.html
+++ b/labs/dependency-examples/enyo_backbone/index.html
@@ -1,15 +1,17 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-framework="enyo">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 	<title>Enyo & Backbone.js • TodoMVC</title>
 	<link rel="stylesheet" href="bower_components/todomvc-common/base.css">
 </head>
-<body class="enyo-unselectable">
-	<!-- Enyo comes with a build and deploy process that will minify and concatenate your files into 2 js files. One for enyo, and one for app code. For the purpose of demonstration, I used the debug loading library to handle the dependency management. The loader nagivates directories for package.js files and injects files they list into the DOM. -->
-	<script src="bower_components/todomvc-common/base.js"></script>
-	<script src="enyo/enyo.js"></script>
-	<script src="js/package.js"></script>
+<body>
+	<div id="todo-container" class="enyo-unselectable">
+		<!-- Enyo comes with a build and deploy process that will minify and concatenate your files into 2 js files. One for enyo, and one for app code. For the purpose of demonstration, I used the debug loading library to handle the dependency management. The loader nagivates directories for package.js files and injects files they list into the DOM. -->
+		<script src="bower_components/todomvc-common/base.js"></script>
+		<script src="enyo/enyo.js"></script>
+		<script src="js/package.js"></script>
+	</div>
 </body>
 </html>

--- a/labs/dependency-examples/enyo_backbone/js/start.js
+++ b/labs/dependency-examples/enyo_backbone/js/start.js
@@ -2,6 +2,9 @@
 /*global enyo:false, ToDo:false */
 // Once everything is loaded through enyo's dependency management, start the app
 enyo.ready(function () {
+	var container = document.getElementById('todo-container');
+
 	window.app = new ToDo.Application();
-	window.app.render();
+	// add extra container to prevent enyo from blowing out the learn side bar
+	window.app.renderInto(container);
 });


### PR DESCRIPTION
Made several small changes to ensure this demo does not destroy the Learn sidebar.
1. Added framework data attribute to the html tag - it was missing and preventing data from being pulled in to render the side bar.
2. Added an additional wrapper div - enyo wipes out everything it is rendered into.
3. Updated start.js to render into the newly made container instead of the body tag.
