### PR TITLE
Removed globals, "Controller as" Syntax, Simplified functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /bower_components
 /dist
 /tooling/node_modules
+.DS_Store
+

--- a/examples/angularjs-perf/index.html
+++ b/examples/angularjs-perf/index.html
@@ -12,21 +12,21 @@
 			<header id="header">
 				<h1>todos</h1>
 				<form id="todo-form" ng-submit="TC.addTodo()">
-					<input id="new-todo" placeholder="What needs to be done?" ng-model="TC.newTodo" autofocus>
+					<input id="new-todo" placeholder="What needs to be done?" ng-model="TC.newTodo.title" autofocus>
 				</form>
 			</header>
 			<section id="main" ng-show="TC.todos.length" ng-cloak>
 				<input id="toggle-all" type="checkbox" ng-model="TC.allChecked" ng-click="TC.markAll(TC.allChecked)">
 				<label for="toggle-all">Mark all as complete</label>
 				<ul id="todo-list">
-					<li ng-repeat="todo in TC.todos | filter:TC.statusFilter track by $index" ng-class="{completed: todo.completed, editing: todo == TC.editedTodo}">
+					<li ng-repeat="todo in TC.todos | filter:TC.statusFilter track by $index" ng-class="{completed: todo.completed, editing: todo === TC.editedTodo}">
 						<div class="view">
-							<input class="toggle" type="checkbox" ng-model="todo.completed" ng-change="TC.todoCompleted(todo)">
+							<input class="toggle" type="checkbox" ng-model="todo.completed">
 							<label ng-dblclick="TC.editTodo(todo)">{{todo.title}}</label>
-							<button class="destroy" ng-click="TC.removeTodo(todo)"></button>
+							<button class="destroy" ng-click="TC.removeTodo($index)"></button>
 						</div>
-						<form ng-submit="TC.doneEditing(todo)">
-							<input class="edit" ng-trim="false" ng-model="todo.title" ng-blur="TC.doneEditing(todo)" todo-escape="TC.revertEditing(todo)" todo-focus="todo == TC.editedTodo">
+						<form ng-submit="TC.doneEditing(todo, $index)">
+							<input class="edit" ng-trim="false" ng-model="todo.title" ng-blur="TC.doneEditing(todo, $index)" todo-escape="TC.revertEditing($index)" todo-focus="todo === TC.editedTodo">
 						</form>
 					</li>
 				</ul>

--- a/examples/angularjs-perf/index.html
+++ b/examples/angularjs-perf/index.html
@@ -8,45 +8,45 @@
 		<style>[ng-cloak] { display: none; }</style>
 	</head>
 	<body>
-		<section id="todoapp" ng-controller="TodoCtrl">
+		<section id="todoapp" ng-controller="TodoCtrl as TC">
 			<header id="header">
 				<h1>todos</h1>
-				<form id="todo-form" ng-submit="addTodo()">
-					<input id="new-todo" placeholder="What needs to be done?" ng-model="newTodo" autofocus>
+				<form id="todo-form" ng-submit="TC.addTodo()">
+					<input id="new-todo" placeholder="What needs to be done?" ng-model="TC.newTodo" autofocus>
 				</form>
 			</header>
-			<section id="main" ng-show="todos.length" ng-cloak>
-				<input id="toggle-all" type="checkbox" ng-model="allChecked" ng-click="markAll(allChecked)">
+			<section id="main" ng-show="TC.todos.length" ng-cloak>
+				<input id="toggle-all" type="checkbox" ng-model="TC.allChecked" ng-click="TC.markAll(TC.allChecked)">
 				<label for="toggle-all">Mark all as complete</label>
 				<ul id="todo-list">
-					<li ng-repeat="todo in todos | filter:statusFilter track by $index" ng-class="{completed: todo.completed, editing: todo == editedTodo}">
+					<li ng-repeat="todo in TC.todos | filter:TC.statusFilter track by $index" ng-class="{completed: todo.completed, editing: todo == TC.editedTodo}">
 						<div class="view">
-							<input class="toggle" type="checkbox" ng-model="todo.completed" ng-change="todoCompleted(todo)">
-							<label ng-dblclick="editTodo(todo)">{{todo.title}}</label>
-							<button class="destroy" ng-click="removeTodo(todo)"></button>
+							<input class="toggle" type="checkbox" ng-model="todo.completed" ng-change="TC.todoCompleted(todo)">
+							<label ng-dblclick="TC.editTodo(todo)">{{todo.title}}</label>
+							<button class="destroy" ng-click="TC.removeTodo(todo)"></button>
 						</div>
