### PR TITLE
gwt - model objects agnostic of presenters

### DIFF
--- a/architecture-examples/gwt/src/com/todo/client/ToDoItem.java
+++ b/architecture-examples/gwt/src/com/todo/client/ToDoItem.java
@@ -4,39 +4,30 @@ package com.todo.client;
  * An individual ToDo item.
  *
  * @author ceberhardt
+ * @author dprotti
  *
  */
 public class ToDoItem {
 
-	private final ToDoPresenter presenter;
-
 	private String title;
 
-	private boolean done;
+	private boolean completed;
 
-	public ToDoItem(String text, ToDoPresenter presenter) {
-		this.title = text;
-		this.done = false;
-		this.presenter = presenter;
+	public ToDoItem(String title) {
+		this(title, false);
 	}
 
-	public ToDoItem(String title, boolean done, ToDoPresenter presenter) {
+	public ToDoItem(String title, boolean completed) {
 		this.title = title;
-		this.done = done;
-		this.presenter = presenter;
+		this.completed = completed;
 	}
 
-	public boolean isDone() {
-		return done;
+	public boolean isCompleted() {
+		return completed;
 	}
 
-	public void setDone(boolean done) {
-		this.done = done;
-		presenter.itemStateChanged(this);
-	}
-
-	public void delete() {
-		presenter.deleteTask(this);
+	public void setCompleted(boolean completed) {
+		this.completed = completed;
 	}
 
 	public String getTitle() {
@@ -44,13 +35,7 @@ public class ToDoItem {
 	}
 
 	public void setTitle(String title) {
-		setTitle(title, true);
+		this.title = title;
 	}
 
-	public void setTitle(String title, boolean notify) {
-		this.title = title;
-		if (notify) {
-			presenter.itemStateChanged(this);
-		}
-	}
 }

--- a/architecture-examples/gwt/src/com/todo/client/ToDoRouting.java
+++ b/architecture-examples/gwt/src/com/todo/client/ToDoRouting.java
@@ -40,7 +40,7 @@ public enum ToDoRouting {
 	private static class MatchActive implements Matcher {
 		@Override
 		public boolean matches(ToDoItem item) {
-			return !item.isDone();
+			return !item.isCompleted();
 		}
 	}
 
@@ -50,7 +50,7 @@ public enum ToDoRouting {
 	private static class MatchCompleted implements Matcher {
 		@Override
 		public boolean matches(ToDoItem item) {
-			return item.isDone();
+			return item.isCompleted();
 		}
 	}
 

--- a/architecture-examples/gwt/src/com/todo/client/events/ToDoEvent.java
+++ b/architecture-examples/gwt/src/com/todo/client/events/ToDoEvent.java
@@ -1,0 +1,29 @@
+package com.todo.client.events;
+
+import com.google.gwt.event.shared.EventBus;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.SimpleEventBus;
+import com.todo.client.ToDoItem;
+
+public abstract class ToDoEvent<H extends EventHandler> extends GwtEvent<H> {
+
+	private final ToDoItem toDo;
+
+	public ToDoEvent(ToDoItem toDo) {
+		this.toDo = toDo;
+	}
+
+	public ToDoItem getToDo() {
+		return toDo;
+	}
+
+	/* This acts as a global event bus factory */
+
+	private static EventBus eventBus = new SimpleEventBus();
+
+	public static EventBus getGlobalEventBus() {
+		return eventBus;
+	}
+
+}

--- a/architecture-examples/gwt/src/com/todo/client/events/ToDoRemovedEvent.java
+++ b/architecture-examples/gwt/src/com/todo/client/events/ToDoRemovedEvent.java
@@ -1,0 +1,28 @@
+package com.todo.client.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.todo.client.ToDoItem;
+
+public class ToDoRemovedEvent extends ToDoEvent<ToDoRemovedEvent.Handler> {
+
+	public static final Type<ToDoRemovedEvent.Handler> TYPE = new Type<ToDoRemovedEvent.Handler>();
+
+	public static interface Handler extends EventHandler {
+
+		void onEvent(ToDoRemovedEvent event);
+	}
+
+	public ToDoRemovedEvent(ToDoItem toDo) {
+		super(toDo);
+	}
+
+	@Override
+	public Type<ToDoRemovedEvent.Handler> getAssociatedType() {
+		return TYPE;
+	}
+
+	@Override
+	protected void dispatch(ToDoRemovedEvent.Handler handler) {
+		handler.onEvent(this);
+	}
+}

--- a/architecture-examples/gwt/src/com/todo/client/events/ToDoUpdatedEvent.java
+++ b/architecture-examples/gwt/src/com/todo/client/events/ToDoUpdatedEvent.java
@@ -1,0 +1,28 @@
+package com.todo.client.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.todo.client.ToDoItem;
+
+public class ToDoUpdatedEvent extends ToDoEvent<ToDoUpdatedEvent.Handler> {
+
+	public static final Type<ToDoUpdatedEvent.Handler> TYPE = new Type<ToDoUpdatedEvent.Handler>();
+
+	public static interface Handler extends EventHandler {
+
+		void onEvent(ToDoUpdatedEvent event);
+	}
+
+	public ToDoUpdatedEvent(ToDoItem toDo) {
+		super(toDo);
+	}
+
+	@Override
+	public Type<ToDoUpdatedEvent.Handler> getAssociatedType() {
+		return TYPE;
+	}
+
+	@Override
+	protected void dispatch(ToDoUpdatedEvent.Handler handler) {
+		handler.onEvent(this);
+	}
+}


### PR DESCRIPTION
Removed dependency from ToDoItem to ToDoPresenter.
It's better if model objects do not invoke methods on presenters or views. One reason is that in GWT, model classes usually lives under a `shared.*` package, since many model objects are transferred back and forth between client and server through RPC calls (RemoteService's). By making model objects depend on client side code, does not allow them to be exposed on these interfaces.
