### PR TITLE
firebase-angular: Correct directive name -- `todoEscape`

### DIFF
--- a/examples/firebase-angular/js/directives/todoEscape.js
+++ b/examples/firebase-angular/js/directives/todoEscape.js
@@ -5,7 +5,7 @@
  * Directive that executes an expression when the element it is applied to gets
  * an `escape` keydown event.
  */
-todomvc.directive('todoBlur', function () {
+todomvc.directive('todoEscape', function () {
 	var ESCAPE_KEY = 27;
 	return function (scope, elem, attrs) {
 		elem.bind('keydown', function (event) {


### PR DESCRIPTION
Was called `todoBlur`. 
Making it the 2nd `todoBlur` with none `todoEscape`.

Miraculously worked by getting both listeners on the same element via the `todoBlur` directive, 
and "stealing" the `todo-escape` attribute.
Don't think the "miracle" would happen if both directives were used on different elements.
(Sadly miracles are rare :)