### PR TITLE
Update todomvc-common of vanillajs example

### DIFF
--- a/examples/vanillajs/bower_components/todomvc-common/base.css
+++ b/examples/vanillajs/bower_components/todomvc-common/base.css
@@ -274,7 +274,6 @@ label[for='toggle-all'] {
 	text-shadow: 0 0 1px #000,
 				 0 0 10px rgba(199, 107, 107, 0.8);
 	-webkit-transform: scale(1.3);
-	-ms-transform: scale(1.3);
 	transform: scale(1.3);
 }
 
@@ -399,7 +398,6 @@ label[for='toggle-all'] {
 		width: 65px;
 		height: 41px;
 		-webkit-transform: rotate(90deg);
-		-ms-transform: rotate(90deg);
 		transform: rotate(90deg);
 		-webkit-appearance: none;
 		appearance: none;

--- a/examples/vanillajs/bower_components/todomvc-common/base.js
+++ b/examples/vanillajs/bower_components/todomvc-common/base.js
@@ -122,16 +122,7 @@
 	}
 
 	function findRoot() {
-		var base;
-
-		[/labs/, /\w*-examples/].forEach(function (href) {
-			var match = location.href.match(href);
-
-			if (!base && match) {
-				base = location.href.indexOf(match);
-			}
-		});
-
+		var base = location.href.indexOf('examples/');
 		return location.href.substr(0, base);
 	}
 
@@ -177,7 +168,7 @@
 		}
 
 		if (!framework && document.querySelector('[data-framework]')) {
-			framework = document.querySelector('[data-framework]').getAttribute('data-framework');
+			framework = document.querySelector('[data-framework]').dataset.framework;
 		}
 
 


### PR DESCRIPTION
Hi!

I think I've found a minor error on this page: http://todomvc.com/examples/vanillajs/ .

`vanillajs` example page doesn't show the side column at the moment, and the reason seems that the path detection of `/learn.json` is not correct, and that is caused by the old version of base.js.

Then I updated todomvc-common dependency of vanillajs example (using `bower install` command).

Thanks,
