### PR TITLE
todo display whitespace fix

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -238,6 +238,7 @@ label[for='toggle-all'] {
 }
 
 #todo-list li label {
+	white-space: pre;
 	word-break: break-word;
 	padding: 15px;
 	margin-left: 45px;


### PR DESCRIPTION
currently an item data stored with multiple whitespace in-between words is rendered as having only one space. Putting css `white-space: pre` fixes this.
