### PR TITLE
Ember input value trimming and text selection removal

### DIFF
--- a/architecture-examples/emberjs/js/controllers/todo_controller.js
+++ b/architecture-examples/emberjs/js/controllers/todo_controller.js
@@ -15,9 +15,9 @@ Todos.TodoController = Ember.ObjectController.extend({
 		},
 
 		doneEditing: function () {
-			var bufferedTitle = this.get('bufferedTitle');
+			var bufferedTitle = this.get('bufferedTitle').trim();
 
-			if (Ember.isEmpty(bufferedTitle.trim())) {
+			if (Ember.isEmpty(bufferedTitle)) {
 				// The `doneEditing` action gets sent twice when the user hits
 				// enter (once via 'insert-newline' and once via 'focus-out').
 				//
@@ -26,10 +26,12 @@ Todos.TodoController = Ember.ObjectController.extend({
 				Ember.run.debounce(this, this.send, 'removeTodo', 0);
 			} else {
 				var todo = this.get('model');
-				todo.set('title', this.get('bufferedTitle'));
+				todo.set('title', bufferedTitle);
 				todo.save();
 			}
 
+			// Re-set our newly edited title to persist it's trimmed version
+			this.set('bufferedTitle', bufferedTitle);
 			this.set('isEditing', false);
 		},
 

--- a/architecture-examples/emberjs/js/controllers/todos_controller.js
+++ b/architecture-examples/emberjs/js/controllers/todos_controller.js
@@ -8,8 +8,8 @@ Todos.TodosController = Ember.ArrayController.extend({
 			var title, todo;
 
 			// Get the todo title set by the "New Todo" text field
-			title = this.get('newTitle');
-			if (!title.trim()) {
+			title = this.get('newTitle').trim();
+			if (!title) {
 				return;
 			}
 

--- a/architecture-examples/emberjs/js/views/edit_todo_view.js
+++ b/architecture-examples/emberjs/js/views/edit_todo_view.js
@@ -3,6 +3,8 @@
 
 Todos.EditTodoView = Ember.TextField.extend({
 	focusOnInsert: function () {
+		// Re-set input value to get rid of a reduntant text selection
+		this.$().val(this.$().val());
 		this.$().focus();
 	}.on('didInsertElement')
 });


### PR DESCRIPTION
Ember.js input trimming on existing todo editing;
Text selection on input focus removed which automatically move a cursor to the end of the line;
Issue #635
