### PR TITLE
Do not exclude es6 example from lint

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -39,7 +39,6 @@
 		"examples/thorax_lumbar/public/*.js",
 		"examples/typescript-*/js/**/*.js",
 		"examples/vanilladart/**/*.js",
-		"examples/vanilla-es6/**/*.js"
 	],
 	"requireSpaceBeforeBlockStatements": true,
 	"requireParenthesesAroundIIFE": true,


### PR DESCRIPTION
since 
https://github.com/tastejs/todomvc/pull/1567

We can now handle es6 :)