### PR TITLE
sidebar links text fixes when framework + Require.js

### DIFF
--- a/learn.json
+++ b/learn.json
@@ -1,4 +1,4 @@
-{
+﻿{
 	"angularjs": {
 		"name": "AngularJS",
 		"description": "HTML is great for declaring static documents, but it falters when we try to use it for declaring dynamic views in web-applications. AngularJS lets you extend HTML vocabulary for your application. The resulting environment is extraordinarily expressive, readable, and quick to develop.",
@@ -7,7 +7,7 @@
 			"name": "Example",
 			"url": "examples/angularjs"
 		}, {
-			"name": "Example",
+			"name": "Require.js & AngularJS",
 			"url": "examples/angularjs_require"
 		}, {
 			"name": "AngularJS Optimized",
@@ -245,7 +245,7 @@
 			"name": "Example",
 			"url": "examples/backbone"
 		}, {
-			"name": "Example",
+			"name": "Require.js & Backbone.js",
 			"url": "examples/backbone_require"
 		}, {
 			"name": "Enyo & Backbone.js",
@@ -365,7 +365,7 @@
 			"name": "Example",
 			"url": "examples/canjs"
 		}, {
-			"name": "Example",
+			"name": "Require.js & CanJS",
 			"url": "examples/canjs_require"
 		}],
 		"link_groups": [{
@@ -806,7 +806,7 @@
 			"name": "Example",
 			"url": "examples/emberjs"
 		}, {
-			"name": "Example",
+			"name": "Require.js & Ember.js",
 			"url": "examples/emberjs_require"
 		}],
 		"link_groups": [{
@@ -1983,7 +1983,7 @@
 			"name": "Example",
 			"url": "examples/somajs"
 		}, {
-			"name": "Example",
+			"name": "Require.js & soma.js",
 			"url": "examples/somajs_require"
 		}],
 		"link_groups": [{


### PR DESCRIPTION
Hello

In some frameworks (AngularJS, Backbone.js etc) the sidebar shows:

    Example
    Source

    Example
    Demo, Source

But the second "Example" header regards the same framework in conjuction with Require.js. This is consistent across all frameworks which have an example with Require.js. This PR fixes this.