### PR TITLE
Use generic comment for localStorage namespace in backbone examples

### DIFF
--- a/examples/backbone/js/collections/todos.js
+++ b/examples/backbone/js/collections/todos.js
@@ -13,7 +13,7 @@ var app = app || {};
 		// Reference to this collection's model.
 		model: app.Todo,
 
-		// Save all of the todo items under the `"todos"` namespace.
+		// Save all of the todo items under this example's namespace.
 		localStorage: new Backbone.LocalStorage('todos-backbone'),
 
 		// Filter down the list of all todo items that are finished.

--- a/examples/backbone_require/js/collections/todos.js
+++ b/examples/backbone_require/js/collections/todos.js
@@ -11,7 +11,7 @@ define([
 		// Reference to this collection's model.
 		model: Todo,
 
-		// Save all of the todo items under the `"todos"` namespace.
+		// Save all of the todo items under this example's namespace.
 		localStorage: new Store('todos-backbone'),
 
 		// Filter down the list of all todo items that are finished.

--- a/examples/react-backbone/js/todos.js
+++ b/examples/react-backbone/js/todos.js
@@ -13,7 +13,7 @@ var app = app || {};
 		// Reference to this collection's model.
 		model: app.Todo,
 
-		// Save all of the todo items under the `"todos"` namespace.
+		// Save all of the todo items under this example's namespace.
 		localStorage: new Backbone.LocalStorage('todos-react-backbone'),
 
 		// Filter down the list of all todo items that are finished.


### PR DESCRIPTION
The comments in the backbone examples are slightly off and made me (slightly) confused when reading them.