### PR TITLE
Fix spec compliance for Marionette.

### DIFF
--- a/examples/backbone_marionette/js/TodoMVC.Layout.js
+++ b/examples/backbone_marionette/js/TodoMVC.Layout.js
@@ -14,7 +14,18 @@ TodoMVC.module('Layout', function (Layout, App, Backbone) {
 		},
 
 		events: {
-			'keypress @ui.input': 'onInputKeypress'
+			'keypress @ui.input': 'onInputKeypress',
+			'keyup @ui.input': 'onInputKeyup'
+		},
+
+		// According to the spec
+		// If escape is pressed during the edit, the edit state should be left and any changes be discarded.
+		onInputKeyup: function (e) {
+			var ESC_KEY = 27;
+
+			if (e.which === ESC_KEY) {
+				this.render();
+			}
 		},
 
 		onInputKeypress: function (e) {


### PR DESCRIPTION
#### What:

In issue #789 @ColinEberhardt pointed out that many of the examples do
not respect the rule that when a user hits the esc key on an input that
the input should be cleared and the input state should be left.

Upon investigation I found the Marionette example to have never followed
this directive.

#### How:

Due the how the escape key works and the keypress event binding from
jQuery one must use the keyup event to register for the escape key
keycode.

Once I intercept the event I instruct the input area to simply rerender.
This has the desired effect in that it clears the transient input state
and also due to it rendering new childnodes clears the focus from the
user.

------

cc @ColinEberhardt 