### PR TITLE
api: GET /api displays blueprint markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "learn.json"
   ],
   "dependencies": {
-    "express": "^4.10.0"
+    "express": "^4.10.0",
+    "github-markdown-css": "^1.2.0",
+    "marked": "^0.3.2",
+    "todomvc-api": "^0.1.1"
   },
   "devDependencies": {
     "del": "^0.1.1",

--- a/server.js
+++ b/server.js
@@ -3,10 +3,24 @@
 var express = require('express');
 var fs = require('fs');
 var learnJson = require('./learn.json');
+var markdown = require('marked');
+var path = require('path');
 
 var app = module.exports = express();
+module.exports.getBlueprintHtml = getBlueprintHtml;
 
 app.use(express.static(__dirname));
+
+// Set a default /api route to display the todomvc-api blueprint markdown file.
+app.get('/api', function (req, res) {
+	getBlueprintHtml(function (err, html) {
+		if (err) {
+			throw err;
+		}
+
+		res.end(html);
+	});
+});
 
 Object.defineProperty(module.exports, 'learnJson', {
 	set: function (backend) {
@@ -18,3 +32,30 @@ Object.defineProperty(module.exports, 'learnJson', {
 		});
 	}
 });
+
+function getBlueprintHtml(callback) {
+	var blueprintPath = require.resolve('todomvc-api/todos.apib');
+
+	fs.readFile(blueprintPath, function (err, blueprint) {
+		if (err) {
+			return callback(err);
+		}
+
+		var cssPath = require.resolve('github-markdown-css/github-markdown.css');
+		var body = markdown(blueprint.toString().replace(/^FORMAT.*/, ''));
+
+		callback(null, [
+			'<!doctype html>',
+			'<html lang="en">',
+			'	<head>',
+			'		<meta charset="utf-8">',
+			'		<title>TodoMVC API Blueprint</title>',
+			'		<link rel="stylesheet" href="' + path.relative(__dirname, cssPath) + '">',
+			'	</head>',
+			'	<body>',
+			'		<article class="markdown-body">' + body + '</article>',
+			'	</body>',
+			'</html>'
+		].join('\n'));
+	});
+}


### PR DESCRIPTION
RE: https://github.com/GoogleCloudPlatform/gcloud-node-todos/issues/18

This will default the `GET /api` route to render the blueprint spec markdown file.
