### PR TITLE
Use @ui syntax in events hash

### DIFF
--- a/labs/architecture-examples/backbone_marionette/js/TodoMVC.Layout.js
+++ b/labs/architecture-examples/backbone_marionette/js/TodoMVC.Layout.js
@@ -14,7 +14,7 @@ TodoMVC.module('Layout', function (Layout, App, Backbone) {
 		},
 
 		events: {
-			'keypress #new-todo': 'onInputKeypress'
+			'keypress @ui.input': 'onInputKeypress'
 		},
 
 		onInputKeypress: function (e) {

--- a/labs/architecture-examples/backbone_marionette/js/TodoMVC.TodoList.Views.js
+++ b/labs/architecture-examples/backbone_marionette/js/TodoMVC.TodoList.Views.js
@@ -18,8 +18,8 @@ TodoMVC.module('TodoList.Views', function (Views, App, Backbone, Marionette, $) 
 		events: {
 			'click .destroy': 'deleteModel',
 			'dblclick label': 'onEditClick',
-			'keydown .edit': 'onEditKeypress',
-			'focusout .edit': 'onEditFocusout',
+			'keydown @ui.edit': 'onEditKeypress',
+			'focusout @ui.edit': 'onEditFocusout',
 			'click .toggle': 'toggle'
 		},
 


### PR DESCRIPTION
Use the @ui syntax to reference dom elements already declared in ui hash.
This syntax reduce redundant code.
