### PR TITLE
Replace deprecated Controller

### DIFF
--- a/examples/backbone_marionette/js/TodoMVC.TodoList.js
+++ b/examples/backbone_marionette/js/TodoMVC.TodoList.js
@@ -17,7 +17,7 @@ TodoMVC.module('TodoList', function (TodoList, App, Backbone, Marionette) {
 	//
 	// Control the workflow and logic that exists at the application
 	// level, above the implementation detail of views and models
-	TodoList.Controller = Marionette.Controller.extend({
+	TodoList.Controller = Marionette.Object.extend({
 		initialize: function () {
 			this.todoList = new App.Todos.TodoList();
 		},


### PR DESCRIPTION
Marionette has marked `Controller` object as a deprecated feature
Instead of using `Controller`, Marionette encourages you to specify your callbacks on a plain 
Javascript object:
http://marionettejs.com/docs/v2.4.2/marionette.controller.html

I propose to use Marionette Object instead of a plain js object. 
Object incorporates many backbone conventions and utilities like initialize and Backbone.Events.
http://marionettejs.com/docs/v2.4.1/marionette.object.html