-						<form ng-submit="doneEditing(todo)">
-							<input class="edit" ng-trim="false" ng-model="todo.title" ng-blur="doneEditing(todo)" todo-escape="revertEditing(todo)" todo-focus="todo == editedTodo">
+						<form ng-submit="TC.doneEditing(todo)">
+							<input class="edit" ng-trim="false" ng-model="todo.title" ng-blur="TC.doneEditing(todo)" todo-escape="TC.revertEditing(todo)" todo-focus="todo == TC.editedTodo">
 						</form>
 					</li>
 				</ul>
 			</section>
-			<footer id="footer" ng-show="todos.length" ng-cloak>
-				<span id="todo-count"><strong>{{remainingCount}}</strong>
-					<ng-pluralize count="remainingCount" when="{ one: 'item left', other: 'items left' }"></ng-pluralize>
+			<footer id="footer" ng-show="TC.todos.length" ng-cloak>
+				<span id="todo-count"><strong>{{TC.remainingCount}}</strong>
+					<ng-pluralize count="TC.remainingCount" when="{ one: 'item left', other: 'items left' }"></ng-pluralize>
 				</span>
 				<ul id="filters">
 					<li>
-						<a ng-class="{selected: location.path() == '/'} " href="#/">All</a>
+						<a ng-class="{selected: TC.location.path() == '/'} " href="#/">All</a>
 					</li>
 					<li>
-						<a ng-class="{selected: location.path() == '/active'}" href="#/active">Active</a>
+						<a ng-class="{selected: TC.location.path() == '/active'}" href="#/active">Active</a>
 					</li>
 					<li>
-						<a ng-class="{selected: location.path() == '/completed'}" href="#/completed">Completed</a>
+						<a ng-class="{selected: TC.location.path() == '/completed'}" href="#/completed">Completed</a>
 					</li>
 				</ul>
-				<button id="clear-completed" ng-click="clearCompletedTodos()" ng-show="remainingCount < todos.length">Clear completed</button>
+				<button id="clear-completed" ng-click="TC.clearCompletedTodos()" ng-show="TC.remainingCount < TC.todos.length">Clear completed</button>
 			</footer>
 		</section>
 		<footer id="info">

--- a/examples/angularjs-perf/js/app.js
+++ b/examples/angularjs-perf/js/app.js
@@ -3,8 +3,8 @@
 'use strict';
 
 /**
- * The main TodoMVC app module
+ * The main TodoMVC app module that pulls all dependency modules declared in same named files
  *
  * @type {angular.Module}
  */
-var todomvc = angular.module('todomvc', []);
+angular.module('todomvc', ['todoCtrl', 'todoEscape', 'todoStorage']);

--- a/examples/angularjs-perf/js/app.js
+++ b/examples/angularjs-perf/js/app.js
@@ -8,5 +8,5 @@
 	 *
 	 * @type {angular.Module}
 	 */
-	angular.module('todomvc', ['todoCtrl', 'todoEscape', 'todoStorage']);
+	angular.module('todomvc', ['todoCtrl', 'todoEscape', 'todoFocus', 'todoStorage']);
 })();

--- a/examples/angularjs-perf/js/app.js
+++ b/examples/angularjs-perf/js/app.js
@@ -1,10 +1,12 @@
 /*global angular */
 /*jshint unused:false */
-'use strict';
+(function () {
+	'use strict';
 
-/**
- * The main TodoMVC app module that pulls all dependency modules declared in same named files
- *
- * @type {angular.Module}
- */
-angular.module('todomvc', ['todoCtrl', 'todoEscape', 'todoStorage']);
+	/**
+	 * The main TodoMVC app module that pulls all dependency modules declared in same named files
+	 *
+	 * @type {angular.Module}
+	 */
+	angular.module('todomvc', ['todoCtrl', 'todoEscape', 'todoStorage']);
+})();

--- a/examples/angularjs-perf/js/controllers/todoCtrl.js
+++ b/examples/angularjs-perf/js/controllers/todoCtrl.js
@@ -1,4 +1,4 @@
-/*global todomvc, angular */
+/*global angular */
 'use strict';
 
 angular.module('todoCtrl', [])

--- a/examples/angularjs-perf/js/controllers/todoCtrl.js
+++ b/examples/angularjs-perf/js/controllers/todoCtrl.js
@@ -1,95 +1,97 @@
 /*global angular */
