### PR TITLE
Clean up FOAM implementation - stop reloading on route change, fix broken link

### DIFF
--- a/examples/foam/Todo.js
+++ b/examples/foam/Todo.js
@@ -53,7 +53,7 @@
 			choiceToHTML: function (id, choice) {
 				var self = this;
 				this.setClass('selected', function () { return self.label === choice[1]; }, id);
-				return '<li><a id="' + id + '" class="choice" href="">' + choice[1] + '</a></li>';
+				return '<li><a id="' + id + '" class="choice" href="javascript:;">' + choice[1] + '</a></li>';
 			}
 		}
 	});
@@ -148,10 +148,9 @@
 					function (memento) {
 						var s = memento && memento.substring(1);
 						var t = s ? s.capitalize() : 'All';
-                                                console.log('memento->label', memento, s, t);
                                                 return t;
 					},
-                                        function (label) { var s = '/' + label.toLowerCase(); console.log('label->memento', label, s); return s; });
+					function (label) { var s = '/' + label.toLowerCase(); console.log('label->memento', label, s); return s; });
 				this.addInitializer(function () {
 					$('new-todo').focus();
 				});

--- a/examples/foam/readme.md
+++ b/examples/foam/readme.md
@@ -45,4 +45,4 @@ To run the app, spin up an HTTP server and visit `http://localhost:8000/`.
 
 ## Credit
 
-This TodoMVC implementation was created by the [FOAM team](https://github.com/orgs/foam-framework/members) at Google Waterloo.
+This TodoMVC implementation was created by the [FOAM team](https://github.com/orgs/foam-framework/people) at Google Waterloo.


### PR DESCRIPTION
The team link in the Credits section of the README was broken; it has been repaired.

The app was also reloading unnecessarily on route change. Route changes are now instant and non-refreshing, as they should be.

Tests are all passing except the Clear Completed ones; those seem to be broken for everyone under the new UI.