### PR TITLE
angularjs: fixed ng-repeat duplicate entry errors

### DIFF
--- a/architecture-examples/angularjs-perf/index.html
+++ b/architecture-examples/angularjs-perf/index.html
@@ -19,7 +19,7 @@
 				<input id="toggle-all" type="checkbox" ng-model="allChecked" ng-click="markAll(allChecked)">
 				<label for="toggle-all">Mark all as complete</label>
 				<ul id="todo-list">
-					<li ng-repeat="todo in todos | filter:statusFilter" ng-class="{completed: todo.completed, editing: todo == editedTodo}">
+					<li ng-repeat="todo in todos track by $index | filter:statusFilter" ng-class="{completed: todo.completed, editing: todo == editedTodo}">
 						<div class="view">
 							<input class="toggle" type="checkbox" ng-model="todo.completed" ng-change="todoCompleted(todo)">
 							<label ng-dblclick="editTodo(todo)">{{todo.title}}</label>

--- a/architecture-examples/angularjs/index.html
+++ b/architecture-examples/angularjs/index.html
@@ -19,7 +19,7 @@
 				<input id="toggle-all" type="checkbox" ng-model="allChecked" ng-click="markAll(allChecked)">
 				<label for="toggle-all">Mark all as complete</label>
 				<ul id="todo-list">
-					<li ng-repeat="todo in todos | filter:statusFilter" ng-class="{completed: todo.completed, editing: todo == editedTodo}">
+					<li ng-repeat="todo in todos track by $index | filter:statusFilter" ng-class="{completed: todo.completed, editing: todo == editedTodo}">
 						<div class="view">
 							<input class="toggle" type="checkbox" ng-model="todo.completed">
 							<label ng-dblclick="editTodo(todo)">{{todo.title}}</label>


### PR DESCRIPTION
Angular 1.2 breaks the application when rendering out duplicate entries pull from localStorage, a quick solution is tell the `ng-repeat` directive to `track by $index`.
