### PR TITLE
clarify legend on home page by restyling

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,6 +147,10 @@
 							<a href="labs/architecture-examples/sapui5/" data-source="http://scn.sap.com/community/developer-center/front-end" data-content="SAPUI5 is SAP's HTML5-based UI technology that allows you to build rich, interactive Web applications.">SAPUI5</a>
 						</li>
 					</ul>
+					<ul class="legend">
+						<li><b>*</b> <span class="label">R</span> = App also demonstrates routing</li>
+						<li><b>*</b> <span class="labs-example">Maroon</span> = App requires further work to be spec-compliant</li>
+					</ul>
 					<hr>
 					<h2>Compile To JavaScript</h2>
 					<ul class="applist ctojs">
@@ -251,8 +255,6 @@
 							<a href="architecture-examples/jquery/" data-source="http://jquery.com" data-content="jQuery is a fast and concise JavaScript Library that simplifies HTML document traversing, event handling, animating, and Ajax interactions for rapid web development. jQuery is designed to change the way that you write JavaScript.">jQuery</a>
 						</li>
 					</ul>
-					<p>* <span class="label">R</span> = App also demonstrates routing</p>
-					<p>* Maroon = App requires further work to be spec-compliant</p>
 				</div>
 			</div>
 			<hr>

--- a/site/css/main.css
+++ b/site/css/main.css
@@ -170,12 +170,12 @@ header nav a:not(:last-child) {
 	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
 
-.applist .labs a{
-	color:#582C42;
+.applist .labs a, .labs-example {
+	color: #582C42;
 }
 
 .applist .label,
-p .label {
+.legend .label {
 	position: relative;
 	top: -3px;
 	font-size: 9px;
@@ -194,6 +194,23 @@ p .label {
 	-ms-columns: 2;
 	-o-columns: 2;
 	columns: 2;
+}
+
+.legend {
+	margin-top: 20px;
+	margin-left: 0;
+	list-style-type: none;
+}
+
+.legend li {
+	margin-bottom: 0.5em;
+}
+.legend li:last-child {
+	margin-bottom: 0;
+}
+
+.labs-example {
+	font-weight: bold;
 }
 
 .collapsed {


### PR DESCRIPTION
affects page http://todomvc.com/

Before:

![before my fixes (current version)](https://f.cloud.github.com/assets/79168/1090011/8de4cd1c-164e-11e3-910b-d30517cb0f0c.png)

After:

![after my fixes](https://f.cloud.github.com/assets/79168/1090013/95edd44a-164e-11e3-8a7a-745a0b35484a.png)

I made “Maroon” look like what it’s referring to, and I added a border around the legend so it looks different from the app lists.
