### PR TITLE
browser-tests - use fixed version of mocha

### DIFF
--- a/browser-tests/package.json
+++ b/browser-tests/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-simple-mocha": "^0.4.0",
-    "mocha": "*",
+    "mocha": "~1.20.1",
     "optimist": "^0.6.1",
     "q": "^1.0.1",
     "selenium-webdriver": "^2.42.1",


### PR DESCRIPTION
Not sure if this is a bug or a feature, but in Mocha 1.21 the suite fails in the same manner for all the frameworks:
(seems https://github.com/visionmedia/mocha/issues/1292 is the one)

`cd browser-tests`

`npm install -g mocha@1.20 ; mocha allTests.js  --reporter spec --browser=phantomjs --framework=agilityjs`

```
  TodoMVC - agilityjs
    No Todos
      √ should hide #main and #footer (406ms)
    New Todo
      √ should allow me to add todo items (656ms)
      √ should clear text input field when an item is added (240ms)
      √ should append new items to the bottom of the list (551ms)
      √ should trim text input (218ms)
      √ should show #main and #footer when items added (406ms)
  ...
```

`npm install -g mocha@1.21 ; mocha allTests.js  --reporter spec --browser=phantomjs --framework=agilityjs`

```
  TodoMVC - agilityjs
    No Todos
      1) "before each" hook
      2) "after each" hook


  0 passing (5s)
  2 failing

  1) TodoMVC - agilityjs "before each" hook:
     Error: timeout of 0ms exceeded
      at done (d:\bin\nodist\bin\node_modules\mocha\lib\runnable.js:202:67)
  ...
```

The error message is "Error: timeout of 0ms exceeded".

Mocha 1.20.1 is the last one with which the suite is working fine.
