### PR TITLE
Update todoCtrl.js

### DIFF
--- a/architecture-examples/angularjs/js/controllers/todoCtrl.js
+++ b/architecture-examples/angularjs/js/controllers/todoCtrl.js
@@ -17,7 +17,7 @@ todomvc.controller('TodoCtrl', function TodoCtrl($scope, $location, todoStorage,
 		$scope.completedCount = todos.length - $scope.remainingCount;
 		$scope.allChecked = !$scope.remainingCount;
 		if (newValue !== oldValue) { // This prevents unneeded calls to the local storage
-			todoStorage.put(todos);
+			todoStorage.put(angular.copy(this.todos));
 		}
 	}, true);
 


### PR DESCRIPTION
Required for angular js 1.1.5+ / 1.2
The old code stored $$hashKey to local storage. Which meant that it would fail when its loaded later on (try browser refresh). This is due to "track by" feature added in angularjs
