### PR TITLE
Improve test suite robustness.

### DIFF
--- a/tests/page.js
+++ b/tests/page.js
@@ -1,333 +1,264 @@
 'use strict';
 
 var webdriver = require('selenium-webdriver');
+var until = require('selenium-webdriver/lib/until');
+
 var idSelectors = true;
+var classOrId = idSelectors ? '#' : '.';
+
+var DEFAULT_TIMEOUT = 3000;
+var REMOVED_TIMEOUT = 100;
+
+var REMOVE_TEXT_KEY_SEQ = Array(51).join(webdriver.Key.BACK_SPACE + webdriver.Key.DELETE);
+
+// Unique symbols
+var ELEMENT_MISSING = Object.freeze({});
+var ITEM_HIDDEN_OR_REMOVED = Object.freeze({});
 
 module.exports = function Page(browser) {
 
-	// ----------------- utility methods
+	// CSS ELEMENT SELECTORS
 
-	this.tryFindByXpath = function (xpath) {
-		return browser.findElements(webdriver.By.xpath(xpath));
+	this.getMainSectionCss = function () { return classOrId + 'main'; };
+
+	this.getFooterSectionCss = function () { return 'footer' + classOrId + 'footer'; };
+
+	this.getClearCompletedButtonCss = function () { return 'button' + classOrId + 'clear-completed'; };
+
+	this.getNewInputCss = function () { return 'input' + classOrId + 'new-todo'; };
+
+	this.getToggleAllCss = function () { return 'input' + classOrId + 'toggle-all'; };
+
+	this.getItemCountCss = function () { return 'span' + classOrId + 'todo-count'; };
+
+	this.getFilterCss = function (index) { return classOrId + 'filters li:nth-of-type(' + (index + 1) + ') a'; };
+
+	this.getSelectedFilterCss = function (index) { return this.getFilterCss(index) + '.selected'; };
+
+	this.getFilterAllCss = function () { return this.getFilterCss(0); };
+
+	this.getFilterActiveCss = function () { return this.getFilterCss(1); };
+
+	this.getFilterCompletedCss = function () { return this.getFilterCss(2); };
+
+	this.getListCss = function (suffixCss) { return 'ul' + classOrId + 'todo-list' + (suffixCss || ''); };
+
+	this.getListItemCss = function (index, suffixCss, excludeParentSelector) {
+		suffixCss = (index === undefined ? '' : ':nth-of-type(' + (index + 1) + ')') + (suffixCss || '');
+		return excludeParentSelector ? 'li' + suffixCss : this.getListCss(' li' + suffixCss);
 	};
 
-	this.findByXpath = function (xpath) {
-		return browser.findElement(webdriver.By.xpath(xpath));
+	this.getListItemToggleCss = function (index) { return this.getListItemCss(index, ' input.toggle'); };
+
+	this.getListItemLabelCss = function (index) { return this.getListItemCss(index, ' label'); };
+
+	this.getLastListItemLabelCss = function (index) { return this.getListItemCss(index, ':last-of-type label'); };
+
+	this.getListItemInputCss = function (index) { return this.getListItemCss(index, ' input.edit'); };
+
+	this.getEditingListItemInputCss = function () { return this.getListItemCss(undefined, '.editing input.edit'); };
+
+	// This CSS selector returns the _last_ element of a list that exactly matches the provided list of completed states
+	// It is used as a boolean test of the item states
+	this.getListItemsWithCompletedStatesCss = function (completedStates) {
+		var suffixCss = ' ' + completedStates.map(function (completed, i) {
+			return this.getListItemCss(i, completed ? '.completed' : ':not(.completed)', true);
+		}, this).join(' + ');
+		return this.getListCss(suffixCss);
 	};
 
-	this.getTodoListXpath = function () {
-		return idSelectors ? '//ul[@id="todo-list"]' : '//ul[contains(@class, "todo-list")]';
-	};
+	// PUBLIC SYMBOLS
 
-	this.getMainSectionXpath = function () {
-		return idSelectors ? '//section[@id="main"]' : '//section[contains(@class, "main")]';
-	};
+	this.ITEM_HIDDEN_OR_REMOVED = ITEM_HIDDEN_OR_REMOVED;
 
-	this.getFooterSectionXpath = function () {
-		return idSelectors ? '//footer[@id="footer"]' : '//footer[contains(@class, "footer")]';
-	};
-
-	this.getCompletedButtonXpath = function () {
-		return idSelectors ? '//button[@id="clear-completed"]' : '//button[contains(@class, "clear-completed")]';
-	};
-
-	this.getNewInputXpath = function () {
-		return idSelectors ? '//input[@id="new-todo"]' : '//input[contains(@class,"new-todo")]';
-	};
-
-	this.getToggleAllXpath = function () {
-		return idSelectors ? '//input[@id="toggle-all"]' : '//input[contains(@class,"toggle-all")]';
-	};
-
-	this.getCountXpath = function () {
-		return idSelectors ? '//span[@id="todo-count"]' : '//span[contains(@class, "todo-count")]';
-	};
-
-	this.getFiltersElementXpath = function () {
-		return idSelectors ? '//*[@id="filters"]' : '//*[contains(@class, "filters")]';
-	};
-
-	this.getFilterXpathByIndex = function (index) {
-		return this.getFiltersElementXpath() + '/li[' + index + ']/a';
-	};
-
-	this.getSelectedFilterXPathByIndex = function (index) {
-		return this.getFilterXpathByIndex(index) + '[contains(@class, "selected")]';
-	};
-
-	this.getFilterAllXpath = function () {
-		return this.getFilterXpathByIndex(1);
-	};
-
-	this.getFilterActiveXpath = function () {
-		return this.getFilterXpathByIndex(2);
-	};
-
-	this.getFilterCompletedXpath = function () {
-		return this.getFilterXpathByIndex(3);
-	};
-
-	this.xPathForItemAtIndex = function (index) {
-		// why is XPath the only language silly enough to be 1-indexed?
-		return this.getTodoListXpath() + '/li[' + (index + 1) + ']';
-	};
-
-	// ----------------- navigation methods
+	// NAVIGATION
 
 	this.back = function () {
 		return browser.navigate().back();
 	};
 
-	// ----------------- try / get methods
+	// ELEMENT RETREIVAL
+	// wait* methods guarantees to return an element, or throw an exception
+	// get* methods may return nothing at all, or in the case of element lists, an older version of the list
 
-	// unfortunately webdriver does not have a decent API for determining if an
-	// element exists. The standard approach is to obtain an array of elements
-	// and test that the length is zero. These methods are used to obtain
-	// elements which *might* be present in the DOM, hence the try/get name.
-
-	this.tryGetMainSectionElement = function () {
-		return this.tryFindByXpath(this.getMainSectionXpath());
+	this.getElements = function (css) {
+		return browser.findElements(webdriver.By.css(css));
 	};
 
-	this.tryGetFooterElement = function () {
-		return this.tryFindByXpath(this.getFooterSectionXpath());
+	this.waitForElement = function (css, failMsg, timeout) {
+		return browser.wait(until.elementLocated(webdriver.By.css(css)), timeout || DEFAULT_TIMEOUT, failMsg);
 	};
 
-	this.tryGetClearCompleteButton = function () {
-		return this.findByXpath(this.getCompletedButtonXpath());
+	this.waitForFocusedElement = function (css, failMsg) {
+		return this.waitForElement(css + ':focus', failMsg);
 	};
 
-	this.tryGetToggleForItemAtIndex = function (index) {
-		var xpath = this.xPathForItemAtIndex(index) + '//input[contains(@class,"toggle")]';
-		return this.findByXpath(xpath);
+	this.waitForBlurredElement = function (css, failMsg) {
+		return this.waitForElement(css + ':not(:focus)', failMsg);
 	};
 
-	this.tryGetItemLabelAtIndex = function (index) {
-		return this.findByXpath(this.xPathForItemAtIndex(index) + '//label');
-	};
-
-	// ----------------- DOM element access methods
-	this.getActiveElement = function () {
-		return browser.switchTo().activeElement();
-	};
-
-	this.getFocussedTagName = function () {
-		return this.getActiveElement().getTagName();
-	};
-
-	this.getFocussedElementIdOrClass = function () {
-		return this.getActiveElement()
-			.getAttribute(idSelectors ? 'id' : 'class');
-	};
-
-	this.getEditInputForItemAtIndex = function (index) {
-		var xpath = this.xPathForItemAtIndex(index) + '//input[contains(@class,"edit")]';
-		return this.findByXpath(xpath);
-	};
-
-	this.getItemInputField = function () {
-		return this.findByXpath(this.getNewInputXpath());
-	};
-
-	this.getMarkAllCompletedCheckBox = function () {
-		return this.findByXpath(this.getToggleAllXpath());
-	};
-
-	this.getItemElements = function () {
-		return this.tryFindByXpath(this.getTodoListXpath() + '/li');
-	};
-
-	this.getNonCompletedItemElements = function () {
-		return this.tryFindByXpath(this.getTodoListXpath() + '/li[not(contains(@class,"completed"))]');
-	};
-
-	this.getItemsCountElement = function () {
-		return this.findByXpath(this.getCountXpath());
-	};
-
-	this.getItemLabelAtIndex = function (index) {
-		return this.findByXpath(this.xPathForItemAtIndex(index) + '//label');
-	};
-
-	this.getItemLabels = function () {
-		var xpath = this.getTodoListXpath() + '/li//label';
-		return this.tryFindByXpath(xpath);
-	};
-
-	this.getVisibleLabelText = function () {
-		var self = this;
-		return this.getVisibileLabelIndicies()
-		.then(function (indicies) {
-			return webdriver.promise.map(indicies, function (elmIndex) {
-				var ret;
-				return browser.wait(function () {
-					return self.tryGetItemLabelAtIndex(elmIndex).getText()
-					.then(function (v) {
-						ret = v;
-						return true;
-					})
-					.thenCatch(function () { return false; });
-				}, 5000)
-				.then(function () {
-					return ret;
-				});
-			});
-		});
-	};
-
-	this.waitForVisibleElement = function (getElementFn, timeout) {
-		var foundVisibleElement;
-		timeout = timeout || 500;
-
-		return browser.wait(function () {
-			foundVisibleElement = getElementFn();
-			return foundVisibleElement.isDisplayed();
-		}, timeout)
-		.then(function () {
-			return foundVisibleElement;
-		})
-		.thenCatch(function (err) {
-			return false;
-		});
-	}
-
-	this.getVisibileLabelIndicies = function () {
-		var self = this;
-		return this.getItemLabels()
-		.then(function (elms) {
-			return elms.map(function (elm, i) {
-				return i;
-			});
-		})
-		.then(function (elms) {
-			return webdriver.promise.filter(elms, function (elmIndex) {
-				return self.waitForVisibleElement(function () {
-					return self.tryGetItemLabelAtIndex(elmIndex);
-				});
-			});
-		});
-	};
-
-	// ----------------- page actions
-	this.ensureAppIsVisible = function () {
+	this.waitForListItemCount = function (count) {
 		var self = this;
 		return browser.wait(function () {
-			// try to find main element by ID
-			return browser.isElementPresent(webdriver.By.css('.new-todo'))
-				.then(function (foundByClass) {
-					if (foundByClass) {
-						idSelectors = false;
-						return true;
-					}
-
-					// try to find main element by CSS class
-					return browser.isElementPresent(webdriver.By.css('#new-todo'));
+			return self.waitForElement(self.getListCss())
+				.then(function (listElement) {
+					return listElement.findElements(webdriver.By.css(self.getListItemCss(undefined, undefined, true)));
+				})
+				.then(function (listItems) {
+					return listItems.length === count;
 				});
-		}, 5000)
-		.then(function (hasFoundNewTodoElement) {
-			if (!hasFoundNewTodoElement) {
-				throw new Error('Unable to find application, did you start your local server?');
-			}
-		});
+		}, DEFAULT_TIMEOUT, 'Expected item list to contain ' + count + ' item' + (count === 1 ? '' : 's'));
+	};
+
+	this.waitForClearCompleteButton = function () {
+		return this.waitForElement(this.getClearCompletedButtonCss());
+	};
+
+	this.waitForToggleForItem = function (index) {
+		return this.waitForElement(this.getListItemToggleCss(index));
+	};
+
+	this.waitForItemLabel = function (index) {
+		return this.waitForElement(this.getListItemLabelCss(index));
+	};
+
+	this.waitForNewItemInputField = function () {
+		return this.waitForElement(this.getNewInputCss());
+	};
+
+	this.waitForMarkAllCompletedCheckBox = function () {
+		return this.waitForElement(this.getToggleAllCss());
+	};
+
+	this.getListItems = function () {
+		return this.getElements(this.getListItemCss());
+	};
+
+	this.waitForVisibility = function (shouldBeVisible, css, failMsg) {
+		if (shouldBeVisible) {
+			return this.waitForElement(css, failMsg)
+				.then(function (element) {
+					return browser.wait(until.elementIsVisible(element), DEFAULT_TIMEOUT, failMsg);
+				});
+		} else {
+			return this.waitForElement(css, undefined, REMOVED_TIMEOUT)
+				.catch(function () { return ELEMENT_MISSING; })
+				.then(function (elementOrError) {
+					return elementOrError === ELEMENT_MISSING ?
+							ELEMENT_MISSING : // Returning a value will resolve the promise
+							browser.wait(until.elementIsNotVisible(elementOrError), DEFAULT_TIMEOUT, failMsg);
+				});
+		}
+	};
+
+	this.waitForMainSectionRemovedOrEmpty = function () {
+		return this.waitForElement(this.getMainSectionCss(), undefined, REMOVED_TIMEOUT)
+			.catch(function () { return ELEMENT_MISSING; })
+			.then(function (elementOrError) {
+				return elementOrError === ELEMENT_MISSING ? ELEMENT_MISSING : this.waitForListItemCount(0);
+			}.bind(this));
+	};
+
+	this.waitForCheckedStatus = function (shouldBeChecked, failMsg, element) {
+		var condition = shouldBeChecked ? 'elementIsSelected' : 'elementIsNotSelected';
+		return browser.wait(until[condition](element), DEFAULT_TIMEOUT, failMsg);
+	};
+
+	this.waitForTextContent = function (text, failMsg, element) {
+		return browser.wait(until.elementTextIs(element, text), DEFAULT_TIMEOUT, failMsg);
+	};
+
+	// PAGE ACTIONS
+
+	this.ensureAppIsVisibleAndLoaded = function () {
+		return this.waitForVisibility(false, this.getFooterSectionCss(), 'Footer is not hidden') // Footer hidden -> app is active
+			.then(this.waitForElement.bind(this, '.new-todo, #new-todo', 'Could not find new todo input field', undefined))
+			.then(function (newTodoElement) {
+				return newTodoElement.getAttribute('id');
+			})
+			.then(function (newTodoElementId) {
+				if (newTodoElementId === 'new-todo') { return; }
+				idSelectors = false;
+				classOrId = idSelectors ? '#' : '.';
+			});
 	};
 
 	this.clickMarkAllCompletedCheckBox = function () {
-		return this.getMarkAllCompletedCheckBox().then(function (checkbox) {
-			return checkbox.click();
-		});
+		return this.waitForMarkAllCompletedCheckBox().click();
 	};
 
 	this.clickClearCompleteButton = function () {
-		var self = this;
-
-		return self.waitForVisibleElement(function () {
-			return self.tryGetClearCompleteButton();
-		})
-		.then(function (clearCompleteButton) {
-			return clearCompleteButton.click();
-		});
+		return this.waitForVisibility(true, this.getClearCompletedButtonCss(), 'Expected clear completed items button to be visible')
+			.then(function (clearCompleteButton) {
+				clearCompleteButton.click();
+			});
 	};
 
 	this.enterItem = function (itemText) {
 		var self = this;
-
-		return browser.wait(function () {
-			var textField;
-
-			return self.getItemInputField().then(function (itemInputField) {
-				textField = itemInputField;
-				return textField.sendKeys(itemText, webdriver.Key.ENTER);
+		var nItems;
+		return self.getListItems()
+			.then(function (items) {
+				nItems = items.length;
 			})
-			.then(function () { return self.getVisibleLabelText(); })
-			.then(function (labels) {
-				if (labels.indexOf(itemText.trim()) >= 0) {
-					return true;
-				}
-
-				return textField.clear().then(function () {
-					return false;
-				});
-			});
-		}, 5000);
+			.then(this.waitForNewItemInputField.bind(this))
+			.then(function (newItemInput) {
+				return newItemInput.sendKeys(itemText).then(function () { return newItemInput; });
+			})
+			.then(function (newItemInput) {
+				return browser.wait(function () {
+					// Hit Enter repeatedly until the text goes away
+					return newItemInput.sendKeys(webdriver.Key.ENTER)
+						.then(newItemInput.getAttribute.bind(newItemInput, 'value'))
+						.then(function (newItemInputValue) {
+							return newItemInputValue.length === 0;
+						});
+				}, DEFAULT_TIMEOUT);
+			})
+			.then(function () {
+				return self.waitForElement(self.getLastListItemLabelCss(nItems));
+			})
+			.then(this.waitForTextContent.bind(this, itemText.trim(), 'Expected new item label to read ' + itemText.trim()));
 	};
 
 	this.toggleItemAtIndex = function (index) {
-		return this.tryGetToggleForItemAtIndex(index).click();
+		return this.waitForToggleForItem(index).click();
 	};
 
 	this.editItemAtIndex = function (index, itemText) {
-		return this.getEditInputForItemAtIndex(index)
-		.then(function (itemEditField) {
-			// send 50 delete keypresses, just to be sure the item text is deleted
-			var deleteKeyPresses = '';
-			for (var i = 0; i < 50; i++) {
-				deleteKeyPresses += webdriver.Key.BACK_SPACE;
-				deleteKeyPresses += webdriver.Key.DELETE;
-			}
-
-			itemEditField.sendKeys(deleteKeyPresses);
-
-			// update the item with the new text.
-			itemEditField.sendKeys(itemText);
-		});
+		return this.waitForElement(this.getListItemInputCss(index))
+			.then(function (itemEditField) {
+				return itemEditField.sendKeys(REMOVE_TEXT_KEY_SEQ, itemText);
+			});
 	};
 
 	this.doubleClickItemAtIndex = function (index) {
-		return this.getItemLabelAtIndex(index).then(function (itemLabel) {
-			// double click is not 'natively' supported, so we need to send the
-			// event direct to the element see:
+		return this.waitForItemLabel(index).then(function (itemLabel) {
+			// double click is not 'natively' supported, so we need to send the event direct to the element, see:
 			// jscs:disable
 			// http://stackoverflow.com/questions/3982442/selenium-2-webdriver-how-to-double-click-a-table-row-which-opens-a-new-window
 			// jscs:enable
-			browser.executeScript('var evt = document.createEvent("MouseEvents");' +
+			return browser.executeScript('var evt = document.createEvent("MouseEvents");' +
 				'evt.initMouseEvent("dblclick",true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0,null);' +
 				'arguments[0].dispatchEvent(evt);', itemLabel);
 		});
 	};
 
-	this.filterBy = function (selectorFn) {
-		var self = this;
-
-		return browser.wait(function () {
-			return self.findByXpath(selectorFn()).click()
-			.then(function () {
-				return self.findByXpath(selectorFn()).getAttribute('class');
-			})
-			.then(function (klass) {
-				return klass.indexOf('selected') !== -1;
-			});
-		}, 5000);
+	this.filterBy = function (filterCss) {
+		return this.waitForElement(filterCss)
+			.click()
+			.then(this.waitForElement.bind(this, filterCss + '.selected', undefined, undefined));
 	};
 
 	this.filterByActiveItems = function () {
-		return this.filterBy(this.getFilterActiveXpath.bind(this));
+		return this.filterBy(this.getFilterActiveCss());
 	};
 
 	this.filterByCompletedItems = function () {
-		return this.filterBy(this.getFilterCompletedXpath.bind(this));
+		return this.filterBy(this.getFilterCompletedCss());
 	};
 
 	this.filterByAllItems = function () {
-		return this.filterBy(this.getFilterAllXpath.bind(this));
+		return this.filterBy(this.getFilterAllCss());
 	};
 };

--- a/tests/pageLaxMode.js
+++ b/tests/pageLaxMode.js
@@ -1,62 +1,73 @@
 'use strict';
 
-var webdriver = require('selenium-webdriver');
 var Page = require('./page');
 
-module.exports = function PageLaxMode(browser) {
-	Page.apply(this, [browser]);
+module.exports = function PageLaxMode() {
 
+	Page.apply(this, arguments);
 
-	this.tryGetMainSectionElement = function () {
-		return this.tryFindByXpath('//section//section');
+	this.getMainSectionCss = function () {
+		return 'section section';
 	};
 
-	this.tryGetFooterElement = function () {
-		return this.tryFindByXpath('//section//footer');
+	this.getFooterSectionCss = function () {
+		return 'section footer';
 	};
 
-	this.getTodoListXpath = function () {
-		return '(//section/ul | //section/div/ul | //ul[@id="todo-list"])';
+	this.getListCss = function (suffixCss) {
+		return [
+			'section > ul',
+			'section > div > ul',
+			'ul#todo-list',
+		].map(function (listCss) {
+			return listCss + (suffixCss || '');
+		}).join(', ');
 	};
 
-	this.getMarkAllCompletedCheckBox = function () {
-		var xpath = '(//section/input[@type="checkbox"] | //section/*/input[@type="checkbox"] | //input[@id="toggle-all"])';
-		return browser.findElement(webdriver.By.xpath(xpath));
+	this.getToggleAllCss = function () {
+		return [
+			'section > input[type="checkbox"]',
+			'section > * > input[type="checkbox"]',
+			'input#toggle-all',
+		].join(', ');
 	};
 
-	this.tryGetClearCompleteButton = function () {
-		var xpath = '(//footer/button | //footer/*/button | //button[@id="clear-completed"])';
-		return browser.findElements(webdriver.By.xpath(xpath));
+	this.getClearCompletedButtonCss = function () {
+		return [
+			'footer > button',
+			'footer > * > button',
+			'button#clear-completed',
+		].join(', ');
 	};
 
-	this.getItemsCountElement = function () {
-		var xpath = '(//footer/span | //footer/*/span)';
-		return browser.findElement(webdriver.By.xpath(xpath));
+	this.getItemCountCss = function () {
+		return [
+			'footer > span',
+			'footer > * > span',
+		].join(', ');
 	};
 
-	this.getFilterElements = function () {
-		return browser.findElements(webdriver.By.xpath('//footer//ul//a'));
+	this.getFilterCss = function (index) {
+		return 'footer ul li:nth-child(' + (index + 1) + ') a';
 	};
 
-
-	this.getItemInputField = function () {
-		// allow a more generic method for locating the text getItemInputField
-		var xpath = '(//header/input | //header/*/input | //input[@id="new-todo"])';
-		return browser.findElement(webdriver.By.xpath(xpath));
+	this.getNewInputCss = function () {
+		return [
+			'header > input',
+			'header > * > input',
+			'input#new-todo',
+		].join(', ');
 	};
 
-	this.tryGetToggleForItemAtIndex = function (index) {
-		// the specification dictates that the checkbox should have the 'toggle' CSS class. Some implementations deviate from
-		// this, hence in lax mode we simply look for any checkboxes within the specified 'li'.
-		var xpath = this.xPathForItemAtIndex(index) + '//input[@type="checkbox"]';
-		return browser.findElements(webdriver.By.xpath(xpath));
+	this.getListItemToggleCss = function (index) {
+		return this.getListItemCss(index, ' input[type="checkbox"]');
 	};
 
-	this.getEditInputForItemAtIndex = function (index) {
-		// the specification dictates that the input element that allows the user to edit a todo item should have a CSS
-		// class of 'edit'. In lax mode, we also look for an input of type 'text'.
-		var xpath = '(' + this.xPathForItemAtIndex(index) + '//input[@type="text"]' + '|' +
-			this.xPathForItemAtIndex(index) + '//input[contains(@class,"edit")]' + ')';
-		return browser.findElement(webdriver.By.xpath(xpath));
+	this.getListItemInputCss = function (index) {
+		return [
+			this.getListItemCss(index, ' input.edit'),
+			this.getListItemCss(index, ' input[type="text"]'),
+		].join(', ');
 	};
+
 };

--- a/tests/testOperations.js
+++ b/tests/testOperations.js
@@ -1,212 +1,100 @@
 'use strict';
-var assert = require('assert');
 
 function TestOperations(page) {
-	// unfortunately webdriver does not have a decent API for determining if an
-	// element exists. The standard approach is to obtain an array of elements
-	// and test that the length is zero. In this case the item is hidden if
-	// it is either not in the DOM, or is in the DOM but not visible.
-	function testIsHidden(elements, name) {
-		if (elements.length === 1) {
-			elements[0].isDisplayed().then(function (isDisplayed) {
-				assert(!isDisplayed, 'the ' + name + ' element should be hidden');
-			});
-		}
-	}
 
-	function testIsVisible(elements, name) {
-		assert.equal(elements.length, 1);
-		return elements[0].isDisplayed()
-			.then(function (isDisplayed) {
-				assert(isDisplayed, 'the ' + name + ' element should be displayed');
-			});
-	}
-
-	this.assertNewInputNotFocused = function () {
-		return page.getFocussedElementIdOrClass()
-			.then(function (focussedElementIdOrClass) {
-				assert.equal(focussedElementIdOrClass.indexOf('new-todo'), -1);
-			});
+	this.assertItemInputFocused = function () {
+		return page.waitForFocusedElement(page.getEditingListItemInputCss(), 'Expected the item input to be focused');
 	};
 
-	this.assertInputFocused = function () {
-		return page.getFocussedTagName()
-			.then(function (name) {
-				assert.equal(name, 'input', 'input does not have focus');
-			});
+	this.assertNewInputFocused = function () {
+		return page.waitForFocusedElement(page.getNewInputCss());
 	};
 
-	this.assertFocussedElement = function (expectedIdentifier) {
-		return page.getFocussedElementIdOrClass()
-			.then(function (focusedElementIdentifier) {
-				var failMsg = 'The focused element did not have the expected class or id "' + expectedIdentifier + '"';
-				assert.notEqual(focusedElementIdentifier.indexOf(expectedIdentifier), -1, failMsg);
-			});
-	};
-
-	this.assertClearCompleteButtonIsHidden = function () {
-		return page.tryGetClearCompleteButton()
-			.then(function (element) {
-				return testIsHidden(element, 'clear completed items button');
-			}, function (_error) {
-				assert(_error.code === 7, 'error accessing clear completed items button, error: ' + _error.message);
-			});
-	};
-
-	this.assertClearCompleteButtonIsVisible = function () {
-		return page.waitForVisibleElement(function () {
-				return page.tryGetClearCompleteButton();
-			})
-			.then(function (clearCompleteButton) {
-				assert(clearCompleteButton, 'the clear completed items button element should be displayed');
-			});
+	this.assertNewInputBlurred = function () {
+		return page.waitForBlurredElement(page.getNewInputCss());
 	};
 
 	this.assertItemCount = function (itemCount) {
-		return page.getItemElements()
-			.then(function (toDoItems) {
-				assert.equal(toDoItems.length, itemCount,
-					itemCount + ' items expected in the todo list, ' + toDoItems.length + ' items observed');
-			});
+		return itemCount === 0 ?
+			page.waitForMainSectionRemovedOrEmpty() :
+			page.waitForListItemCount(itemCount);
 	};
 
 	this.assertClearCompleteButtonText = function (buttonText) {
-		return page.waitForVisibleElement(function () {
-				return page.tryGetClearCompleteButton();
-			})
-			.then(function (clearCompleteButton) {
-				return clearCompleteButton.getText();
-			})
-			.then(function (text) {
-				return assert.equal(text, buttonText);
-			});
+		return page.waitForClearCompleteButton()
+			.then(page.waitForTextContent.bind(page, buttonText, 'Expected clear button text to be ' + buttonText));
 	};
 
-	this.assertMainSectionIsHidden = function () {
-		return page.tryGetMainSectionElement()
-			.then(function (mainSection) {
-				return testIsHidden(mainSection, 'main');
-			});
+	this.assertClearCompleteButtonVisibility = function (shouldBeVisible) {
+		var failMsg = 'Expected the clear completed items button to be ' + (shouldBeVisible ? 'visible' : 'hidden');
+		return page.waitForVisibility(shouldBeVisible, page.getClearCompletedButtonCss(), failMsg);
 	};
 
-	this.assertFooterIsHidden = function () {
-		return page.tryGetFooterElement()
-			.then(function (footer) {
-				return testIsHidden(footer, 'footer');
-			});
+	this.assertMainSectionVisibility = function (shouldBeVisible) {
+		var failMsg = 'Expected main section to be ' + (shouldBeVisible ? 'visible' : 'hidden');
+		return page.waitForVisibility(shouldBeVisible, page.getMainSectionCss(), failMsg);
 	};
 
-	this.assertMainSectionIsVisible = function () {
-		return page.tryGetMainSectionElement()
-			.then(function (mainSection) {
-				return testIsVisible(mainSection, 'main');
-			});
+	this.assertFooterVisibility = function (shouldBeVisible) {
+		var failMsg = 'Expected footer to be ' + (shouldBeVisible ? 'visible' : 'hidden');
+		return page.waitForVisibility(shouldBeVisible, page.getFooterSectionCss(), failMsg);
 	};
 
-	//TODO: fishy!
 	this.assertItemToggleIsHidden = function (index) {
-		return page.tryGetToggleForItemAtIndex(index)
-			.then(function (toggleItem) {
-				return testIsHidden(toggleItem, 'item-toggle');
-			});
+		return page.waitForVisibility(false, page.getListItemToggleCss(index), 'Expected the item toggle button to be hidden');
 	};
 
 	this.assertItemLabelIsHidden = function (index) {
-		return page.tryGetItemLabelAtIndex(index)
-			.then(function (toggleItem) {
-				return testIsHidden(toggleItem, 'item-label');
-			});
+		return page.waitForVisibility(false, page.getListItemLabelCss(index), 'Expected the item label to be hidden');
 	};
 
-	this.assertFooterIsVisible = function () {
-		return page.tryGetFooterElement()
-			.then(function (footer) {
-				return testIsVisible(footer, 'footer');
-			});
+	this.assertNewItemInputFieldText = function (text) {
+		return page.waitForNewItemInputField()
+			.then(page.waitForTextContent.bind(page, text, 'Expected the new item input text field contents to be ' + text));
 	};
 
-	this.assertItemInputFieldText = function (text) {
-		return page.getItemInputField().getText()
-			.then(function (inputFieldText) {
-				assert.equal(inputFieldText, text);
-			});
+	this.assertItemText = function (itemIndex, text) {
+		return page.waitForItemLabel(itemIndex)
+			.then(page.waitForTextContent.bind(page, text, 'Expected the item label to be ' + text));
 	};
 
-	this.assertItemText = function (itemIndex, textToAssert) {
-		return page.getItemLabelAtIndex(itemIndex).getText()
-			.then(function (text) {
-				assert.equal(text, textToAssert,
-					'A todo item with text \'' + textToAssert + '\' was expected at index ' +
-					itemIndex + ', the text \'' + text + '\' was observed');
-			});
-	};
-
-	// tests that the list contains the following items, independant of order
 	this.assertItems = function (textArray) {
-		return page.getVisibleLabelText()
-			.then(function (visibleText) {
-				assert.deepEqual(visibleText.sort(), textArray.sort());
+		return page.getListItems().then(function (items) {
+			if (items.length < textArray.length) {
+				// This means that the framework removes rather than hides list items
+				textArray = textArray.filter(function (item) { return item !== page.ITEM_HIDDEN_OR_REMOVED; });
+			}
+			var ret;
+			textArray.forEach(function (text, i) {
+				if (text === page.ITEM_HIDDEN_OR_REMOVED) { return; }
+				var promise = page.waitForTextContent(text, 'Expected item text to be ' + text, items[i]);
+				ret = ret ? ret.then(promise) : promise;
 			});
+			return ret;
+		});
 	};
 
-	this.assertItemCountText = function (textToAssert) {
-		return page.getItemsCountElement().getText()
-			.then(function (text) {
-				assert.equal(text.trim(), textToAssert, 'the item count text was incorrect');
-			});
+	this.assertItemCountText = function (text) {
+		return page.waitForElement(page.getItemCountCss())
+			.then(page.waitForTextContent.bind(page, text, 'Expected item count text to be ' + text));
 	};
 
-	// tests for the presence of the 'completed' CSS class for the item at the given index
-	this.assertItemAtIndexIsCompleted = function (index) {
-		return page.getItemElements()
-			.then(function (toDoItems) {
-				return toDoItems[index].getAttribute('class');
-			})
-			.then(function (cssClass) {
-				var failMsg = 'the item at index ' + index + ' should have been marked as completed';
-				assert(cssClass.indexOf('completed') !== -1, failMsg);
-			});
-	};
-
-	this.assertItemAtIndexIsNotCompleted = function (index) {
-		return page.getItemElements()
-			.then(function (toDoItems) {
-				return toDoItems[index].getAttribute('class');
-			})
-			.then(function (cssClass) {
-				// the maria implementation uses an 'incompleted' CSS class which is redundant
-				// TODO: this should really be moved into the pageLaxMode
-				var failMsg = 'the item at index ' + index + ' should not have been marked as completed';
-				assert(cssClass.indexOf('completed') === -1 || cssClass.indexOf('incompleted') !== -1, failMsg);
-			});
+	this.assertItemCompletedStates = function (completedStates) {
+		return page.waitForElement(
+			page.getListItemsWithCompletedStatesCss(completedStates),
+			'Item completed states were incorrect');
 	};
 
 	this.assertFilterAtIndexIsSelected = function (selectedIndex) {
-		return page.findByXpath(page.getSelectedFilterXPathByIndex(selectedIndex + 1))
-			.then(function (elm) {
-				var failMsg = 'the filter / route at index ' + selectedIndex + ' should have been selected';
-				assert.notEqual(elm, undefined, failMsg);
-			});
+		return page.waitForElement(
+			page.getSelectedFilterCss(selectedIndex),
+			'Expexted the filter / route at index ' + selectedIndex + ' to be selected');
 	};
 
-	this.assertCompleteAllIsClear = function () {
-		return page.getMarkAllCompletedCheckBox()
-			.then(function (markAllCompleted) {
-				return markAllCompleted.isSelected();
-			})
-			.then(function (isSelected) {
-				assert(!isSelected, 'the mark-all-completed checkbox should be clear');
-			});
-	};
-
-	this.assertCompleteAllIsChecked = function () {
-		return page.getMarkAllCompletedCheckBox()
-			.then(function (markAllCompleted) {
-				return markAllCompleted.isSelected();
-			})
-			.then(function (isSelected) {
-				assert(isSelected, 'the mark-all-completed checkbox should be checked');
-			});
+	this.assertCompleteAllCheckedStatus = function (shouldBeChecked) {
+		var failMsg = 'Expected the mark-all-completed checkbox to be ' + shouldBeChecked ? 'checked' : 'unchecked';
+		return page.waitForMarkAllCompletedCheckBox()
+			.then(page.waitForCheckedStatus.bind(page, shouldBeChecked, failMsg));
 	};
 }
 


### PR DESCRIPTION
When running the tests on the Todo app for my (not yet submitted) framework I noticed that some test were blinking. The reason for this nondeterminism is that my framework defers DOM updates using requestAnimationFrame, and thus it has not yet updated the DOM when the tests are asserting things.

To fix this I rewrote the test suite back-end, so that it waits for DOM states instead of just testing for them once, at an arbitrary time.

I have run the test suite on all frameworks presented on the TodoMVC front page and there seems to be no regressions. Some framework test suite results of interest:

* KnockoutJS: 2 test cases fail, both before and after my changes.
* Knockback.js: 1 test case fails, both before and after my changes.
* Flight: 2 test cases fail after my changes, 3 before. The current suite reports a false negative, because it does not wait until the main section and footer are hidden.
* TroopJS+RequireJS: Almost all test cases fail after my changes. This is because of a currently uncaught bug in the TroopJS app, where the app eats up input for a while, before it is completely loaded. Repro; type something and hit Enter repeatedly and quickly while the app is loading, see that the text is removed from the input field but no todo item is added.