### PR TITLE
Travis CI test. Don't merge. Testing using express.js server for tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,6 @@ before_install:
     - sh -e /etc/init.d/xvfb start
     - curl -Lo chrome.zip https://download-chromium.appspot.com/dl/Linux_x64 && unzip chrome.zip
     - curl -Lo chromedriver.zip http://chromedriver.storage.googleapis.com/2.18/chromedriver_linux64.zip && unzip chromedriver.zip
-before_script:
-    - cp site-assets/favicon.ico favicon.ico
-    - python -m SimpleHTTPServer > /dev/null 2>&1 &
-    - sleep 2
 script:
     # We want to gate on passing tests and a successful build
     - ./test-runner.sh

--- a/examples/backbone/js/views/app-view.js
+++ b/examples/backbone/js/views/app-view.js
@@ -123,7 +123,7 @@ var app = app || {};
 
 			app.todos.each(function (todo) {
 				todo.save({
-					completed: completed
+					completed: false
 				});
 			});
 		}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,3 +109,7 @@ gulp.task('pagespeed', pagespeed.bind(null, {
 gulp.task('serve', function (cb) {
 	app.listen(8080, cb);
 });
+
+gulp.task('test-server', function (cb) {
+	app.listen(8000, cb);
+});

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-vulcanize": "^1.0.0",
     "jshint-stylish": "^1.0.0",
     "psi": "^0.1.1",
-    "run-sequence": "^1.0.1"
+    "run-sequence": "^1.0.1",
+    "serve-favicon": "^2.3.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -5,8 +5,10 @@ var fs = require('fs');
 var learnJson = require('./learn.json');
 
 var app = module.exports = express();
+var favicon = require('serve-favicon');
 
 app.use(express.static(__dirname));
+app.use(favicon(__dirname + '/site-assets/favicon.ico'));
 
 Object.defineProperty(module.exports, 'learnJson', {
 	set: function (backend) {

--- a/test-runner.sh
+++ b/test-runner.sh
@@ -9,9 +9,9 @@ get_changes ()
 	git diff HEAD origin/master --name-only |  awk 'BEGIN {FS = "/"}; {print $1 "/" $2 "/" $3}' | grep -v \/\/ | grep examples | awk -F '[/]' '{print "--framework=" $2}'|uniq
 }
 
+npm i -g gulp
 if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]
 then
-	npm i -g gulp
 	gulp
 	git submodule add -b gh-pages https://${GH_OAUTH_TOKEN}@github.com/${GH_OWNER}/${GH_PROJECT_NAME} site > /dev/null 2>&1
 	cd site
@@ -35,6 +35,7 @@ else
 		cd tooling && \
 		echo $changes | xargs ./run.sh && \
 		cd ../tests && \
+		(gulp test-server &) && \
 		echo $changes | xargs ./run.sh
 	fi
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,10 +20,12 @@ These tests use Selenium 2 (WebDriver), via the JavaScript API (WebdriverJS).  I
 $ npm install
 ```
 
-You need to run a local server at the root of the TodoMVC project. Start the server using:
+If you haven't already run `npm install` in the root directory, execute `npm install` there as well.
+
+You need to run a local server for the tests. Start the test server using:
 
 ```sh
-$ npm run serve
+$ gulp test-server
 ```
 
 To run the tests for all TodoMVC implementations, run the following:

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "devDependencies": {
     "chromedriver": "^2.18.0",
-    "http-server": "^0.7.5",
     "mocha": "*",
     "mocha-known-issues-reporter": "git+https://github.com/ColinEberhardt/mocha-known-issues-reporter.git#v0.0.0",
     "optimist": "^0.6.1",
@@ -12,7 +11,6 @@
     "drool": "0.2.2"
   },
   "scripts": {
-    "serve": "http-server -p 8000 ..",
     "test": "mocha allTests.js --no-timeouts --reporter spec"
   }
 }


### PR DESCRIPTION
This is a temporary version of this pull request so that we can test that everything is working correctly with Travis CI now using a different server to run the tests. The Travis CI build should produce a couple of integration test errors because of the breaking change to `examples/backbone/js/views/app-view.js`.