### PR TITLE
typescript-backbone: Add routing

### DIFF
--- a/examples/typescript-backbone/index.html
+++ b/examples/typescript-backbone/index.html
@@ -92,6 +92,17 @@ https://github.com/documentcloud/backbone/blob/master/examples/todos/index.html
 					<span class="word"><%= remaining == 1 ? 'item' : 'items' %></span> left
 				</span>
 			<% } %>
+			<ul class="filters">
+				<li>
+					<a class="selected" href="#/">All</a>
+				</li>
+				<li>
+					<a href="#/active">Active</a>
+				</li>
+				<li>
+					<a href="#/completed">Completed</a>
+				</li>
+			</ul>
 			<% if (completed) { %>
 				<span class="todo-clear">
 					<button class="clear-completed">Clear completed</button>

--- a/examples/typescript-backbone/js/app.js
+++ b/examples/typescript-backbone/js/app.js
@@ -39,11 +39,10 @@ DEALINGS IN THE SOFTWARE.
 --------------------------------------------------------------------------------------- */
 // Todos.js
 // https://github.com/documentcloud/backbone/blob/master/examples/todos/todos.js
-var __extends = this.__extends || function (d, b) {
+var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 // Todo Model
 // ----------
@@ -112,6 +111,7 @@ var TodoList = (function (_super) {
 })(Backbone.Collection);
 // Create our global collection of **Todos**.
 var Todos = new TodoList();
+var taskFilter;
 // Todo Item View
 // --------------
 // The DOM element for a todo item...
@@ -132,19 +132,29 @@ var TodoView = (function (_super) {
         _super.call(this, options);
         // Cache the template function for a single item.
         this.template = _.template($('#item-template').html());
-        _.bindAll(this, 'render', 'close', 'remove');
+        _.bindAll(this, 'render', 'close', 'remove', 'toggleVisible');
         this.model.bind('change', this.render);
         this.model.bind('destroy', this.remove);
+        this.model.bind('visible', this.toggleVisible);
     }
     // Re-render the contents of the todo item.
     TodoView.prototype.render = function () {
-        this.$el.html(this.template(this.model.toJSON())).toggleClass('completed', this.model.get('completed'));
+        this.$el
+            .html(this.template(this.model.toJSON()))
+            .toggleClass('completed', this.model.get('completed'));
+        this.toggleVisible();
         this.input = this.$('.todo-input');
         return this;
     };
     // Toggle the `completed` state of the model.
     TodoView.prototype.toggleDone = function () {
         this.model.toggle();
+    };
+    TodoView.prototype.toggleVisible = function () {
+        var completed = this.model.get('completed');
+        var hidden = (taskFilter === 'completed' && !completed) ||
+            (taskFilter === 'active' && completed);
+        this.$el.toggleClass('hidden', hidden);
     };
     // Switch this view into `'editing'` mode, displaying the input field.
     TodoView.prototype.edit = function () {
@@ -184,6 +194,25 @@ var TodoView = (function (_super) {
     TodoView.ESC_KEY = 27;
     return TodoView;
 })(Backbone.View);
+// Todo Router
+// -----------
+var TodoRouter = (function (_super) {
+    __extends(TodoRouter, _super);
+    function TodoRouter() {
+        _super.call(this);
+        this.routes = {
+            '*filter': 'setFilter'
+        };
+        this._bindRoutes();
+    }
+    TodoRouter.prototype.setFilter = function (param) {
+        if (param === void 0) { param = ''; }
+        // Trigger a collection filter event, causing hiding/unhiding
+        // of Todo view items
+        Todos.trigger('filter', param);
+    };
+    return TodoRouter;
+})(Backbone.Router);
 // The Application
 // ---------------
 // Our overall **AppView** is the top-level piece of UI.
@@ -203,7 +232,7 @@ var AppView = (function (_super) {
         // At initialization we bind to the relevant events on the `Todos`
         // collection, when items are added or changed. Kick things off by
         // loading any preexisting todos that might be saved in *localStorage*.
-        _.bindAll(this, 'addOne', 'addAll', 'render', 'toggleAllComplete');
+        _.bindAll(this, 'addOne', 'addAll', 'render', 'toggleAllComplete', 'filter');
         this.input = this.$('.new-todo');
         this.allCheckbox = this.$('.toggle-all')[0];
         this.mainElement = this.$('.main')[0];
@@ -212,7 +241,12 @@ var AppView = (function (_super) {
         Todos.bind('add', this.addOne);
         Todos.bind('reset', this.addAll);
         Todos.bind('all', this.render);
+        Todos.bind('change:completed', this.filterOne);
+        Todos.bind('filter', this.filter);
         Todos.fetch();
+        // Initialize the router, showing the selected view
+        var todoRouter = new TodoRouter();
+        Backbone.history.start();
     }
     // Re-rendering the App just means refreshing the statistics -- the rest
     // of the app doesn't change.
@@ -227,6 +261,10 @@ var AppView = (function (_super) {
                 completed: completed,
                 remaining: remaining
             }));
+            this.$('.filters li a')
+                .removeClass('selected')
+                .filter('[href="#/' + (taskFilter || '') + '"]')
+                .addClass('selected');
         }
         else {
             this.mainElement.style.display = 'none';
@@ -243,6 +281,17 @@ var AppView = (function (_super) {
     // Add all items in the **Todos** collection at once.
     AppView.prototype.addAll = function () {
         Todos.each(this.addOne);
+    };
+    // Filter out completed/remaining tasks
+    AppView.prototype.filter = function (criteria) {
+        taskFilter = criteria;
+        this.filterAll();
+    };
+    AppView.prototype.filterOne = function (todo) {
+        todo.trigger('visible');
+    };
+    AppView.prototype.filterAll = function () {
+        Todos.each(this.filterOne);
     };
     // Generate the attributes for a new Todo item.
     AppView.prototype.newAttributes = function () {


### PR DESCRIPTION
Fixes #1487 

Seems to be passing unit tests and jscs (thanks to the .jscsrc exclusions on `examples/typescript-*`) but not jshint on the generated .js of course.

I felt dirty for introducing a global for the routing filter criteria but `examples/backbone` does it the same way so ¯\\_(ツ)_/¯.

It really seemed to me that the naming should be `backbone-typescript` to keep all the variants of one MVC framework together in the folder, but I don't know if it's too late for that kind of reorg. 