### PR TITLE
Backbone input value trimming on edit

### DIFF
--- a/architecture-examples/backbone/js/views/todo-view.js
+++ b/architecture-examples/backbone/js/views/todo-view.js
@@ -67,11 +67,18 @@ var app = app || {};
 
 		// Close the `"editing"` mode, saving changes to the todo.
 		close: function () {
-			var trimmedValue = this.$input.val().trim();
-			this.$input.val(trimmedValue);
+			var value = this.$input.val();
+			var trimmedValue = value.trim();
 
 			if (trimmedValue) {
 				this.model.save({ title: trimmedValue });
+
+				if (value !== trimmedValue) {
+					// Model values changes consisting of whitespaces only are not causing change to be triggered
+					// Therefore we've to compare untrimmed version with a trimmed one to chech whether anything changed
+					// And if yes, we've to trigger change event ourselves
+					this.model.trigger('change');
+				}
 			} else {
 				this.clear();
 			}

--- a/dependency-examples/backbone_require/js/views/todos.js
+++ b/dependency-examples/backbone_require/js/views/todos.js
@@ -67,10 +67,18 @@ define([
 
 		// Close the `"editing"` mode, saving changes to the todo.
 		close: function () {
-			var value = this.$input.val().trim();
+			var value = this.$input.val();
+			var trimmedValue = value.trim();
 
-			if (value) {
-				this.model.save({ title: value });
+			if (trimmedValue) {
+				this.model.save({ title: trimmedValue });
+
+				if (value !== trimmedValue) {
+					// Model values changes consisting of whitespaces only are not causing change to be triggered
+					// Therefore we've to compare untrimmed version with a trimmed one to chech whether anything changed
+					// And if yes, we've to trigger change event ourselves
+					this.model.trigger('change');
+				}
 			} else {
 				this.clear();
 			}


### PR DESCRIPTION
This solution will trigger change event only if anything changes in edited input.
We need this event to rerender input with trimmed value and keep an event intact.
Issue #635 
