### PR TITLE
use fetch({reset:true}) for 2x-5x increase in rendering performance for backbone.

### DIFF
--- a/architecture-examples/backbone/js/views/app-view.js
+++ b/architecture-examples/backbone/js/views/app-view.js
@@ -39,6 +39,9 @@ var app = app || {};
 			this.listenTo(app.todos, 'filter', this.filterAll);
 			this.listenTo(app.todos, 'all', this.render);
 
+			//suppresses 'add' events with {reset: true} and prevents the app view 
+			//from being re-rendered for every model.
+			//Only renders when the 'reset' event is triggered at the end of the fetch.
 			app.todos.fetch({reset: true});
 		},
 


### PR DESCRIPTION
I'm not sure why, and I can't seem to reproduce a minimal test case but using reset:true seems to increase rendering performance about 2-3x on chrome (28) and 5x on firefox (23). Didn't test on any other browsers.

Here's my benchmark: (performed in console when backbone todos are open)

setup: 

``` javascript

function setup() {
  for (var i=0; i<500; i++) app.todos.add({title: Math.random().toString()});
  app.todos.each(function(m) {m.save()});
}

function time(reset) {
  app.todos.reset(); 
  var t = performance.now(); 
  app.todos.fetch({reset: reset});
  return performance.now() - t
}

setup();
```

in chrome:

time()
529.0000000003492
time(true)
253.00000000058208

in firefox

time()
2093
time(true)
451

It was an accidental find and if anyone knows why it's happening (chrome timeline shows that a lot more time is spend parsing html) please fill me in :)
