### PR TITLE
Fix `frameworkNamePattern` regex

### DIFF
--- a/tests/allTests.js
+++ b/tests/allTests.js
@@ -4,7 +4,7 @@ var testSuite = require('./test.js');
 var fs = require('fs');
 var argv = require('optimist').default('laxMode', false).default('browser', 'chrome').argv;
 var rootUrl = 'http://localhost:8000/';
-var frameworkNamePattern = /^[a-z-_]+$/;
+var frameworkNamePattern = /^[a-z-_\d]+$/;
 
 var excludedFrameworks = [
 	// this implementation deviates from the specification to such an extent that they are


### PR DESCRIPTION
In the test suite, we had a regex in place to match framework folder names. It didn't include numbers so we couldn't run tests on the `sapui5` app for example. 