### PR TITLE
Fixes typo in firebase-angular

### DIFF
--- a/labs/architecture-examples/firebase-angular/index.html
+++ b/labs/architecture-examples/firebase-angular/index.html
@@ -62,7 +62,7 @@
 		<script src="https://cdn.firebase.com/v0/firebase.js"></script>
 		<script src="bower_components/todomvc-common/base.js"></script>
 		<script src="bower_components/angular/angular.js"></script>
-		<script src="bower_components/angularfire/angularFire.js"></script>
+		<script src="bower_components/angularfire/angularfire.js"></script>
 		<script src="js/app.js"></script>
 		<script src="js/controllers/todoCtrl.js"></script>
 		<script src="js/directives/todoFocus.js"></script>


### PR DESCRIPTION
A capital "F" kept this TodoMVC example from working at all.
