### PR TITLE
Update base.css

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -250,7 +250,7 @@ label[for='toggle-all'] {
 	transition: color 0.4s;
 }
 
-#todo-list li.completed label {
+#todo-list li.complete label {
 	color: #a9a9a9;
 	text-decoration: line-through;
 }


### PR DESCRIPTION
Updated base.css to include proper class for completed todos.
Changed 'completed' to 'complete'.

Completed todos are now displayed as grey & struck out.
