### PR TITLE
thorax: Cancel editing with the Escape key

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -26,16 +26,17 @@
 	"excludeFiles": [
 		"**/node_modules/**",
 		"**/bower_components/**",
-		"examples/vanilladart/**/*.js",
-		"examples/duel/www/**",
-		"examples/duel/src/main/webapp/js/lib/**",
+		"**/generated/**",
 		"examples/ampersand/todomvc.bundle.js",
 		"examples/angular2/**/*.js",
-		"examples/polymer/elements/elements.build.js",
+		"examples/duel/www/**",
+		"examples/duel/src/main/webapp/js/lib/**",
+		"examples/humble/js/**",
 		"examples/js_of_ocaml/js/*.js",
+		"examples/polymer/elements/elements.build.js",
+		"examples/thorax/js/lib/backbone-localstorage.js",
 		"examples/typescript-*/js/**/*.js",
-		"**/generated/**",
-		"examples/humble/js/**"
+		"examples/vanilladart/**/*.js"
 	],
 	"requireSpaceBeforeBlockStatements": true,
 	"requireParenthesesAroundIIFE": true,

--- a/examples/thorax/js/app.js
+++ b/examples/thorax/js/app.js
@@ -1,6 +1,7 @@
 /*global Thorax, Backbone*/
 /*jshint unused:false*/
 var ENTER_KEY = 13;
+var ESCAPE_KEY = 27;
 
 (function () {
 	'use strict';

--- a/examples/thorax/js/views/todo-item.js
+++ b/examples/thorax/js/views/todo-item.js
@@ -1,4 +1,4 @@
-/*global Thorax, ENTER_KEY*/
+/*global Thorax, ENTER_KEY, ESCAPE_KEY*/
 (function () {
 	'use strict';
 
@@ -19,7 +19,7 @@
 			'click .toggle':	'toggleCompleted',
 			'dblclick label':	'edit',
 			'click .destroy':	'clear',
-			'keypress .edit':	'updateOnEnter',
+			'keyup .edit':		'keyListener',
 			'blur .edit':		'close',
 			// The "rendered" event is triggered by Thorax each time render()
 			// is called and the result of the template has been appended
@@ -37,11 +37,16 @@
 		// Switch this view into `"editing"` mode, displaying the input field.
 		edit: function () {
 			this.$el.addClass('editing');
-			this.$('.edit').focus();
+			this.$('.edit').val(this.model.get('title')).focus();
 		},
 
-		// Close the `"editing"` mode, saving changes to the todo.
+		// Close the `"editing"` mode.
 		close: function () {
+			// If editing was cancelled, don't save
+			if (!this.$el.hasClass('editing')) {
+				return;
+			}
+
 			var value = this.$('.edit').val().trim();
 
 			if (value) {
@@ -53,10 +58,17 @@
 			this.$el.removeClass('editing');
 		},
 
-		// If you hit `enter`, we're through editing the item.
-		updateOnEnter: function (e) {
+		// User cancelled editing, don't update the todo.
+		cancelEdits: function () {
+			this.$el.removeClass('editing');
+		},
+
+		// Enter completes the editing, Escape cancels it
+		keyListener: function (e) {
 			if (e.which === ENTER_KEY) {
 				this.close();
+			} else if (e.which === ESCAPE_KEY) {
+				this.cancelEdits();
 			}
 		},
 


### PR DESCRIPTION
Yeah, me again.

This may fail a bunch of jscs style checks on files I didn't edit, but it's fine for the files I did edit. Let me know if you want me to bring this up to spec for those checks as well.

Changes are pretty straightforward, I changed to `keyup` from `keypress` because browsers never standardized behavior for the latter on important keys like Esc which I kinda need to use here. :smiling_imp: 