### PR TITLE
React: fix markdown in readme

### DIFF
--- a/examples/react/readme.md
+++ b/examples/react/readme.md
@@ -27,7 +27,7 @@ Get help from other React users:
 
 * [React on StackOverflow](http://stackoverflow.com/questions/tagged/reactjs)
 * [Mailing list on Google Groups](https://groups.google.com/forum/#!forum/reactjs)
-*
+
 _If you have other helpful links to share, or find any of the links above no longer work, please [let us know](https://github.com/tastejs/todomvc/issues)._
 
 


### PR DESCRIPTION
The asterisk caused the next line to be displayed inline with the last list item instead of below the links.