### PR TITLE
React has broken toggle-all checkbox

### DIFF
--- a/architecture-examples/react/js/todoItem.jsx
+++ b/architecture-examples/react/js/todoItem.jsx
@@ -78,7 +78,7 @@
 						<input
 							className="toggle"
 							type="checkbox"
-							checked={this.props.todo.completed ? 'checked' : null}
+							checked={this.props.todo.completed}
 							onChange={this.props.onToggle}
 						/>
 						<label onDoubleClick={this.handleEdit}>


### PR DESCRIPTION
The React example has a broken toggle-all checkbox.  To reproduce the bug: 1) add two todo items, 2) set the first item to done, then 3) click toggle-all two times.  The first item will still be marked done, instead of both being marked not-done as should be.

The cause of the bug is from incorrectly setting checked to null instead of false.  From the React source code:

```
 * If `checked` or `value` are not supplied (or null/undefined), user actions
 * that affect the checked state or value will trigger updates to the element.
 *
 * If they are supplied (and not null/undefined), the rendered element will not
 * trigger updates to the element. Instead, the props must change in order for
 * the rendered element to be updated.
```
