### PR TITLE
dont lint the same example a bunch of times

### DIFF
--- a/test-runner.sh
+++ b/test-runner.sh
@@ -6,7 +6,7 @@ get_changes ()
 {
 	git remote add current https://github.com/tastejs/todomvc.git && \
 	git fetch --quiet current && \
-	git diff HEAD origin/master --name-only |  awk 'BEGIN {FS = "/"}; {print $1 "/" $2 "/" $3}' | uniq | grep -v \/\/ | grep examples | awk -F '[/]' '{print "--framework=" $2}'
+	git diff HEAD origin/master --name-only |  awk 'BEGIN {FS = "/"}; {print $1 "/" $2 "/" $3}' | grep -v \/\/ | grep examples | awk -F '[/]' '{print "--framework=" $2}'|uniq
 }
 
 if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]


### PR DESCRIPTION
Small change in a script i stumbled over - i dont know if jscs is clever enough to avoid relinting the same files over and over, but if its naive this should improve performance a bit.

> @ lint /home/travis/build/tastejs/todomvc/tooling

> jscs "-c" "../.jscsrc" "../examples/scalajs-react" "../examples/scalajs-react" "../examples/scalajs-react" "../examples/scalajs-react" "../examples/scalajs-react" "../examples/scalajs-react" "../examples/scalajs-react" "../examples/scalajs-react" "../examples/scalajs-react" "../examples/scalajs-react"