### PR TITLE
fixed youtube urls for "Articles and Guides" section in marionettejs example

### DIFF
--- a/learn.json
+++ b/learn.json
@@ -1479,10 +1479,10 @@
 			"heading": "Articles and Guides",
 			"links": [{
 				"name": "Marionette 101",
-				"url": "https://www.youtube.com/watch?v=7yZKsgKxziw#t=106"
+				"url": "https://www.youtube.com/watch?v=7yZKsgKxziw"
 			}, {
 				"name": "Marionette - The Backbone Framework",
-				"url": "https://www.youtube.com/watch?v=EvQnntaqVdE#t=12"
+				"url": "https://www.youtube.com/watch?v=EvQnntaqVdE"
 			}]
 		}, {
 			"heading": "Community",


### PR DESCRIPTION
I missed a comment from @samccone about the youtube urls having IDs attached to them in my other PR (https://github.com/tastejs/todomvc/pull/1172), this PR removes them, fixing the issue of the linked videos jumping ahead on page load