### PR TITLE
todo display right padding fix

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -239,7 +239,7 @@ label[for='toggle-all'] {
 
 #todo-list li label {
 	word-break: break-word;
-	padding: 15px;
+	padding: 15px 60px 15px 15px;
 	margin-left: 45px;
 	display: block;
 	line-height: 1.2;


### PR DESCRIPTION
a long todo item might step on the X sign. `padding-right` of 60 fixes this symmetrically (X sign width 40px, right offset 10).
