### PR TITLE
Fixed readme.md AngularJS links to .org instead of .com

### DIFF
--- a/architecture-examples/angularjs/readme.md
+++ b/architecture-examples/angularjs/readme.md
@@ -2,11 +2,11 @@
 
 > HTML is great for declaring static documents, but it falters when we try to use it for declaring dynamic views in web-applications. AngularJS lets you extend HTML vocabulary for your application. The resulting environment is extraordinarily expressive, readable, and quick to develop.
 
-> _[AngularJS - angularjs.com](http://angularjs.com)_
+> _[AngularJS - angularjs.org](http://angularjs.org)_
 
 
 ## Learning AngularJS
-The [AngularJS website](http://angularjs.com) is a great resource for getting started.
+The [AngularJS website](http://angularjs.org) is a great resource for getting started.
 
 Here are some links you may find helpful:
 


### PR DESCRIPTION
Currently the Readme is pointing at angularjs.com which is not (currently) related to the Angular project in any way. Updated to correct links.
