### PR TITLE
Update use of initializers

### DIFF
--- a/examples/backbone_marionette/js/TodoMVC.TodoList.js
+++ b/examples/backbone_marionette/js/TodoMVC.TodoList.js
@@ -57,13 +57,13 @@ TodoMVC.module('TodoList', function (TodoList, App, Backbone, Marionette) {
 		}
 	});
 
-	// TodoList Initializer
+	// On App start
 	// --------------------
 	//
 	// Get the TodoList up and running by initializing the mediator
 	// when the the application is started, pulling in all of the
 	// existing Todo items and displaying them.
-	TodoList.addInitializer(function () {
+	App.on('start', function () {
 		var controller = new TodoList.Controller();
 		controller.router = new TodoList.Router({
 			controller: controller


### PR DESCRIPTION
Marionette as of v2.3.0 has marked initializers as a deprecated feature.
https://github.com/marionettejs/backbone.marionette/commit/1717c71af306be28cafebcdafda86ba218df0caa

Why is this?

Back when Marionette was built (late 2011), module patterns were still
emerging, it was the wild west in many ways. @derickbailey came up with
the idea of marionette modules. Modules were built for managing "components" and nested
components. They could be stopped and started at will and were also
started and stopped with their parents (since modules are nest-able).

Initializers and Finalizers (pieces of the Marionette.Callbacks helper
class) are a great idea, and are a very powerful one at that, allowing people to specify actions to take `onStart` or `onEnd`.

That said, the year is 2015 and much has changed about the landscape of
modules and javascript. Heck @derickbailey even wrote a post about why you
should not use them anymore.
http://derickbailey.com/2014/06/10/browserify-my-new-choice-for-modules-in-a-browser-backbone-app/

Marionette is moving away from modules, and is moving into the land of
applications and sub applications to help people better handle complex
applications.

If you are interested in reading more, and or following along with the Marionette's team progress follow below:

https://github.com/marionettejs/backbone.marionette/issues/2201
https://github.com/marionettejs/backbone.marionette/issues/2026
https://github.com/marionettejs/backbone.marionette/issues/2200 

-------

fixes #1105