### PR TITLE
Add jQuery annotated source

### DIFF
--- a/architecture-examples/jquery/readme.md
+++ b/architecture-examples/jquery/readme.md
@@ -20,6 +20,7 @@ Here are some links you may find helpful:
 Articles and guides from the community:
 
 * [Try jQuery](http://try.jquery.com)
+* [jQuery Annotated Source](http://github.com/robflaherty/jquery-annotated-source)
 * [10 Things I Learned From the jQuery Source](http://paulirish.com/2010/10-things-i-learned-from-the-jquery-source)
 
 Get help from other jQuery users:


### PR DESCRIPTION
I suggest adding annotated source to the readme, as it seems helpful to understand how most of the things work "under the hood". I know it's only v1.6.2, but I figured some people might find such info useful (just as me).
