### PR TITLE
Ember: Prevent global leakage of 'use strict' directive

### DIFF
--- a/architecture-examples/emberjs/bower_components/ember-localstorage-adapter/localstorage_adapter.js
+++ b/architecture-examples/emberjs/bower_components/ember-localstorage-adapter/localstorage_adapter.js
@@ -127,4 +127,4 @@
 			namespace.records[data.id] = data;
 		}
 	});
-}());
+})();

--- a/architecture-examples/emberjs/js/controllers/todo_controller.js
+++ b/architecture-examples/emberjs/js/controllers/todo_controller.js
@@ -56,4 +56,4 @@
 			this.get('model').save();
 		}.observes('isCompleted')
 	});
-}());
+})();

--- a/architecture-examples/emberjs/js/controllers/todos_controller.js
+++ b/architecture-examples/emberjs/js/controllers/todos_controller.js
@@ -48,4 +48,4 @@
 			}
 		}.property('length', 'completed.length')
 	});
-}());
+})();

--- a/architecture-examples/emberjs/js/helpers/pluralize.js
+++ b/architecture-examples/emberjs/js/helpers/pluralize.js
@@ -8,4 +8,4 @@
 
 		return count === 1 ? singular : inflector.pluralize(singular);
 	});
-}());
+})();

--- a/architecture-examples/emberjs/js/models/todo.js
+++ b/architecture-examples/emberjs/js/models/todo.js
@@ -6,4 +6,4 @@
 		title: DS.attr('string'),
 		isCompleted: DS.attr('boolean')
 	});
-}());
+})();

--- a/architecture-examples/emberjs/js/router.js
+++ b/architecture-examples/emberjs/js/router.js
@@ -40,4 +40,4 @@
 			this.controllerFor('todos').set('filteredTodos', todos);
 		}
 	});
-}());
+})();

--- a/architecture-examples/emberjs/js/views/edit_todo_view.js
+++ b/architecture-examples/emberjs/js/views/edit_todo_view.js
@@ -11,4 +11,4 @@
 	});
 
 	Ember.Handlebars.helper('edit-todo', Todos.EditTodoView);
-}());
+})();

--- a/architecture-examples/emberjs/js/views/todos_view.js
+++ b/architecture-examples/emberjs/js/views/todos_view.js
@@ -7,4 +7,4 @@
 			this.$('#new-todo').focus();
 		}.on('didInsertElement')
 	});
-}());
+})();


### PR DESCRIPTION
Ember.js doesn't work in strict mode when minified. All the application files leak strict mode to the global scope, breaking the app when minfied and bundled.

A similar pull request has been sent to ember-localstorage-adapter: https://github.com/rpflorence/ember-localstorage-adapter/pull/37
