### PR TITLE
AngularJS - Add a check for changes to prevent unneeded saves.

### DIFF
--- a/architecture-examples/angularjs/js/controllers/todoCtrl.js
+++ b/architecture-examples/angularjs/js/controllers/todoCtrl.js
@@ -12,11 +12,13 @@ todomvc.controller('TodoCtrl', function TodoCtrl($scope, $location, todoStorage,
 	$scope.newTodo = '';
 	$scope.editedTodo = null;
 
-	$scope.$watch('todos', function () {
+	$scope.$watch('todos', function (newValue, oldValue) {
 		$scope.remainingCount = filterFilter(todos, { completed: false }).length;
 		$scope.completedCount = todos.length - $scope.remainingCount;
 		$scope.allChecked = !$scope.remainingCount;
-		todoStorage.put(todos);
+		if (newValue !== oldValue) { // This prevents unneeded calls to the local storage
+			todoStorage.put(todos);
+		}
 	}, true);
 
 	if ($location.path() === '') {


### PR DESCRIPTION
Since the `$watch` will be fired every time that a `todo` changes and assigning the `todos` from the `localStorage` is considered a change, I consider that is a waste of resources (no that big in this case) to load the data and immediately save them again (because the `$watch`).

So I put a check to see if the todos has been changed before save them again. So the first time we load them, they won't be saved again.

Merge this PR if you find it interesting :)
