### PR TITLE
Debounce the rendering of the application view

### DIFF
--- a/examples/backbone/js/views/app-view.js
+++ b/examples/backbone/js/views/app-view.js
@@ -38,7 +38,7 @@ var app = app || {};
 			this.listenTo(app.todos, 'reset', this.addAll);
 			this.listenTo(app.todos, 'change:completed', this.filterOne);
 			this.listenTo(app.todos, 'filter', this.filterAll);
-			this.listenTo(app.todos, 'all', this.render);
+			this.listenTo(app.todos, 'all', _.debounce(this.render, 0));
 
 			// Suppresses 'add' events with {reset: true} and prevents the app view
 			// from being re-rendered for every model. Only renders when the 'reset'
@@ -51,8 +51,9 @@ var app = app || {};
 		render: function () {
 			var completed = app.todos.completed().length;
 			var remaining = app.todos.remaining().length;
+			var size = app.todos.length;
 
-			if (app.todos.length) {
+			if (size) {
 				this.$main.show();
 				this.$footer.show();
 
@@ -70,7 +71,7 @@ var app = app || {};
 				this.$footer.hide();
 			}
 
-			this.allCheckbox.checked = !remaining;
+			this.allCheckbox.checked = size && !remaining;
 		},
 
 		// Add a single todo item to the list by creating a view for it, and


### PR DESCRIPTION
If we don't debounce "this.render", the app-view will be rendered 4 times on each todo (visible, change, change:complete and sync). So when we try to check globally all todos, this.render is called a hundred times. Once this PR is accepted, I will edit Backbone-requirejs.

Another problem I have addressed concerning the global checkbox. It should be checked when we have at least one completed todo.