### PR TITLE
[backbone_marionette] move backbone.history.start() after controller initialization

### DIFF
--- a/examples/backbone_marionette/js/TodoMVC.js
+++ b/examples/backbone_marionette/js/TodoMVC.js
@@ -8,13 +8,13 @@ $(function () {
 	// After we initialize the app, we want to kick off the router
 	// and controller, which will handle initializing our Views
 	TodoMVC.App.on('start', function () {
-		Backbone.history.start();
 		var controller = new TodoMVC.Controller();
 		controller.router = new TodoMVC.Router({
 			controller: controller
 		});
 
 		controller.start();
+		Backbone.history.start();
 	});
 
 	// start the TodoMVC app (defined in js/TodoMVC.js)


### PR DESCRIPTION
Backbone history should be started only after controller is started. Otherwise you cannot navigate directly to states like /#/active