### PR TITLE
Fixing a memory leak in yui example

### DIFF
--- a/examples/yui/js/app.js
+++ b/examples/yui/js/app.js
@@ -115,6 +115,9 @@ YUI.add('todo-app', function (Y) {
 				fragment.append(view.render().get('container'));
 			});
 
+			// To delete previously attached views and fix the memory leak.
+			this.get('container').one('#todo-list').destroy({recursivePurge: true});
+
 			this.get('container').one('#todo-list').setContent(fragment);
 		},
 


### PR DESCRIPTION
Hi,

This pull request is to fix a memory leak in yui example, issue #1248.
The leak is caused because the view objects are not completely destroyed.

Thanks,
Masrud