### PR TITLE
app.js reset event

### DIFF
--- a/dependency-examples/backbone_require/js/views/app.js
+++ b/dependency-examples/backbone_require/js/views/app.js
@@ -42,7 +42,7 @@ define([
 			this.listenTo(Todos, 'filter', this.filterAll);
 			this.listenTo(Todos, 'all', this.render);
 
-			Todos.fetch();
+			Todos.fetch({reset:true});
 		},
 
 		// Re-rendering the App just means refreshing the statistics -- the rest


### PR DESCRIPTION
If you want to smartly update the contents of a Collection, adding new models, removing missing ones, and merging those already present, you now call set (previously named "update"), a similar operation to calling set on a Model. This is now the default when you call fetch on a collection. To get the old behavior, pass {reset: true}.

In you code you use listener to 'reset' event. So you should pass {reset: true} to get what you want.
