### PR TITLE
link to the spec where it’s mentioned in the legend

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
 					</ul>
 					<ul class="legend">
 						<li><b>*</b> <span class="label">R</span> = App also demonstrates routing</li>
-						<li><b>*</b> <span class="labs-example">Maroon</span> = App requires further work to be spec-compliant</li>
+						<li><b>*</b> <span class="labs-example">Maroon</span> = App requires further work to comply with <a href="https://github.com/tastejs/todomvc/wiki/App-Specification">the spec</a></li>
 					</ul>
 					<hr>
 					<h2>Compile To JavaScript</h2>


### PR DESCRIPTION
I reworded that legend entry so that “spec” is its own word:

![after rewording](https://f.cloud.github.com/assets/79168/1097419/220edfc4-1711-11e3-8428-ccbac6732f10.png)

because it looked a little weird to have part of a word boldened like this:

![part of word boldened, without rewording](https://f.cloud.github.com/assets/79168/1097402/fe340214-1710-11e3-81f1-bce216fc45a1.png)

There is one other link to the spec on the whole page, in the “Getting Involved” section at the very bottom right.
