### PR TITLE
Fix bug: Show all items when "All" tab is active

### DIFF
--- a/examples/typescript-angular/js/Application.js
+++ b/examples/typescript-angular/js/Application.js
@@ -129,7 +129,7 @@ var todos;
         TodoCtrl.prototype.onPath = function (path) {
             this.$scope.statusFilter = (path === '/active') ?
                 { completed: false } : (path === '/completed') ?
-                { completed: true } : null;
+                { completed: true } : {};
         };
         TodoCtrl.prototype.onTodos = function () {
             this.$scope.remainingCount = this.filterFilter(this.todos, { completed: false }).length;

--- a/examples/typescript-angular/js/controllers/TodoCtrl.ts
+++ b/examples/typescript-angular/js/controllers/TodoCtrl.ts
@@ -50,9 +50,9 @@ module todos {
 		}
 
 		onPath(path: string) {
-			this.$scope.statusFilter = (path === '/active') ?
-				{ completed: false } : (path === '/completed') ?
-				{ completed: true } : null;
+            this.$scope.statusFilter = (path === '/active') ?
+                { completed: false } : (path === '/completed') ?
+                    { completed: true } : {};
 		}
 
 		onTodos() {

--- a/examples/typescript-angular/js/controllers/TodoCtrl.ts
+++ b/examples/typescript-angular/js/controllers/TodoCtrl.ts
@@ -50,9 +50,9 @@ module todos {
 		}
 
 		onPath(path: string) {
-            this.$scope.statusFilter = (path === '/active') ?
-                { completed: false } : (path === '/completed') ?
-                    { completed: true } : {};
+			this.$scope.statusFilter = (path === '/active') ?
+				{ completed: false } : (path === '/completed') ?
+				{ completed: true } : {};
 		}
 
 		onTodos() {

--- a/examples/typescript-angular/js/interfaces/ITodoScope.ts
+++ b/examples/typescript-angular/js/interfaces/ITodoScope.ts
@@ -10,7 +10,7 @@ module todos {
 		doneCount: number;
 		allChecked: boolean;
 		reverted: boolean;
-                statusFilter: { completed?: boolean };
+               statusFilter: { completed?: boolean };
 		location: ng.ILocationService;
 		vm: TodoCtrl;
 	}

--- a/examples/typescript-angular/js/interfaces/ITodoScope.ts
+++ b/examples/typescript-angular/js/interfaces/ITodoScope.ts
@@ -10,7 +10,7 @@ module todos {
 		doneCount: number;
 		allChecked: boolean;
 		reverted: boolean;
-               statusFilter: { completed?: boolean };
+		statusFilter: { completed?: boolean };
 		location: ng.ILocationService;
 		vm: TodoCtrl;
 	}

--- a/examples/typescript-angular/js/interfaces/ITodoScope.ts
+++ b/examples/typescript-angular/js/interfaces/ITodoScope.ts
@@ -10,7 +10,7 @@ module todos {
 		doneCount: number;
 		allChecked: boolean;
 		reverted: boolean;
-		statusFilter: any;
+        statusFilter: { completed?: boolean };
 		location: ng.ILocationService;
 		vm: TodoCtrl;
 	}

--- a/examples/typescript-angular/js/interfaces/ITodoScope.ts
+++ b/examples/typescript-angular/js/interfaces/ITodoScope.ts
@@ -10,7 +10,7 @@ module todos {
 		doneCount: number;
 		allChecked: boolean;
 		reverted: boolean;
-        statusFilter: { completed?: boolean };
+                statusFilter: { completed?: boolean };
 		location: ng.ILocationService;
 		vm: TodoCtrl;
 	}

--- a/examples/typescript-angular/js/interfaces/ITodoScope.ts
+++ b/examples/typescript-angular/js/interfaces/ITodoScope.ts
@@ -10,7 +10,7 @@ module todos {
 		doneCount: number;
 		allChecked: boolean;
 		reverted: boolean;
-		statusFilter: { completed: boolean; };
+		statusFilter: any;
 		location: ng.ILocationService;
 		vm: TodoCtrl;
 	}


### PR DESCRIPTION
Small change to show all items when the "All" tab is active.

This way the behavior is the same as in the AngularJS version of the todos app.