### PR TITLE
travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@
 sudo: false
 language: node_js
 node_js:
-    - '0.12'
+    - 'stable'
 notifications:
     irc: 'irc.freenode.org#tastejs'
 env:

--- a/test-runner.sh
+++ b/test-runner.sh
@@ -36,7 +36,7 @@ else
 		echo $changes | xargs ./run.sh && \
 		cd ../tests && \
 		(gulp test-server &) && \
-		sleep 2 && \ # give the server time to boot in the background
+		sleep 2 && \
 		echo $changes | xargs ./run.sh
 	fi
 


### PR DESCRIPTION
One of our child dependences started to use es6 syntax, because we were locked down to node 0.12 the code actually failed, this should resolve the issue for us

I also dropped an inline comment from our test runner because it was causing an error in the bash script