### PR TITLE
Bump jscs version to 1.6

### DIFF
--- a/tooling/package.json
+++ b/tooling/package.json
@@ -4,6 +4,6 @@
     "lint": "jscs"
   },
   "dependencies": {
-    "jscs": "^1.13.1"
+    "jscs": "^1.6.0"
   }
 }


### PR DESCRIPTION
See https://github.com/tastejs/todomvc/pull/1441#issuecomment-141721812. jscs 1.6 supports ignoring certain js files via a special comment: `// jscs:disable`. This is important for Humble and other compile-to-js frameworks.