### PR TITLE
Typo in app.tsx importing TodoModel from ./TodoModel.

### DIFF
--- a/examples/typescript-react/js/app.tsx
+++ b/examples/typescript-react/js/app.tsx
@@ -9,7 +9,7 @@
 
 declare var Router;
 
-import { TodoModel } from "./TodoModel";
+import { TodoModel } from "./todoModel";
 import { TodoFooter } from "./footer";
 import { TodoItem } from "./todoItem";
 import { ALL_TODOS, ACTIVE_TODOS, COMPLETED_TODOS, ENTER_KEY } from "./constants";


### PR DESCRIPTION
Compiling as downloaded (with `tsc -p js/`) yields the following error:
```
js/app.tsx(12,27): error TS2307: Cannot find module './TodoModel'.
```