### PR TITLE
Adding info footer as well as learn sidebar back, refs #1088.

### DIFF
--- a/examples/dojo/index.html
+++ b/examples/dojo/index.html
@@ -65,6 +65,16 @@
 				</section>
 			</script>
 		</section>
+		<footer id="info">
+			<p>Double-click to edit a todo</p>
+			<p>Credits:
+				<a href="http://jamesthom.as/">James Thomas</a>,
+				<a href="https://github.com/edchat">Ed Chatelain</a> and
+				<a href="https://github.com/asudoh">Akira Sudoh</a>
+			</p>
+			<p>Part of <a href="http://todomvc.com">TodoMVC</a></p>
+		</footer>
+		<script src="bower_components/todomvc-common/base.js"></script>
 		<script src="js/main.js"></script>
 		<script src="js/lib/dojo/dojo.js"></script>
 		<!-- Use below instead of above line to use non-built version of Dojo components. -->

--- a/learn.json
+++ b/learn.json
@@ -778,7 +778,7 @@
 				"url": "http://dojotoolkit.org/documentation"
 			}, {
 				"name": "Getting started guide",
-				"url": "https://dojotoolkit.org/reference-guide/1.8/quickstart"
+				"url": "https://dojotoolkit.org/reference-guide/quickstart"
 			}, {
 				"name": "API Reference",
 				"url": "http://dojotoolkit.org/api"
@@ -795,8 +795,8 @@
 		}, {
 			"heading": "Community",
 			"links": [{
-				"name": "Dojo on Stack Overflow",
-				"url": "http://stackoverflow.com/questions/tagged/dojo"
+				"name": "Dojo/MVC on Stack Overflow",
+				"url": "http://stackoverflow.com/questions/tagged/dojo+model-view-controller"
 			}, {
 				"name": "Mailing list",
 				"url": "http://dojotoolkit.org/community"


### PR DESCRIPTION
[My previous PR](https://github.com/tastejs/todomvc/pull/1101) lacked “info” footer as well as “learn” side bar. This PR adds them back. My apologies for that.