### PR TITLE
Replace Mailing list on Google Groups with forum on React discuss

### DIFF
--- a/examples/react/readme.md
+++ b/examples/react/readme.md
@@ -26,7 +26,7 @@ Articles and guides from the community:
 Get help from other React users:
 
 * [React on StackOverflow](http://stackoverflow.com/questions/tagged/reactjs)
-* [Mailing list on Google Groups](https://groups.google.com/forum/#!forum/reactjs)
+* [Forum on React discuss](https://discuss.reactjs.org/)
 
 _If you have other helpful links to share, or find any of the links above no longer work, please [let us know](https://github.com/tastejs/todomvc/issues)._
 


### PR DESCRIPTION
Mailing list on Google Groups closed and they use forum on React discuss instead.