### PR TITLE
Remove deprecated JSHint options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -16,7 +16,5 @@
 	"undef": true,
 	"unused": true,
 	"strict": true,
-	"trailing": true,
-	"smarttabs": true,
 	"white": true
 }


### PR DESCRIPTION
The `trailing` and `smarttabs` JSHint options are deprecated since JSHint v2.5.
