### PR TITLE
batman.js - fix the index view to render contents correctly

### DIFF
--- a/labs/architecture-examples/batman/app.coffee
+++ b/labs/architecture-examples/batman/app.coffee
@@ -11,7 +11,7 @@ class Alfred.TodosController extends Batman.Controller
 	routingKey: 'todos'
 
 	index: ->
-		@set('currentTodoSet', 'all')
+		@set('currentTodoSet', 'default')
 
 	completed: ->
 		@set 'currentTodoSet', 'completed'
@@ -78,6 +78,9 @@ class Alfred.Todo extends Batman.Model
 
 	@encode 'title', 'completed'
 	@validate 'title', presence: true
+
+  @classAccessor 'default', ->
+    @get('all').filter (todo) -> true
 
 	@classAccessor 'active', ->
 		@get('all').filter (todo) -> !todo.get('completed')

--- a/labs/architecture-examples/batman/app.js
+++ b/labs/architecture-examples/batman/app.js
@@ -37,7 +37,7 @@
     TodosController.prototype.routingKey = 'todos';
 
     TodosController.prototype.index = function() {
-      return this.set('currentTodoSet', 'all');
+      return this.set('currentTodoSet', 'default');
     };
 
     TodosController.prototype.completed = function() {
@@ -182,6 +182,12 @@
 
     Todo.validate('title', {
       presence: true
+    });
+
+    Todo.classAccessor('default', function() {
+      return this.get('all').filter(function(todo) {
+        return true;
+      });
     });
 
     Todo.classAccessor('active', function() {


### PR DESCRIPTION
If an item was removed on the active or completed view it would not render correctly on the index view. A SimpleHash was used to index the results of get('all') and it was not enumerating the items correctly. Forcing it to use the results of a filter resolves that for now.
