### PR TITLE
Move marionette out of compile-to-js section

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,6 +129,9 @@
 								<li class="routing">
 									<a href="examples/vue/" data-source="http://vuejs.org" data-content="Vue.js provides the benefits of MVVM data binding and a composable component system with an extremely simple and flexible API.">Vue.js</a>
 								</li>
+								<li class="routing">
+									<a href="examples/backbone_marionette/" data-source="http://marionettejs.com" data-content="Backbone.Marionette is a composite application library for Backbone.js that aims to simplify the construction of large scale JavaScript applications.">MarionetteJS</a>
+								</li>
 							</ul>
 						</div>
 						<div class="js-app-list" data-app-list="ctojs">
@@ -163,9 +166,6 @@
 								</li>
 								<li>
 									<a href="examples/serenadejs/" data-source="https://github.com/elabs/serenade.js" data-content="Serenade.js is yet another MVC client side JavaScript framework. Why do we indulge in recreating the wheel? We believe that Serenade.js more closely follows the ideas of classical MVC than competing frameworks.">Serenade.js</a>
-								</li>
-								<li class="routing">
-									<a href="examples/backbone_marionette/" data-source="http://marionettejs.com" data-content="Backbone.Marionette is a composite application library for Backbone.js that aims to simplify the construction of large scale JavaScript applications.">MarionetteJS</a>
 								</li>
 							</ul>
 						</div>


### PR DESCRIPTION
Sorry about the last one #1137, accidentally put marionette into the wrong section, since we are not compile to js :smiley_cat: 
