### PR TITLE
Typo in firebase+angular app description

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@
 							<a href="http://todomvc-socketstream.herokuapp.com" data-source="http://www.socketstream.org" data-content="SocketStream is a fast, modular Node.js web framework dedicated to building realtime single-page apps">SocketStream</a>
 						</li>
 						<li class="routing labs">
-							<a href="labs/architecture-examples/firebase-angular/" data-source="https://www.firebase.com" data-content="Firebase is a scalable realtime backend that lets you build apps without managing servers. Firebase persists and updates JSON data in realtime and is best used in combination with a JavaScrpt MV* framework such as AngularJS or Backbone.">Firebase + AngularJS</a>
+							<a href="labs/architecture-examples/firebase-angular/" data-source="https://www.firebase.com" data-content="Firebase is a scalable realtime backend that lets you build apps without managing servers. Firebase persists and updates JSON data in realtime and is best used in combination with a JavaScript MV* framework such as AngularJS or Backbone.">Firebase + AngularJS</a>
 						</li>
 					</ul>
 					<hr>


### PR DESCRIPTION
Should s/JavaScrpt/JavaScript/

BTW it's a pity there are no real-time apps in the set of stable/mature frameworks.
