### PR TITLE
Fixing Optimized Angularjs's markAll method.

### DIFF
--- a/architecture-examples/angularjs-perf/js/controllers/todoCtrl.js
+++ b/architecture-examples/angularjs-perf/js/controllers/todoCtrl.js
@@ -80,7 +80,7 @@ todomvc.controller('TodoCtrl', function TodoCtrl($scope, $location, todoStorage,
 		todos.forEach(function (todo) {
 			todo.completed = !completed;
 		});
-		$scope.remainingCount = completed ? 0 : todos.length;
+		$scope.remainingCount = completed ? todos.length : 0;
 		todoStorage.put(todos);
 	};
 });


### PR DESCRIPTION
Clicking the mark all checkbox in angularjs-perf currently sets all todos to be completed, but sets remaining count to todos.length instead of 0.  This can cause $scope.remainingCount to exceed todos.length and prevents the "Clear completed" button from displaying correctly.

![image](https://f.cloud.github.com/assets/274827/1971025/846f6c92-831d-11e3-875b-ef1eadb89c32.png)
