### PR TITLE
Ticket #688 - Fix for Store#find returning on first prop match

### DIFF
--- a/vanilla-examples/vanillajs/js/store.js
+++ b/vanilla-examples/vanillajs/js/store.js
@@ -50,9 +50,13 @@
 		var todos = JSON.parse(localStorage[this._dbName]).todos;
 
 		callback.call(this, todos.filter(function (todo) {
+			var match = true;
 			for (var q in query) {
-				return query[q] === todo[q];
+				if (query[q] !== todo[q]) {
+					match = false;
+				}
 			}
+			return match;
 		}));
 	};
 


### PR DESCRIPTION
This fixes an issue where Store#find would return any item that had just 1 property match. It now goes through every property and unless it finds a property that does NOT match the query, it assumes it's a match.
