### PR TITLE
Remove React onEdit() workaround

### DIFF
--- a/examples/react/js/app.jsx
+++ b/examples/react/js/app.jsx
@@ -62,12 +62,8 @@ var app = app || {};
 			this.props.model.destroy(todo);
 		},
 
-		edit: function (todo, callback) {
-			// refer to todoItem.js `handleEdit` for the reasoning behind the
-			// callback
-			this.setState({editing: todo.id}, function () {
-				callback();
-			});
+		edit: function (todo) {
+			this.setState({editing: todo.id});
 		},
 
 		save: function (todoToSave, text) {

--- a/examples/react/js/todoItem.jsx
+++ b/examples/react/js/todoItem.jsx
@@ -23,15 +23,7 @@ var app = app || {};
 		},
 
 		handleEdit: function () {
-			// react optimizes renders by batching them. This means you can't call
-			// parent's `onEdit` (which in this case triggeres a re-render), and
-			// immediately manipulate the DOM as if the rendering's over. Put it as a
-			// callback. Refer to app.jsx' `edit` method
-			this.props.onEdit(function () {
-				var node = this.refs.editField.getDOMNode();
-				node.focus();
-				node.setSelectionRange(node.value.length, node.value.length);
-			}.bind(this));
+			this.props.onEdit();
 			this.setState({editText: this.props.todo.title});
 		},
 
@@ -65,6 +57,20 @@ var app = app || {};
 				nextProps.editing !== this.props.editing ||
 				nextState.editText !== this.state.editText
 			);
+		},
+
+		/**
+		 * Safely manipulate the DOM after updating the state when invoking
+		 * `this.props.onEdit()` in the `handleEdit` method above.
+		 * For more info refer to notes at https://facebook.github.io/react/docs/component-api.html#setstate
+		 * and https://facebook.github.io/react/docs/component-specs.html#updating-componentdidupdate
+		 */
+		componentDidUpdate: function (prevProps) {
+			if (!prevProps.editing && this.props.editing) {
+				var node = this.refs.editField.getDOMNode();
+				node.focus();
+				node.setSelectionRange(node.value.length, node.value.length);
+			}
 		},
 
 		render: function () {


### PR DESCRIPTION
- New Feature: No.
- BugFix: No.
- Refactor: Yes.

Hi there.
Before anything I'd like to say thanks for this amazing project, it helped a lot to decide on a JS library.

I revisited the React code today and I noticed a workaround in TodoApp::onEdit() and in TodoItem::handleEdit() functions.

With this pull request I'm aiming to simplify the code  by moving the DOM manipulation to a more appropriated place where it feels more natural  to the React lifecycles.

We will also make the TodoApp crud methods more consistent. I noticed that only onEdit() function expects a callback to be passed, and it feels harder to reason about.

If you noticed I moved the DOM manipulation to `componentDidUpdate` method. While this make things feel "more natural", I think it also promotes a switch-case design which is not good either.

However I find more advantages by doing it this way, like, for example, that now the node.focus() logic stays encapsulated within the TodoItem and we avoid making the TodoApp aware that it needs to execute a callback whenever onEdit is invoked.

What do you guys think? Regards.