### PR TITLE
Debounce the rendering of the application view

### DIFF
--- a/examples/backbone_require/js/views/app.js
+++ b/examples/backbone_require/js/views/app.js
@@ -41,7 +41,7 @@ define([
 			this.listenTo(Todos, 'reset', this.addAll);
 			this.listenTo(Todos, 'change:completed', this.filterOne);
 			this.listenTo(Todos, 'filter', this.filterAll);
-			this.listenTo(Todos, 'all', this.render);
+			this.listenTo(Todos, 'all', _.debounce(this.render, 0));
 
 			Todos.fetch({reset:true});
 		},


### PR DESCRIPTION
If we don't debounce "this.render", the app-view will be rendered 4 times on each todo (visible, change, change:complete and sync). So when we try to check globally all todos, this.render is called a hundred times. Once this PR is accepted, I will edit Backbone-requirejs.