### PR TITLE
SAPUI5: fix adding new tasks, remove browser-dependent autoselect

### DIFF
--- a/examples/sapui5/index.html
+++ b/examples/sapui5/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 		<title>SAPUI5 • TodoMVC</title>
 		<script
-			src="https://sapui5.netweaver.ondemand.com/resources/sap-ui-core.js"
+			src="https://sapui5.hana.ondemand.com/resources/sap-ui-core.js"
 			id="sap-ui-bootstrap"
 			data-sap-ui-libs="sap.ui.commons"
 			data-sap-ui-theme="base">

--- a/examples/sapui5/js/todo/Todo.controller.js
+++ b/examples/sapui5/js/todo/Todo.controller.js
@@ -39,12 +39,13 @@
 				return;
 			}
 
-			this.model.setProperty('/todos/', this.model.getProperty('/todos/')
-				.push({
-					id: jQuery.sap.uid(),
-					done: false,
-					text: todo
-				}));
+			var todos = this.model.getProperty('/todos/');
+			todos.push({
+				id: jQuery.sap.uid(),
+				done: false,
+				text: todo
+			});
+			this.model.setProperty('/todos/', todos);
 
 			this.store.set(this.model.getData());
 

--- a/examples/sapui5/js/todo/Todo.view.js
+++ b/examples/sapui5/js/todo/Todo.view.js
@@ -44,8 +44,7 @@
 			// Text field for entering a new todo
 			newTodo = new todo.SmartTextField('new-todo', {
 				placeholder: 'What needs to be done?',
-				// Don't autofocus in case of MSIE and Opera as both hide placeholder on focus
-				autofocus: !sap.ui.Device.browser.internet_explorer && !$.browser.opera
+				autofocus: true
 			}).attachChange(function () {
 				oController.createTodo(this.getProperty('value'));
 				this.setValue('');


### PR DESCRIPTION
The return value of Array.push() was expected to be the resulting array,
but it is the length of the array. Not sure how this ever worked, maybe
Array.push() had been overridden wrongly somewhere.

The browser detection API conflicted with TodoMVC's code checks and is
anyway undesired.

Also update the URL from which SAPUI5 is loaded:
sapui5.hana.ondemand.com is the one to use and is powered by Akamai CDN.

Fixes https://github.com/tastejs/todomvc/issues/1315