### PR TITLE
Refine selector by providing a context

### DIFF
--- a/architecture-examples/jquery/js/app.js
+++ b/architecture-examples/jquery/js/app.js
@@ -43,13 +43,14 @@ jQuery(function ($) {
 			this.todoTemplate = Handlebars.compile($('#todo-template').html());
 			this.footerTemplate = Handlebars.compile($('#footer-template').html());
 			this.$todoApp = $('#todoapp');
-			this.$newTodo = $('#new-todo');
-			this.$toggleAll = $('#toggle-all');
-			this.$main = $('#main');
-			this.$todoList = $('#todo-list');
+			this.$header = this.$todoApp.find('#header');
+			this.$main = this.$todoApp.find('#main');
 			this.$footer = this.$todoApp.find('#footer');
-			this.$count = $('#todo-count');
-			this.$clearBtn = $('#clear-completed');
+			this.$newTodo = this.$header.find('#new-todo');
+			this.$toggleAll = this.$main.find('#toggle-all');
+			this.$todoList = this.$main.find('#todo-list');
+			this.$count = this.$footer.find('#todo-count');
+			this.$clearBtn = this.$footer.find('#clear-completed');
 		},
 		bindEvents: function () {
 			var list = this.$todoList;


### PR DESCRIPTION
The context comes in handy when it comes to restrict the "region" the selector has to operate in. 
Besides, it makes clearer (I think) in which region the $element sits in.

It is a way to apply the concept of "region" here (Backbone Marionette uses extensively).
