### PR TITLE
Fix TypeError: webdriver.WebDriver.Logs is not a function (#1605)

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -7,7 +7,7 @@
     "mocha": "*",
     "mocha-known-issues-reporter": "git+https://github.com/ColinEberhardt/mocha-known-issues-reporter.git#v0.0.0",
     "optimist": "^0.6.1",
-    "selenium-webdriver": "^2.46.1",
+    "selenium-webdriver": "~2.46.1",
     "drool": "0.2.2"
   },
   "scripts": {


### PR DESCRIPTION
```bash
$ npm run test -- --framework=backbone --grep 'should trim entered text'

> todomvc-browser-tests@ test /repos/todomvc/tests
> mocha allTests.js --no-timeouts --reporter spec "--framework=backbone" "--grep" "should trim entered text"



  TodoMVC - backbone
    Editing
      ✓ should trim entered text (528ms)
      1) "after each" hook for "should trim entered text"


  1 passing (5s)
  1 failing

  1) TodoMVC - backbone "after each" hook for "should trim entered text":
     TypeError: webdriver.WebDriver.Logs is not a function
      at printCapturedLogs (test.js:56:15)
      at Context.<anonymous> (test.js:99:5)
      at node_modules/selenium-webdriver/testing/index.js:134:11
      at new ManagedPromise (node_modules/selenium-webdriver/lib/promise.js:1048:7)
      at controlFlowExecute (node_modules/selenium-webdriver/testing/index.js:129:14)
      at TaskQueue.execute_ (node_modules/selenium-webdriver/lib/promise.js:2868:14)
      at TaskQueue.executeNext_ (node_modules/selenium-webdriver/lib/promise.js:2851:21)
      at node_modules/selenium-webdriver/lib/promise.js:2775:25
      at node_modules/selenium-webdriver/lib/promise.js:639:7
  From: Task: TodoMVC - backbone "after each" hook
      at Context.ret (node_modules/selenium-webdriver/testing/index.js:128:10)
```


Webdriver logs in actual version of selenium [should never be instantiated directly](https://github.com/SeleniumHQ/selenium/blob/fa5ac92b451cff497e686d8e1e67c9c3101440a3/javascript/node/selenium-webdriver/lib/webdriver.js#L1429-L1432).

But drool [still uses selenium 2.46.1](https://github.com/samccone/drool/commit/3770a157d218e6ea27ef9fd2e78f58105375fca0), so the fast fix is the old version of selenium.

Fixes #1605.