### PR TITLE
gwt - trim item on update

### DIFF
--- a/architecture-examples/gwt/src/com/todo/client/ToDoItem.java
+++ b/architecture-examples/gwt/src/com/todo/client/ToDoItem.java
@@ -44,7 +44,13 @@ public class ToDoItem {
 	}
 
 	public void setTitle(String title) {
+		setTitle(title, true);
+	}
+
+	public void setTitle(String title, boolean notify) {
 		this.title = title;
-		presenter.itemStateChanged(this);
+		if (notify) {
+			presenter.itemStateChanged(this);
+		}
 	}
 }

--- a/architecture-examples/gwt/src/com/todo/client/ToDoPresenter.java
+++ b/architecture-examples/gwt/src/com/todo/client/ToDoPresenter.java
@@ -202,8 +202,10 @@ public class ToDoPresenter {
 			return;
 		}
 
-		// if the item has become empty, remove it
-		if (toDoItem.getTitle().trim().equals("")) {
+		boolean notify = false;
+		toDoItem.setTitle(toDoItem.getTitle().trim(), notify);
+
+		if (toDoItem.getTitle().isEmpty()) {
 			todos.remove(toDoItem);
 		}
 


### PR DESCRIPTION
On [GWT sample](http://todomvc.com/architecture-examples/gwt/), to-do items are trimmed when they are created, but they are not trimmed when they are later updated.
