### PR TITLE
CI Test work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ node_js:
     - '0.12'
 notifications:
     irc: 'irc.freenode.org#tastejs'
-branches:
-    only:
-        - master
+addons:
+    sauce_connect: true
 env:
+    # add in tokens for sauce labs
     global:
+        - secure: gd7Y1sZyUc4+eck+c4cZ19WdVkmvvfE16fegUMZ9/BMRVYaaEfLZ/805+mOPccAebu5nuGKX0dAjXBwDGcAk2T9YvXpgl8GHu5sAHT3ax0XTibwW7Je2ayf8dJqTO9eRelY616v2mYUlj9QMmbWCB2zESsscY3hi2DQAPeueMdo=
+        - secure: av1hgfvD9UpQr59Q2qcyC0WmiUvRivJHzdcrwj3uYiIJLxxpXv00EC4PzqMZAVREOaQEK1s9FwFVSYn8FbvtvWp5TnWNvSXUXCSjc+I0MYhxbtvcAuKlDzayHSfp17bt0BY3pxB/1BdwMdPwDYumEULphKOmsLr4ocsJCfng2Ds=
         # GH_OAUTH_TOKEN is the oauth token generated as described at
         # https://help.github.com/articles/creating-an-oauth-token-for-command-line-use
         #
@@ -31,20 +33,9 @@ env:
 before_script:
     # install dependencies
     - npm install -g gulp
+    - python -m SimpleHTTPServer &
+    - sleep 2
 script:
     # We want to gate on passing tests and a successful build
     - gulp
-after_success:
-    # Any command that using GH_OAUTH_TOKEN must pipe the output to /dev/null to not expose your oauth token
-    - git submodule add -b gh-pages https://${GH_OAUTH_TOKEN}@github.com/${GH_OWNER}/${GH_PROJECT_NAME} site > /dev/null 2>&1
-    - cd site
-    - if git checkout gh-pages; then git checkout -b gh-pages; fi
-    - git rm -r .
-    - cp -R ../dist/* .
-    - cp ../dist/.* .
-    - git add -f .
-    - git config user.email 'travis@rdrei.net'
-    - git config user.name 'TasteBot'
-    - git commit -am 'update the build files for gh-pages [ci skip]'
-    # Any command that using GH_OAUTH_TOKEN must pipe the output to /dev/null to not expose your oauth token
-    - git push https://${GH_OAUTH_TOKEN}@github.com/${GH_OWNER}/${GH_PROJECT_NAME} HEAD:gh-pages > /dev/null 2>&1
+    - ./travis-runner.sh

--- a/browser-tests/allTests.js
+++ b/browser-tests/allTests.js
@@ -63,7 +63,9 @@ list = list.filter(function (framework) {
 // if a specific framework has been named, just run this one
 if (argv.framework) {
 	list = list.filter(function (framework) {
-		return framework.name === argv.framework;
+		return [].concat(argv.framework).some(function (f) {
+			return f === framework.name;
+		});
 	});
 
 	if (list.length === 0) {

--- a/browser-tests/package.json
+++ b/browser-tests/package.json
@@ -9,7 +9,7 @@
     "mocha-known-issues-reporter": "git+https://github.com/ColinEberhardt/mocha-known-issues-reporter.git#v0.0.0",
     "optimist": "^0.6.1",
     "q": "^1.0.1",
-    "selenium-webdriver": "^2.42.1"
+    "selenium-webdriver": "^2.45.1"
   },
   "scripts": {
     "serve": "http-server -p 8000 ..",

--- a/browser-tests/test.js
+++ b/browser-tests/test.js
@@ -21,9 +21,31 @@ module.exports.todoMVCTest = function (frameworkName, baseUrl, speedMode, laxMod
 		}
 
 		function launchBrowser() {
-			browser = new webdriver.Builder()
-			.withCapabilities({browserName : browserName})
-			.build();
+
+			if (process.env.SAUCE_USERNAME !== undefined) {
+				browser = new webdriver.Builder()
+				.usingServer(
+					'http://' +
+					process.env.SAUCE_USERNAME +
+					':' +
+					process.env.SAUCE_ACCESS_KEY +
+					'@ondemand.saucelabs.com:80/wd/hub'
+				)
+				.withCapabilities({
+					'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
+					build: process.env.TRAVIS_BUILD_NUMBER,
+					browserName: browserName,
+					username: process.env.SAUCE_USERNAME,
+					accessKey: process.env.SAUCE_ACCESS_KEY
+				})
+				.build();
+			} else {
+				browser = new webdriver.Builder()
+				.withCapabilities({
+					browserName: browserName
+				})
+				.build();
+			}
 
 			browser.get(baseUrl);
 

--- a/travis-runner.sh
+++ b/travis-runner.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -o pipefail
+
+if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]
+then
+  git submodule add -b gh-pages https://${GH_OAUTH_TOKEN}@github.com/${GH_OWNER}/${GH_PROJECT_NAME} site > /dev/null 2>&1
+  cd site
+  if git checkout gh-pages; then git checkout -b gh-pages; fi
+  git rm -r .
+  cp -R ../dist/* .
+  cp ../dist/.* .
+  git add -f .
+  git config user.email 'travis@rdrei.net'
+  git config user.name 'TasteBot'
+  git commit -am 'update the build files for gh-pages [ci skip]'
+  # Any command that using GH_OAUTH_TOKEN must pipe the output to /dev/null to not expose your oauth token
+  git push https://${GH_OAUTH_TOKEN}@github.com/${GH_OWNER}/${GH_PROJECT_NAME} HEAD:gh-pages > /dev/null 2>&1
+else
+  git remote add current https://github.com/tastejs/todomvc.git && \
+  git fetch current && \
+  cd browser-tests/ && \
+  npm i && \
+  git diff HEAD current/master --name-only |  awk 'BEGIN {FS = "/"}; {print $1 "/" $2 "/" $3}' | uniq | grep -v \/\/ | grep examples | awk -F '[/]' '{print "--framework=" $2}' | xargs npm run test --
+
+  exit $?
+fi


### PR DESCRIPTION
Master still runs deploy but all other branches and PR's will run the tests on the changes.

:sparkles: :dancer: :sparkles: 

I anticipate a bit of friction when we flip this on.. just with the sauce keys and such but, everything works on my fork :+1: 


* First we add the real remote and fetch the contents
* then we diff the current branch from masters contents
* then we get the examples folders.. for instance

examples/backbone/....
examples/angular/.....

then I awk out the middle name, which happens to be used with our test
suite to run each test. From there I use xargs to invoke the tests
running over a subset of all of the tests.

```shell
npm run test -- --framework=backbone --framework=angular
--framework=dogescript
```


---

commit 1 allows us to do this

`npm run test -- --framework=jquery --framework=backbone --grep 'should trim entered text'`


------

Fixes #946