### PR TITLE
Make todo-list XPath more permissive

### DIFF
--- a/tests/page.js
+++ b/tests/page.js
@@ -16,7 +16,7 @@ module.exports = function Page(browser) {
 	};
 
 	this.getTodoListXpath = function () {
-		return !idSelectors ? '//ul[@id="todo-list"]' : '//ul[@class="todo-list"]';
+		return !idSelectors ? '//ul[@id="todo-list"]' : '//ul[contains(@class, "todo-list")]';
 	};
 
 	this.getMainSectionXpath = function () {


### PR DESCRIPTION
This patch updates the XPath returned from `page.getTodoListXpath` to test if the `class` attribute contains `todo-list` vs. the previous behaviour where the test was equality. This provides a robust solution that prevents some false positives returned from route related tests in tastejs/todomvc#1491.