### PR TITLE
Bug fix in angular example (issue #1083)

### DIFF
--- a/examples/angularjs/js/controllers/todoCtrl.js
+++ b/examples/angularjs/js/controllers/todoCtrl.js
@@ -74,6 +74,7 @@ angular.module('todomvc')
 			todo.title = todo.title.trim();
 
 			if (todo.title === $scope.originalTodo.title) {
+				$scope.editedTodo = null;
 				return;
 			}
 


### PR DESCRIPTION
I was able to reproduce this bug according to @kogarashisan description.
The controller don't back to read-only state when the editbox loses focus. I just set the correct state.
Fixes #1083 