-'use strict';
+(function () {
+	'use strict';
 
-angular.module('todoCtrl', [])
+	angular.module('todoCtrl', [])
 
-/**
- * The main controller for the app. The controller:
- * - retrieves and persists the model via the todoStorage service
- * - exposes the model to the template and provides event handlers
- */
-.controller('TodoCtrl', function TodoCtrl($scope, $location, $filter, todoStorage) {
-	var todos = $scope.todos = todoStorage.get();
-
-	$scope.newTodo = '';
-	$scope.remainingCount = $filter('filter')(todos, {completed: false}).length;
-	$scope.editedTodo = null;
-
-	if ($location.path() === '') {
-		$location.path('/');
-	}
-
-	$scope.location = $location;
-
-	$scope.$watch('location.path()', function (path) {
-		$scope.statusFilter = { '/active': {completed: false}, '/completed': {completed: true} }[path];
-	});
-
-	$scope.$watch('remainingCount == 0', function (val) {
-		$scope.allChecked = val;
-	});
-
-	$scope.addTodo = function () {
-		var newTodo = $scope.newTodo.trim();
-		if (newTodo.length === 0) {
-			return;
-		}
-
-		todos.push({
-			title: newTodo,
-			completed: false
-		});
-		todoStorage.put(todos);
+	/**
+	 * The main controller for the app. The controller:
+	 * - retrieves and persists the model via the todoStorage service
+	 * - exposes the model to the template and provides event handlers
+	 */
+	.controller('TodoCtrl', function TodoCtrl($scope, $location, $filter, todoStorage) {
+		var todos = $scope.todos = todoStorage.get();
 
 		$scope.newTodo = '';
-		$scope.remainingCount++;
-	};
-
-	$scope.editTodo = function (todo) {
-		$scope.editedTodo = todo;
-		// Clone the original todo to restore it on demand.
-		$scope.originalTodo = angular.extend({}, todo);
-	};
-
-	$scope.doneEditing = function (todo) {
+		$scope.remainingCount = $filter('filter')(todos, {completed: false}).length;
 		$scope.editedTodo = null;
-		todo.title = todo.title.trim();
 
-		if (!todo.title) {
-			$scope.removeTodo(todo);
+		if ($location.path() === '') {
+			$location.path('/');
 		}
 
-		todoStorage.put(todos);
-	};
+		$scope.location = $location;
 
-	$scope.revertEditing = function (todo) {
-		todos[todos.indexOf(todo)] = $scope.originalTodo;
-		$scope.doneEditing($scope.originalTodo);
-	};
-
-	$scope.removeTodo = function (todo) {
-		$scope.remainingCount -= todo.completed ? 0 : 1;
-		todos.splice(todos.indexOf(todo), 1);
-		todoStorage.put(todos);
-	};
-
-	$scope.todoCompleted = function (todo) {
-		$scope.remainingCount += todo.completed ? -1 : 1;
-		todoStorage.put(todos);
-	};
-
-	$scope.clearCompletedTodos = function () {
-		$scope.todos = todos = todos.filter(function (val) {
-			return !val.completed;
+		$scope.$watch('location.path()', function (path) {
+			$scope.statusFilter = { '/active': {completed: false}, '/completed': {completed: true} }[path];
 		});
-		todoStorage.put(todos);
-	};
 
-	$scope.markAll = function (completed) {
-		todos.forEach(function (todo) {
-			todo.completed = completed;
+		$scope.$watch('remainingCount == 0', function (val) {
+			$scope.allChecked = val;
 		});
-		$scope.remainingCount = completed ? 0 : todos.length;
-		todoStorage.put(todos);
-	};
-});
+
+		$scope.addTodo = function () {
+			var newTodo = $scope.newTodo.trim();
+			if (newTodo.length === 0) {
+				return;
+			}
+
+			todos.push({
+				title: newTodo,
+				completed: false
+			});
+			todoStorage.put(todos);
+
+			$scope.newTodo = '';
+			$scope.remainingCount++;
+		};
+
+		$scope.editTodo = function (todo) {
+			$scope.editedTodo = todo;
+			// Clone the original todo to restore it on demand.
+			$scope.originalTodo = angular.extend({}, todo);
+		};
+
+		$scope.doneEditing = function (todo) {
+			$scope.editedTodo = null;
+			todo.title = todo.title.trim();
+
+			if (!todo.title) {
+				$scope.removeTodo(todo);
+			}
+
+			todoStorage.put(todos);
+		};
+
+		$scope.revertEditing = function (todo) {
+			todos[todos.indexOf(todo)] = $scope.originalTodo;
+			$scope.doneEditing($scope.originalTodo);
+		};
+
+		$scope.removeTodo = function (todo) {
+			$scope.remainingCount -= todo.completed ? 0 : 1;
+			todos.splice(todos.indexOf(todo), 1);
+			todoStorage.put(todos);
+		};
+
+		$scope.todoCompleted = function (todo) {
+			$scope.remainingCount += todo.completed ? -1 : 1;
+			todoStorage.put(todos);
+		};
+
+		$scope.clearCompletedTodos = function () {
+			$scope.todos = todos = todos.filter(function (val) {
+				return !val.completed;
+			});
+			todoStorage.put(todos);
+		};
+
+		$scope.markAll = function (completed) {
+			todos.forEach(function (todo) {
+				todo.completed = completed;
+			});
+			$scope.remainingCount = completed ? 0 : todos.length;
+			todoStorage.put(todos);
+		};
+	});
+})();

--- a/examples/angularjs-perf/js/controllers/todoCtrl.js
+++ b/examples/angularjs-perf/js/controllers/todoCtrl.js
@@ -1,12 +1,14 @@
 /*global todomvc, angular */
 'use strict';
 
+angular.module('todoCtrl', [])
+
 /**
  * The main controller for the app. The controller:
  * - retrieves and persists the model via the todoStorage service
  * - exposes the model to the template and provides event handlers
  */
-todomvc.controller('TodoCtrl', function TodoCtrl($scope, $location, $filter, todoStorage) {
+.controller('TodoCtrl', function TodoCtrl($scope, $location, $filter, todoStorage) {
 	var todos = $scope.todos = todoStorage.get();
 
 	$scope.newTodo = '';

--- a/examples/angularjs-perf/js/controllers/todoCtrl.js
+++ b/examples/angularjs-perf/js/controllers/todoCtrl.js
@@ -10,28 +10,29 @@
 	 * - exposes the model to the template and provides event handlers
 	 */
 	.controller('TodoCtrl', function TodoCtrl($scope, $location, $filter, todoStorage) {
-		var todos = $scope.todos = todoStorage.get();
+		var TC = this;
+		var todos = TC.todos = todoStorage.get();
 
-		$scope.newTodo = '';
-		$scope.remainingCount = $filter('filter')(todos, {completed: false}).length;
-		$scope.editedTodo = null;
+		TC.newTodo = '';
+		TC.remainingCount = $filter('filter')(todos, {completed: false}).length;
+		TC.editedTodo = null;
 
 		if ($location.path() === '') {
 			$location.path('/');
 		}
 
-		$scope.location = $location;
+		TC.location = $location;
 
-		$scope.$watch('location.path()', function (path) {
-			$scope.statusFilter = { '/active': {completed: false}, '/completed': {completed: true} }[path];
+		$scope.$watch('TC.location.path()', function (path) {
+			TC.statusFilter = { '/active': {completed: false}, '/completed': {completed: true} }[path];
 		});
 
-		$scope.$watch('remainingCount == 0', function (val) {
-			$scope.allChecked = val;
+		$scope.$watch('TC.remainingCount == 0', function (val) {
+			TC.allChecked = val;
 		});
 
-		$scope.addTodo = function () {
-			var newTodo = $scope.newTodo.trim();
+		TC.addTodo = function () {
+			var newTodo = TC.newTodo.trim();
 			if (newTodo.length === 0) {
 				return;
 			}
@@ -42,55 +43,56 @@
 			});
 			todoStorage.put(todos);
 
-			$scope.newTodo = '';
-			$scope.remainingCount++;
+			TC.newTodo = '';
+			TC.remainingCount++;
 		};
 
-		$scope.editTodo = function (todo) {
-			$scope.editedTodo = todo;
+		TC.editTodo = function (todo) {
+			TC.editedTodo = todo;
+			
 			// Clone the original todo to restore it on demand.
-			$scope.originalTodo = angular.extend({}, todo);
+			TC.originalTodo = angular.extend({}, todo);
 		};
 
-		$scope.doneEditing = function (todo) {
-			$scope.editedTodo = null;
+		TC.doneEditing = function (todo) {
+			TC.editedTodo = null;
 			todo.title = todo.title.trim();
 
 			if (!todo.title) {
-				$scope.removeTodo(todo);
+				TC.removeTodo(todo);
 			}
 
 			todoStorage.put(todos);
 		};
 
-		$scope.revertEditing = function (todo) {
-			todos[todos.indexOf(todo)] = $scope.originalTodo;
-			$scope.doneEditing($scope.originalTodo);
+		TC.revertEditing = function (todo) {
+			todos[todos.indexOf(todo)] = TC.originalTodo;
+			TC.doneEditing(TC.originalTodo);
 		};
 
-		$scope.removeTodo = function (todo) {
-			$scope.remainingCount -= todo.completed ? 0 : 1;
+		TC.removeTodo = function (todo) {
+			TC.remainingCount -= todo.completed ? 0 : 1;
 			todos.splice(todos.indexOf(todo), 1);
 			todoStorage.put(todos);
 		};
 
-		$scope.todoCompleted = function (todo) {
-			$scope.remainingCount += todo.completed ? -1 : 1;
+		TC.todoCompleted = function (todo) {
+			TC.remainingCount += todo.completed ? -1 : 1;
 			todoStorage.put(todos);
 		};
 
-		$scope.clearCompletedTodos = function () {
-			$scope.todos = todos = todos.filter(function (val) {
+		TC.clearCompletedTodos = function () {
+			TC.todos = todos = todos.filter(function (val) {
 				return !val.completed;
 			});
 			todoStorage.put(todos);
 		};
 
-		$scope.markAll = function (completed) {
+		TC.markAll = function (completed) {
 			todos.forEach(function (todo) {
 				todo.completed = completed;
 			});
-			$scope.remainingCount = completed ? 0 : todos.length;
+			TC.remainingCount = completed ? 0 : todos.length;
 			todoStorage.put(todos);
 		};
 	});

--- a/examples/angularjs-perf/js/directives/todoEscape.js
+++ b/examples/angularjs-perf/js/directives/todoEscape.js
@@ -1,11 +1,13 @@
 /*global todomvc */
 'use strict';
 
+angular.module('todoEscape', [])
+
 /**
  * Directive that executes an expression when the element it is applied to gets
  * an `escape` keydown event.
  */
-todomvc.directive('todoEscape', function () {
+.directive('todoEscape', function () {
 	var ESCAPE_KEY = 27;
 	return function (scope, elem, attrs) {
 		elem.bind('keydown', function (event) {

--- a/examples/angularjs-perf/js/directives/todoEscape.js
+++ b/examples/angularjs-perf/js/directives/todoEscape.js
@@ -1,4 +1,4 @@
-/*global todomvc */
+/*global angular */
 'use strict';
 
 angular.module('todoEscape', [])

--- a/examples/angularjs-perf/js/directives/todoEscape.js
+++ b/examples/angularjs-perf/js/directives/todoEscape.js
@@ -1,23 +1,25 @@
 /*global angular */
-'use strict';
+(function () {
+	'use strict';
 
-angular.module('todoEscape', [])
+	angular.module('todoEscape', [])
 
-/**
- * Directive that executes an expression when the element it is applied to gets
- * an `escape` keydown event.
- */
-.directive('todoEscape', function () {
-	var ESCAPE_KEY = 27;
-	return function (scope, elem, attrs) {
-		elem.bind('keydown', function (event) {
-			if (event.keyCode === ESCAPE_KEY) {
-				scope.$apply(attrs.todoEscape);
-			}
-		});
+	/**
+	 * Directive that executes an expression when the element it is applied to gets
+	 * an `escape` keydown event.
+	 */
+	.directive('todoEscape', function () {
+		var ESCAPE_KEY = 27;
+		return function (scope, elem, attrs) {
+			elem.bind('keydown', function (event) {
+				if (event.keyCode === ESCAPE_KEY) {
+					scope.$apply(attrs.todoEscape);
+				}
+			});
 
-		scope.$on('$destroy', function () {
-			elem.unbind('keydown');
-		});
-	};
-});
+			scope.$on('$destroy', function () {
+				elem.unbind('keydown');
+			});
+		};
+	});
+})();

--- a/examples/angularjs-perf/js/directives/todoFocus.js
+++ b/examples/angularjs-perf/js/directives/todoFocus.js
@@ -1,19 +1,21 @@
 /*global angular */
-'use strict';
+(function () {
+	'use strict';
 
-angular.module('todoFocus', [])
+	angular.module('todoFocus', [])
 
-/**
- * Directive that places focus on the element it is applied to when the expression it binds to evaluates to true
- */
-.directive('todoFocus', function ($timeout) {
-	return function (scope, elem, attrs) {
-		scope.$watch(attrs.todoFocus, function (newVal) {
-			if (newVal) {
-				$timeout(function () {
-					elem[0].focus();
-				}, 0, false);
-			}
-		});
-	};
-});
+	/**
+	 * Directive that places focus on the element it is applied to when the expression it binds to evaluates to true
+	 */
+	.directive('todoFocus', function ($timeout) {
+		return function (scope, elem, attrs) {
+			scope.$watch(attrs.todoFocus, function (newVal) {
+				if (newVal) {
+					$timeout(function () {
+						elem[0].focus();
+					}, 0, false);
+				}
+			});
+		};
+	});
+})();

--- a/examples/angularjs-perf/js/directives/todoFocus.js
+++ b/examples/angularjs-perf/js/directives/todoFocus.js
@@ -1,10 +1,12 @@
 /*global todomvc */
 'use strict';
 
+angular.module('todoFocus', [])
+
 /**
  * Directive that places focus on the element it is applied to when the expression it binds to evaluates to true
  */
-todomvc.directive('todoFocus', function ($timeout) {
+.directive('todoFocus', function ($timeout) {
 	return function (scope, elem, attrs) {
 		scope.$watch(attrs.todoFocus, function (newVal) {
 			if (newVal) {

--- a/examples/angularjs-perf/js/directives/todoFocus.js
+++ b/examples/angularjs-perf/js/directives/todoFocus.js
@@ -1,4 +1,4 @@
-/*global todomvc */
+/*global angular */
 'use strict';
 
 angular.module('todoFocus', [])

--- a/examples/angularjs-perf/js/services/todoStorage.js
+++ b/examples/angularjs-perf/js/services/todoStorage.js
@@ -1,4 +1,4 @@
-/*global todomvc */
+/*global angular */
 'use strict';
 
 angular.module('todoStorage', [])

--- a/examples/angularjs-perf/js/services/todoStorage.js
+++ b/examples/angularjs-perf/js/services/todoStorage.js
@@ -1,21 +1,23 @@
 /*global angular */
-'use strict';
+(function () {
+	'use strict';
 
-angular.module('todoStorage', [])
+	angular.module('todoStorage', [])
 
-/**
- * Services that persists and retrieves TODOs from localStorage
-*/
-.factory('todoStorage', function () {
-	var STORAGE_ID = 'todos-angularjs-perf';
+	/**
+	 * Services that persists and retrieves TODOs from localStorage
+	*/
+	.factory('todoStorage', function () {
+		var STORAGE_ID = 'todos-angularjs-perf';
 
-	return {
-		get: function () {
-			return JSON.parse(localStorage.getItem(STORAGE_ID) || '[]');
-		},
+		return {
+			get: function () {
+				return JSON.parse(localStorage.getItem(STORAGE_ID) || '[]');
+			},
 
-		put: function (todos) {
-			localStorage.setItem(STORAGE_ID, JSON.stringify(todos));
-		}
-	};
-});
+			put: function (todos) {
+				localStorage.setItem(STORAGE_ID, JSON.stringify(todos));
+			}
+		};
+	});
+})();

--- a/examples/angularjs-perf/js/services/todoStorage.js
+++ b/examples/angularjs-perf/js/services/todoStorage.js
@@ -1,10 +1,12 @@
 /*global todomvc */
 'use strict';
 
+angular.module('todoStorage', [])
+
 /**
  * Services that persists and retrieves TODOs from localStorage
 */
-todomvc.factory('todoStorage', function () {
+.factory('todoStorage', function () {
 	var STORAGE_ID = 'todos-angularjs-perf';
 
 	return {


### PR DESCRIPTION
- Removed the global `todomvc` as it promotes a bad practice. Used modular approach instead. All modules are now visible in `app.js` and named as their files, following the principle of least surprise.

- Enclosed in anonymous functions as recommended in https://github.com/tastejs/todomvc/blob/master/codestyle.md

- Replaced the "$scope soup" by the recommended "Controller as" syntax. Improves readability of the template by  making clear distinction between controller-defined properties/methods and the rest, among other benefits. All properties/methods are now named exactly the same in both template and controller.

- Simplified functions and watchers. No more need to use `$filter` in controller, eliminated unnecessarily complexity.

- More consistent naming. `newTodo` is made a todo, rather than a todo title.