### PR TITLE
Tests: add back `persistence` test

### DIFF
--- a/browser-tests/test.js
+++ b/browser-tests/test.js
@@ -285,7 +285,7 @@ module.exports.todoMVCTest = function (frameworkName, baseUrl, speedMode, laxMod
 			});
 		});
 
-		/*test.describe('Persistence', function () {
+		test.describe('Persistence', function () {
 			test.it('should persist its data', function () {
 				// set up state
 				page.enterItem(TODO_ITEM_ONE);
@@ -302,13 +302,13 @@ module.exports.todoMVCTest = function (frameworkName, baseUrl, speedMode, laxMod
 				stateTest();
 
 				// navigate away and back again
-				browser.get(otherUrl);
+				browser.get('about:blank');
 				browser.get(baseUrl);
 
 				// repeat the state test
 				stateTest();
 			});
-		});*/
+		});
 
 		test.describe('Routing', function () {
 			test.it('should allow me to display active items', function () {


### PR DESCRIPTION
In the past we commented out this test because it failed intermittently. This was simply because the `otherUrl` variable didn't exist and an error was thrown when trying to access it.

Changing `otherUrl` with `about:blank` seemed to fix the issue. [This should, normally, work cross-browser.](http://en.wikipedia.org/wiki/About_URI_scheme)

@ColinEberhardt Would love to hear your thoughts on this.

Fixes https://github.com/tastejs/todomvc/issues/834