### PR TITLE
Update AngularJS case studies links

### DIFF
--- a/examples/angularjs-perf/readme.md
+++ b/examples/angularjs-perf/readme.md
@@ -13,7 +13,7 @@ Here are some links you may find helpful:
 * [Tutorial](http://docs.angularjs.org/tutorial)
 * [API Reference](http://docs.angularjs.org/api)
 * [Developer Guide](http://docs.angularjs.org/guide)
-* [Applications built with AngularJS](http://builtwith.angularjs.org)
+* [Applications built with AngularJS](https://www.madewithangular.com/)
 * [Blog](http://blog.angularjs.org)
 * [FAQ](http://docs.angularjs.org/misc/faq)
 * [AngularJS Meetups](http://www.youtube.com/angularjs)

--- a/examples/angularjs/readme.md
+++ b/examples/angularjs/readme.md
@@ -13,7 +13,7 @@ Here are some links you may find helpful:
 * [Tutorial](http://docs.angularjs.org/tutorial)
 * [API Reference](http://docs.angularjs.org/api)
 * [Developer Guide](http://docs.angularjs.org/guide)
-* [Applications built with AngularJS](http://builtwith.angularjs.org)
+* [Applications built with AngularJS](https://www.madewithangular.com/)
 * [Blog](http://blog.angularjs.org)
 * [FAQ](http://docs.angularjs.org/misc/faq)
 * [AngularJS Meetups](http://www.youtube.com/angularjs)

--- a/examples/angularjs_require/readme.md
+++ b/examples/angularjs_require/readme.md
@@ -13,7 +13,7 @@ Here are some links you may find helpful:
 * [Tutorial](http://docs.angularjs.org/tutorial)
 * [API Reference](http://docs.angularjs.org/api)
 * [Developer Guide](http://docs.angularjs.org/guide)
-* [Applications built with AngularJS](http://builtwith.angularjs.org)
+* [Applications built with AngularJS](https://www.madewithangular.com/)
 * [Blog](http://blog.angularjs.org)
 * [FAQ](http://docs.angularjs.org/misc/faq)
 * [AngularJS Meetups](http://www.youtube.com/angularjs)

--- a/learn.json
+++ b/learn.json
@@ -37,7 +37,7 @@
 				"url": "http://docs.angularjs.org/guide"
 			}, {
 				"name": "Applications built with AngularJS",
-				"url": "http://builtwith.angularjs.org"
+				"url": "https://www.madewithangular.com/"
 			}, {
 				"name": "Blog",
 				"url": "http://blog.angularjs.org"


### PR DESCRIPTION
We have deprecated the https://builtwith.angularjs.org site in favour of the new https://www.madewithangular.com/ site. This PR updates the links to that new site.