### PR TITLE
Backbone: remove unneeded logic in todo View

### DIFF
--- a/examples/backbone/js/views/todo-view.js
+++ b/examples/backbone/js/views/todo-view.js
@@ -91,15 +91,6 @@ var app = app || {};
 
 			if (trimmedValue) {
 				this.model.save({ title: trimmedValue });
-
-				if (value !== trimmedValue) {
-					// Model values changes consisting of whitespaces only are
-					// not causing change to be triggered Therefore we've to
-					// compare untrimmed version with a trimmed one to check
-					// whether anything changed
-					// And if yes, we've to trigger change event ourselves
-					this.model.trigger('change');
-				}
 			} else {
 				this.clear();
 			}


### PR DESCRIPTION
The removed check is unncecessary and also incorrectly implemented,
resulting in a test failure (the "Editing should trim entered text"
example) and flawed user interaction. This change results in 100%
passing tests and the desired user interaction.

Unneeded: the associated comment states that "Model values changes
consisting of whitespaces only are not causing change to be triggered",
and so the code manually triggers a change event when the only change to
the todo is whitespace being added at the beginning and/or end of the
todo. However, there is no need for the change event when this is the
only change. So the situation described in the comment is not a problem.
The change event triggers a re-rendering of the view, but if the only
change is whitespace at the beginning or end, which is trimmed off,
anyway, then re-rendering is pointless.

Incorrectly implemented: The code in question is
`this.model.trigger('change');`. This ultimately raises an error,
because (perhaps surprisingly) when the 'change' event is manually
triggered on a model, the model is not automatically bound as the so-to-
speak "context" of that change. This can be corrected manually like so:
`this.model.trigger('change', this.model);`. This eliminates the error
and failing test case. However, as this code is not needed, anyway, of
course it's better to simply remove it rather than correct it. :)