### PR TITLE
Minor bug fix in controller.js Controller.prototype.removeItem

### DIFF
--- a/vanilla-examples/vanillajs/js/controller.js
+++ b/vanilla-examples/vanillajs/js/controller.js
@@ -164,7 +164,7 @@
 	Controller.prototype.removeItem = function (id) {
 		this.model.remove(id, function () {
       var elem = $$('[data-id="' + id + '"]');
-			if(elem){
+			if (elem) {
         this.$todoList.removeChild(elem);
       }
 		}.bind(this));


### PR DESCRIPTION
Controller.prototype.removeItem did not check if the item was available
via the DOM before calling removeChild.  If you were only viewing
"active" and clicked the "Clear completed" button it would result in an
error.  Wrapped the remvoeChild call in an if statement to validate
existence of the elememnt.
