### PR TITLE
Updating the Marionette, Chaplin Comparision Link

### DIFF
--- a/examples/chaplin-brunch/readme.md
+++ b/examples/chaplin-brunch/readme.md
@@ -24,7 +24,7 @@ Here are some links you may find helpful:
 
 Articles and guides from the community:
 
-* [JavaScript MVC frameworks: A Comparison of Marionette and Chaplin](http://9elements.com/io/index.php/comparison-of-marionette-and-chaplin)
+* [JavaScript MVC frameworks: A Comparison of Marionette and Chaplin](http://9elements.com/io/index.php/comparison-of-marionette-and-chaplin/)
 
 Get help from other Chaplin users:
 


### PR DESCRIPTION
For some reason when there was no leading slash towards the end of the url, the page was not being loaded in chrome.