### PR TITLE
Exit right away on error.

### DIFF
--- a/test-runner.sh
+++ b/test-runner.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -o pipefail
-
+set -e
 
 get_changes ()
 {


### PR DESCRIPTION
This will prevent invalid deploys when we encounter errors instead of a
partial complete deploy.

ref #1635