### PR TITLE
Remove link to marionette require_js

### DIFF
--- a/learn.json
+++ b/learn.json
@@ -1438,9 +1438,6 @@
 		"examples": [{
 			"name": "Example Basic Marionette",
 			"url": "examples/backbone_marionette"
-		}, {
-			"name": "Example Marionette with RequireJS",
-			"url": "examples/backbone_marionette_require"
 		}],
 		"link_groups": [{
 			"heading": "Official Resources",


### PR DESCRIPTION
This example was removed in 79c34b30006f91f35b14295087bcc477ba8ea990

Fixes #1187