### PR TITLE
Typescript-backbone: do not create item on empty input

### DIFF
--- a/labs/architecture-examples/typescript-backbone/js/app.js
+++ b/labs/architecture-examples/typescript-backbone/js/app.js
@@ -285,7 +285,7 @@ var AppView = (function (_super) {
     // If you hit return in the main input field, create new **Todo** model,
     // persisting it to *localStorage*.
     AppView.prototype.createOnEnter = function (e) {
-        if (e.which === 13 && this.input.val().trim()) {
+        if (e.which === TodoView.ENTER_KEY && this.input.val().trim()) {
             Todos.create(this.newAttributes());
             this.input.val('');
         }

--- a/labs/architecture-examples/typescript-backbone/js/app.ts
+++ b/labs/architecture-examples/typescript-backbone/js/app.ts
@@ -348,7 +348,7 @@ class AppView extends Backbone.View {
 	// If you hit return in the main input field, create new **Todo** model,
 	// persisting it to *localStorage*.
 	createOnEnter(e) {
-		if (e.which === 13 && this.input.val().trim()) {
+		if (e.which === TodoView.ENTER_KEY && this.input.val().trim()) {
 			Todos.create(this.newAttributes());
 			this.input.val('');
 		}


### PR DESCRIPTION
This fix was missing for #919.
