### PR TITLE
Debounce the rendering of the application view

### DIFF
--- a/examples/backbone/js/views/app-view.js
+++ b/examples/backbone/js/views/app-view.js
@@ -38,7 +38,7 @@ var app = app || {};
 			this.listenTo(app.todos, 'reset', this.addAll);
 			this.listenTo(app.todos, 'change:completed', this.filterOne);
 			this.listenTo(app.todos, 'filter', this.filterAll);
-			this.listenTo(app.todos, 'all', this.render);
+			this.listenTo(app.todos, 'all', _.debounce(this.render, 0));
 
 			// Suppresses 'add' events with {reset: true} and prevents the app view
 			// from being re-rendered for every model. Only renders when the 'reset'


### PR DESCRIPTION
If we don't debounce "this.render", the app-view will be rendered 4 times on each todo (visible, change, change:complete and sync). So when we try to check globally all todos, this.render is called a hundred times.