### PR TITLE
SAPUI5: remove unneeded libraries from bootstrap

### DIFF
--- a/labs/architecture-examples/sapui5/index.html
+++ b/labs/architecture-examples/sapui5/index.html
@@ -7,7 +7,7 @@
 		<script
 			src="https://sapui5.netweaver.ondemand.com/resources/sap-ui-core.js"
 			id="sap-ui-bootstrap"
-			data-sap-ui-libs="sap.ui.commons,sap.ui.ux3,sap.ui.table"
+			data-sap-ui-libs="sap.ui.commons"
 			data-sap-ui-theme="base">
 		</script>
 		<link href="css/base.css" rel="stylesheet">


### PR DESCRIPTION
SAPUI5 controls are organized in libraries. The SAPUI5 TodoMVC app currently declares three libraries but actually only uses controls from one of these libraries. This causes four additional requests (2 json, 2 CSS) containing loads of unneeded data.
My change removes these unneeded library references, eliminating those requests.

BTW, introducing myself...: I'm also working at SAP (in the SAPUI5 development team). I already talked to schubertha about this change. Despite having worked with Git for quite some time, this is my first pull request on GitHub, so please be patient as long as I'm doing things wrong...
