### PR TITLE
React - Unused element footer#info

### DIFF
--- a/architecture-examples/react/index.html
+++ b/architecture-examples/react/index.html
@@ -7,7 +7,6 @@
 	</head>
 	<body>
 		<section id="todoapp"></section>
-		<footer id="info"></footer>
 		<footer id="info">
 			<p>Double-click to edit a todo</p>
 			<p>Created by <a href="http://github.com/petehunt/">petehunt</a></p>


### PR DESCRIPTION
There's an unused (and wrong - more than one element with the same id attribute and more than one footer element for its nearest ancestor) `<footer id="info"></footer>` [footer element](http://dev.w3.org/html5/spec/sections.html#the-footer-element).

This PR removes it
