### PR TITLE
removes uncessary pragma - react

### DIFF
--- a/architecture-examples/react/js/todoModel.js
+++ b/architecture-examples/react/js/todoModel.js
@@ -1,6 +1,3 @@
-/**
- * @jsx React.DOM
- */
 /*jshint quotmark:false */
 /*jshint white:false */
 /*jshint trailing:false */


### PR DESCRIPTION
There's no need for the `@jsx React.DOM`  in `todoModel.js`
