### PR TITLE
Polymer: fix/remove links

### DIFF
--- a/learn.json
+++ b/learn.json
@@ -1572,16 +1572,10 @@
 			"heading": "Official Resources",
 			"links": [{
 				"name": "Documentation",
-				"url": "http://www.polymer-project.org/getting-started.html"
+				"url": "http://www.polymer-project.org/docs/start/usingelements.html"
 			}, {
 				"name": "API Reference",
-				"url": "http://www.polymer-project.org/polymer.html"
-			}, {
-				"name": "Tools And Testing",
-				"url": "http://www.polymer-project.org/tooling-strategy.html"
-			}, {
-				"name": "FAQ",
-				"url": "http://www.polymer-project.org/faq.html"
+				"url": "http://www.polymer-project.org/docs/polymer/polymer.html"
 			}, {
 				"name": "Polymer on GitHub",
 				"url": "https://github.com/polymer"


### PR DESCRIPTION
The Polymer Project got a new website, so most of the links were
deadlinks now. Some of them where easy to fix, for some there
is not a section on the Polymer page any more.
