### PR TITLE
Update marionette.js to v3

### DIFF
--- a/examples/backbone_marionette/.gitignore
+++ b/examples/backbone_marionette/.gitignore
@@ -19,3 +19,6 @@ node_modules/backbone
 
 node_modules/backbone.localstorage
 !node_modules/backbone.localstorage/backbone.localStorage.js
+
+node_modules/backbone.radio
+!node_modules/backbone.radio/build/backbone.radio.js

--- a/examples/backbone_marionette/index.html
+++ b/examples/backbone_marionette/index.html
@@ -51,10 +51,10 @@
 			</div>
 			<input class="edit" value="<%- title %>">
 		</script>
-		<script type="text/html" id="template-todoListCompositeView">
+		<script type="text/html" id="template-todoListView">
 			<input id="toggle-all" type="checkbox">
 			<label for="toggle-all">Mark all as complete</label>
-			<ul id="todo-list"></ul>
+			<ul></ul>
 		</script>
 		<!-- vendor libraries -->
 		<script src="node_modules/todomvc-common/base.js"></script>
@@ -62,8 +62,8 @@
 		<script src="node_modules/underscore/underscore.js"></script>
 		<script src="node_modules/backbone/backbone.js"></script>
 		<script src="node_modules/backbone.localstorage/backbone.localStorage.js"></script>
-		<script src="node_modules/backbone.marionette/lib/backbone.marionette.js"></script>
 		<script src="node_modules/backbone.radio/build/backbone.radio.js"></script>
+		<script src="node_modules/backbone.marionette/lib/backbone.marionette.js"></script>
 		<!-- application -->
 		<script src="js/TodoMVC.Application.js"></script>
 		<script src="js/TodoMVC.Todos.js"></script>

--- a/examples/backbone_marionette/js/TodoMVC.Application.js
+++ b/examples/backbone_marionette/js/TodoMVC.Application.js
@@ -5,7 +5,7 @@ var TodoMVC = TodoMVC || {};
 (function () {
 	'use strict';
 
-	var TodoApp = Backbone.Marionette.Application.extend({
+	var TodoApp = Mn.Application.extend({
 		setRootLayout: function () {
 			this.root = new TodoMVC.RootLayout();
 		}

--- a/examples/backbone_marionette/js/TodoMVC.Layout.js
+++ b/examples/backbone_marionette/js/TodoMVC.Layout.js
@@ -7,7 +7,7 @@ var TodoMVC = TodoMVC || {};
 
 	var filterChannel = Backbone.Radio.channel('filter');
 
-	TodoMVC.RootLayout = Backbone.Marionette.LayoutView.extend({
+	TodoMVC.RootLayout = Mn.View.extend({
 
 		el: '#todoapp',
 
@@ -20,7 +20,7 @@ var TodoMVC = TodoMVC || {};
 
 	// Layout Header View
 	// ------------------
-	TodoMVC.HeaderLayout = Backbone.Marionette.ItemView.extend({
+	TodoMVC.HeaderLayout = Mn.View.extend({
 
 		template: '#template-header',
 
@@ -60,7 +60,7 @@ var TodoMVC = TodoMVC || {};
 
 	// Layout Footer View
 	// ------------------
-	TodoMVC.FooterLayout = Backbone.Marionette.ItemView.extend({
+	TodoMVC.FooterLayout = Mn.View.extend({
 		template: '#template-footer',
 
 		// UI bindings create cached attributes that
@@ -82,7 +82,7 @@ var TodoMVC = TodoMVC || {};
 			all: 'render'
 		},
 
-		templateHelpers: {
+		templateContext: {
 			activeCountLabel: function () {
 				return (this.activeCount === 1 ? 'item' : 'items') + ' left';
 			}

--- a/examples/backbone_marionette/js/TodoMVC.Router.js
+++ b/examples/backbone_marionette/js/TodoMVC.Router.js
@@ -12,7 +12,7 @@ var TodoMVC = TodoMVC || {};
 	//
 	// Handles a single dynamic route to show
 	// the active vs complete todo items
-	TodoMVC.Router = Backbone.Marionette.AppRouter.extend({
+	TodoMVC.Router = Mn.AppRouter.extend({
 		appRoutes: {
 			'*filter': 'filterItems'
 		}
@@ -23,7 +23,7 @@ var TodoMVC = TodoMVC || {};
 	//
 	// Control the workflow and logic that exists at the application
 	// level, above the implementation detail of views and models
-	TodoMVC.Controller = Backbone.Marionette.Object.extend({
+	TodoMVC.Controller = Mn.Object.extend({
 
 		initialize: function () {
 			this.todoList = new TodoMVC.TodoList();

--- a/examples/backbone_marionette/js/TodoMVC.TodoList.Views.js
+++ b/examples/backbone_marionette/js/TodoMVC.TodoList.Views.js
@@ -12,7 +12,7 @@ var TodoMVC = TodoMVC || {};
 	//
 	// Display an individual todo item, and respond to changes
 	// that are made to the item, including marking completed.
-	TodoMVC.TodoView = Backbone.Marionette.ItemView.extend({
+	TodoMVC.TodoView = Mn.View.extend({
 
 		tagName: 'li',
 
@@ -81,18 +81,38 @@ var TodoMVC = TodoMVC || {};
 		}
 	});
 
-	// Item List View
+	// Item List View Body
 	// --------------
 	//
 	// Controls the rendering of the list of items, including the
-	// filtering of activs vs completed items for display.
-	TodoMVC.ListView = Backbone.Marionette.CompositeView.extend({
+	// filtering of items for display.
+	TodoMVC.ListViewBody = Mn.CollectionView.extend({
+		tagName: 'ul',
 
-		template: '#template-todoListCompositeView',
+		id: 'todo-list',
 
 		childView: TodoMVC.TodoView,
 
-		childViewContainer: '#todo-list',
+		filter: function (child) {
+			var filteredOn = filterChannel.request('filterState').get('filter');
+			return child.matchesFilter(filteredOn);
+		}
+	});
+
+	// Item List View
+	// --------------
+	//
+	// Manages List View
+	TodoMVC.ListView = Mn.View.extend({
+
+		template: '#template-todoListView',
+
+		regions: {
+			listBody: {
+				el: 'ul',
+				replaceElement: true
+			}
+		},
 
 		ui: {
 			toggle: '#toggle-all'
@@ -111,11 +131,6 @@ var TodoMVC = TodoMVC || {};
 			this.listenTo(filterChannel.request('filterState'), 'change:filter', this.render, this);
 		},
 
-		filter: function (child) {
-			var filteredOn = filterChannel.request('filterState').get('filter');
-			return child.matchesFilter(filteredOn);
-		},
-
 		setCheckAllState: function () {
 			function reduceCompleted(left, right) {
 				return left && right.get('completed');
@@ -132,6 +147,12 @@ var TodoMVC = TodoMVC || {};
 			this.collection.each(function (todo) {
 				todo.save({ completed: isChecked });
 			});
+		},
+
+		onRender: function() {
+			this.showChildView('listBody', new TodoMVC.ListViewBody({
+				collection: this.collection
+			}));
 		}
 	});
 })();

--- a/examples/backbone_marionette/js/TodoMVC.TodoList.Views.js
+++ b/examples/backbone_marionette/js/TodoMVC.TodoList.Views.js
@@ -149,7 +149,7 @@ var TodoMVC = TodoMVC || {};
 			});
 		},
 
-		onRender: function() {
+		onRender: function () {
 			this.showChildView('listBody', new TodoMVC.ListViewBody({
 				collection: this.collection
 			}));

--- a/examples/backbone_marionette/node_modules/backbone.marionette/lib/backbone.marionette.js
+++ b/examples/backbone_marionette/node_modules/backbone.marionette/lib/backbone.marionette.js
@@ -1,3819 +1,3240 @@
 // MarionetteJS (Backbone.Marionette)
 // ----------------------------------
-// v2.4.1
+// v3.0.0
 //
-// Copyright (c)2015 Derick Bailey, Muted Solutions, LLC.
+// Copyright (c)2016 Derick Bailey, Muted Solutions, LLC.
 // Distributed under MIT license
 //
 // http://marionettejs.com
 
 
-/*!
- * Includes BabySitter
- * https://github.com/marionettejs/backbone.babysitter/
- *
- * Includes Wreqr
- * https://github.com/marionettejs/backbone.wreqr/
- */
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('backbone'), require('underscore'), require('backbone.radio')) :
+	typeof define === 'function' && define.amd ? define(['backbone', 'underscore', 'backbone.radio'], factory) :
+	(global.Marionette = global['Mn'] = factory(global.Backbone,global._,global.Backbone.Radio));
+}(this, function (Backbone,_,Radio) { 'use strict';
+
+	Backbone = 'default' in Backbone ? Backbone['default'] : Backbone;
+	_ = 'default' in _ ? _['default'] : _;
+	Radio = 'default' in Radio ? Radio['default'] : Radio;
+
+	var version = "3.0.0";
+
+	//Internal utility for creating context style global utils
+	var proxy = function proxy(method) {
+	  return function (context) {
+	    for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+	      args[_key - 1] = arguments[_key];
+	    }
+
+	    return method.apply(context, args);
+	  };
+	};
+
+	// Borrow the Backbone `extend` method so we can use it as needed
+	var extend = Backbone.Model.extend;
+
+	var deprecate = function deprecate(message, test) {
+	  if (_.isObject(message)) {
+	    message = message.prev + ' is going to be removed in the future. ' + 'Please use ' + message.next + ' instead.' + (message.url ? ' See: ' + message.url : '');
+	  }
+
+	  if (!Marionette.DEV_MODE) {
+	    return;
+	  }
+
+	  if ((test === undefined || !test) && !deprecate._cache[message]) {
+	    deprecate._warn('Deprecation warning: ' + message);
+	    deprecate._cache[message] = true;
+	  }
+	};
+
+	deprecate._console = typeof console !== 'undefined' ? console : {};
+	deprecate._warn = function () {
+	  var warn = deprecate._console.warn || deprecate._console.log || _.noop;
+	  return warn.apply(deprecate._console, arguments);
+	};
+	deprecate._cache = {};
+
+	// Determine if `el` is a child of the document
+	var isNodeAttached = function isNodeAttached(el) {
+	  return Backbone.$.contains(document.documentElement, el);
+	};
+
+	// Merge `keys` from `options` onto `this`
+	var mergeOptions = function mergeOptions(options, keys) {
+	  if (!options) {
+	    return;
+	  }
+	  _.extend(this, _.pick(options, keys));
+	};
+
+	// Marionette.getOption
+	// --------------------
+
+	// Retrieve an object, function or other value from the
+	// object or its `options`, with `options` taking precedence.
+	var getOption = function getOption(optionName) {
+	  if (!optionName) {
+	    return;
+	  }
+	  if (this.options && this.options[optionName] !== undefined) {
+	    return this.options[optionName];
+	  } else {
+	    return this[optionName];
+	  }
+	};
+
+	// Marionette.normalizeMethods
+	// ----------------------
+
+	// Pass in a mapping of events => functions or function names
+	// and return a mapping of events => functions
+	var normalizeMethods = function normalizeMethods(hash) {
+	  var _this = this;
+
+	  return _.reduce(hash, function (normalizedHash, method, name) {
+	    if (!_.isFunction(method)) {
+	      method = _this[method];
+	    }
+	    if (method) {
+	      normalizedHash[name] = method;
+	    }
+	    return normalizedHash;
+	  }, {});
+	};
+
+	// split the event name on the ":"
+	var splitter = /(^|:)(\w)/gi;
+
+	// take the event section ("section1:section2:section3")
+	// and turn it in to uppercase name onSection1Section2Section3
+	function getEventName(match, prefix, eventName) {
+	  return eventName.toUpperCase();
+	}
+
+	// Trigger an event and/or a corresponding method name. Examples:
+	//
+	// `this.triggerMethod("foo")` will trigger the "foo" event and
+	// call the "onFoo" method.
+	//
+	// `this.triggerMethod("foo:bar")` will trigger the "foo:bar" event and
+	// call the "onFooBar" method.
+	function triggerMethod(event) {
+	  // get the method name from the event name
+	  var methodName = 'on' + event.replace(splitter, getEventName);
+	  var method = getOption.call(this, methodName);
+	  var result = void 0;
+
+	  // call the onMethodName if it exists
+
+	  for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+	    args[_key - 1] = arguments[_key];
+	  }
+
+	  if (_.isFunction(method)) {
+	    // pass all args, except the event name
+	    result = method.apply(this, args);
+	  }
+
+	  // trigger the event
+	  this.trigger.apply(this, [event].concat(args));
+
+	  return result;
+	}
+
+	// triggerMethodOn invokes triggerMethod on a specific context
+	//
+	// e.g. `Marionette.triggerMethodOn(view, 'show')`
+	// will trigger a "show" event or invoke onShow the view.
+	function triggerMethodOn(context) {
+	  var fnc = _.isFunction(context.triggerMethod) ? context.triggerMethod : triggerMethod;
+
+	  for (var _len2 = arguments.length, args = Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
+	    args[_key2 - 1] = arguments[_key2];
+	  }
+
+	  return fnc.apply(context, args);
+	}
+
+	// Trigger method on children unless a pure Backbone.View
+	function triggerMethodChildren(view, event, shouldTrigger) {
+	  if (!view._getImmediateChildren) {
+	    return;
+	  }
+	  _.each(view._getImmediateChildren(), function (child) {
+	    if (!shouldTrigger(child)) {
+	      return;
+	    }
+	    triggerMethodOn(child, event, child);
+	  });
+	}
+
+	function shouldTriggerAttach(view) {
+	  return !view._isAttached;
+	}
+
+	function shouldAttach(view) {
+	  if (!shouldTriggerAttach(view)) {
+	    return false;
+	  }
+	  view._isAttached = true;
+	  return true;
+	}
+
+	function shouldTriggerDetach(view) {
+	  return view._isAttached;
+	}
+
+	function shouldDetach(view) {
+	  if (!shouldTriggerDetach(view)) {
+	    return false;
+	  }
+	  view._isAttached = false;
+	  return true;
+	}
+
+	// Monitor a view's state, propagating attach/detach events to children and firing dom:refresh
+	// whenever a rendered view is attached or an attached view is rendered.
+	function monitorViewEvents(view) {
+	  if (view._areViewEventsMonitored) {
+	    return;
+	  }
+
+	  view._areViewEventsMonitored = true;
+
+	  function handleBeforeAttach() {
+	    triggerMethodChildren(view, 'before:attach', shouldTriggerAttach);
+	  }
+
+	  function handleAttach() {
+	    triggerMethodChildren(view, 'attach', shouldAttach);
+	    triggerDOMRefresh();
+	  }
+
+	  function handleBeforeDetach() {
+	    triggerMethodChildren(view, 'before:detach', shouldTriggerDetach);
+	  }
+
+	  function handleDetach() {
+	    triggerMethodChildren(view, 'detach', shouldDetach);
+	  }
+
+	  function handleRender() {
+	    triggerDOMRefresh();
+	  }
+
+	  function triggerDOMRefresh() {
+	    if (view._isAttached && view._isRendered) {
+	      triggerMethodOn(view, 'dom:refresh', view);
+	    }
+	  }
+
+	  view.on({
+	    'before:attach': handleBeforeAttach,
+	    'attach': handleAttach,
+	    'before:detach': handleBeforeDetach,
+	    'detach': handleDetach,
+	    'render': handleRender
+	  });
+	}
+
+	var errorProps = ['description', 'fileName', 'lineNumber', 'name', 'message', 'number'];
+
+	var MarionetteError = extend.call(Error, {
+	  urlRoot: 'http://marionettejs.com/docs/v' + version + '/',
+
+	  constructor: function constructor(message, options) {
+	    if (_.isObject(message)) {
+	      options = message;
+	      message = options.message;
+	    } else if (!options) {
+	      options = {};
+	    }
+
+	    var error = Error.call(this, message);
+	    _.extend(this, _.pick(error, errorProps), _.pick(options, errorProps));
+
+	    this.captureStackTrace();
+
+	    if (options.url) {
+	      this.url = this.urlRoot + options.url;
+	    }
+	  },
+	  captureStackTrace: function captureStackTrace() {
+	    if (Error.captureStackTrace) {
+	      Error.captureStackTrace(this, MarionetteError);
+	    }
+	  },
+	  toString: function toString() {
+	    return this.name + ': ' + this.message + (this.url ? ' See: ' + this.url : '');
+	  }
+	});
+
+	MarionetteError.extend = extend;
+
+	// Bind/unbind the event to handlers specified as a string of
+	// handler names on the target object
+	function bindFromStrings(target, entity, evt, methods, actionName) {
+	  var methodNames = methods.split(/\s+/);
+
+	  _.each(methodNames, function (methodName) {
+	    var method = target[methodName];
+	    if (!method) {
+	      throw new MarionetteError('Method "' + methodName + '" was configured as an event handler, but does not exist.');
+	    }
+
+	    target[actionName](entity, evt, method);
+	  });
+	}
+
+	// generic looping function
+	function iterateEvents(target, entity, bindings, actionName) {
+	  if (!entity || !bindings) {
+	    return;
+	  }
+
+	  // type-check bindings
+	  if (!_.isObject(bindings)) {
+	    throw new MarionetteError({
+	      message: 'Bindings must be an object.',
+	      url: 'marionette.functions.html#marionettebindevents'
+	    });
+	  }
+
+	  // iterate the bindings and bind/unbind them
+	  _.each(bindings, function (method, evt) {
+
+	    // allow for a list of method names as a string
+	    if (_.isString(method)) {
+	      bindFromStrings(target, entity, evt, method, actionName);
+	      return;
+	    }
+
+	    target[actionName](entity, evt, method);
+	  });
+	}
+
+	function bindEvents(entity, bindings) {
+	  iterateEvents(this, entity, bindings, 'listenTo');
+	  return this;
+	}
+
+	function unbindEvents(entity, bindings) {
+	  iterateEvents(this, entity, bindings, 'stopListening');
+	  return this;
+	}
+
+	function iterateReplies(target, channel, bindings, actionName) {
+	  if (!channel || !bindings) {
+	    return;
+	  }
+
+	  // type-check bindings
+	  if (!_.isObject(bindings)) {
+	    throw new MarionetteError({
+	      message: 'Bindings must be an object.',
+	      url: 'marionette.functions.html#marionettebindrequests'
+	    });
+	  }
+
+	  var normalizedRadioRequests = normalizeMethods.call(target, bindings);
+
+	  channel[actionName](normalizedRadioRequests, target);
+	}
+
+	function bindRequests(channel, bindings) {
+	  iterateReplies(this, channel, bindings, 'reply');
+	  return this;
+	}
+
+	function unbindRequests(channel, bindings) {
+	  iterateReplies(this, channel, bindings, 'stopReplying');
+	  return this;
+	}
+
+	// Internal utility for setting options consistently across Mn
+	var setOptions = function setOptions() {
+	  for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+	    args[_key] = arguments[_key];
+	  }
+
+	  this.options = _.extend.apply(_, [{}, _.result(this, 'options')].concat(args));
+	};
+
+	var CommonMixin = {
+
+	  // Imports the "normalizeMethods" to transform hashes of
+	  // events=>function references/names to a hash of events=>function references
+	  normalizeMethods: normalizeMethods,
+
+	  _setOptions: setOptions,
+
+	  // A handy way to merge passed-in options onto the instance
+	  mergeOptions: mergeOptions,
+
+	  // Enable getting options from this or this.options by name.
+	  getOption: getOption,
+
+	  // Enable binding view's events from another entity.
+	  bindEvents: bindEvents,
+
+	  // Enable unbinding view's events from another entity.
+	  unbindEvents: unbindEvents
+	};
+
+	// MixinOptions
+	// - channelName
+	// - radioEvents
+	// - radioRequests
+
+	var RadioMixin = {
+	  _initRadio: function _initRadio() {
+	    var channelName = _.result(this, 'channelName');
+
+	    if (!channelName) {
+	      return;
+	    }
+
+	    /* istanbul ignore next */
+	    if (!Radio) {
+	      throw new MarionetteError({
+	        name: 'BackboneRadioMissing',
+	        message: 'The dependency "backbone.radio" is missing.'
+	      });
+	    }
+
+	    var channel = this._channel = Radio.channel(channelName);
+
+	    var radioEvents = _.result(this, 'radioEvents');
+	    this.bindEvents(channel, radioEvents);
+
+	    var radioRequests = _.result(this, 'radioRequests');
+	    this.bindRequests(channel, radioRequests);
+
+	    this.on('destroy', this._destroyRadio);
+	  },
+	  _destroyRadio: function _destroyRadio() {
+	    this._channel.stopReplying(null, null, this);
+	  },
+	  getChannel: function getChannel() {
+	    return this._channel;
+	  },
 
 
-(function(root, factory) {
+	  // Proxy `bindEvents`
+	  bindEvents: bindEvents,
 
-  /* istanbul ignore next */
-  if (typeof define === 'function' && define.amd) {
-    define(['backbone', 'underscore'], function(Backbone, _) {
-      return (root.Marionette = root.Mn = factory(root, Backbone, _));
-    });
-  } else if (typeof exports !== 'undefined') {
-    var Backbone = require('backbone');
-    var _ = require('underscore');
-    module.exports = factory(root, Backbone, _);
-  } else {
-    root.Marionette = root.Mn = factory(root, root.Backbone, root._);
-  }
+	  // Proxy `unbindEvents`
+	  unbindEvents: unbindEvents,
 
-}(this, function(root, Backbone, _) {
-  'use strict';
+	  // Proxy `bindRequests`
+	  bindRequests: bindRequests,
 
-  /* istanbul ignore next */
-  // Backbone.BabySitter
-  // -------------------
-  // v0.1.6
-  //
-  // Copyright (c)2015 Derick Bailey, Muted Solutions, LLC.
-  // Distributed under MIT license
-  //
-  // http://github.com/marionettejs/backbone.babysitter
-  (function(Backbone, _) {
-    "use strict";
-    var previousChildViewContainer = Backbone.ChildViewContainer;
-    // BabySitter.ChildViewContainer
-    // -----------------------------
-    //
-    // Provide a container to store, retrieve and
-    // shut down child views.
-    Backbone.ChildViewContainer = function(Backbone, _) {
-      // Container Constructor
-      // ---------------------
-      var Container = function(views) {
-        this._views = {};
-        this._indexByModel = {};
-        this._indexByCustom = {};
-        this._updateLength();
-        _.each(views, this.add, this);
-      };
-      // Container Methods
-      // -----------------
-      _.extend(Container.prototype, {
-        // Add a view to this container. Stores the view
-        // by `cid` and makes it searchable by the model
-        // cid (and model itself). Optionally specify
-        // a custom key to store an retrieve the view.
-        add: function(view, customIndex) {
-          var viewCid = view.cid;
-          // store the view
-          this._views[viewCid] = view;
-          // index it by model
-          if (view.model) {
-            this._indexByModel[view.model.cid] = viewCid;
-          }
-          // index by custom
-          if (customIndex) {
-            this._indexByCustom[customIndex] = viewCid;
-          }
-          this._updateLength();
-          return this;
-        },
-        // Find a view by the model that was attached to
-        // it. Uses the model's `cid` to find it.
-        findByModel: function(model) {
-          return this.findByModelCid(model.cid);
-        },
-        // Find a view by the `cid` of the model that was attached to
-        // it. Uses the model's `cid` to find the view `cid` and
-        // retrieve the view using it.
-        findByModelCid: function(modelCid) {
-          var viewCid = this._indexByModel[modelCid];
-          return this.findByCid(viewCid);
-        },
-        // Find a view by a custom indexer.
-        findByCustom: function(index) {
-          var viewCid = this._indexByCustom[index];
-          return this.findByCid(viewCid);
-        },
-        // Find by index. This is not guaranteed to be a
-        // stable index.
-        findByIndex: function(index) {
-          return _.values(this._views)[index];
-        },
-        // retrieve a view by its `cid` directly
-        findByCid: function(cid) {
-          return this._views[cid];
-        },
-        // Remove a view
-        remove: function(view) {
-          var viewCid = view.cid;
-          // delete model index
-          if (view.model) {
-            delete this._indexByModel[view.model.cid];
-          }
-          // delete custom index
-          _.any(this._indexByCustom, function(cid, key) {
-            if (cid === viewCid) {
-              delete this._indexByCustom[key];
-              return true;
-            }
-          }, this);
-          // remove the view from the container
-          delete this._views[viewCid];
-          // update the length
-          this._updateLength();
-          return this;
-        },
-        // Call a method on every view in the container,
-        // passing parameters to the call method one at a
-        // time, like `function.call`.
-        call: function(method) {
-          this.apply(method, _.tail(arguments));
-        },
-        // Apply a method on every view in the container,
-        // passing parameters to the call method one at a
-        // time, like `function.apply`.
-        apply: function(method, args) {
-          _.each(this._views, function(view) {
-            if (_.isFunction(view[method])) {
-              view[method].apply(view, args || []);
-            }
-          });
-        },
-        // Update the `.length` attribute on this container
-        _updateLength: function() {
-          this.length = _.size(this._views);
-        }
-      });
-      // Borrowing this code from Backbone.Collection:
-      // http://backbonejs.org/docs/backbone.html#section-106
-      //
-      // Mix in methods from Underscore, for iteration, and other
-      // collection related features.
-      var methods = [ "forEach", "each", "map", "find", "detect", "filter", "select", "reject", "every", "all", "some", "any", "include", "contains", "invoke", "toArray", "first", "initial", "rest", "last", "without", "isEmpty", "pluck", "reduce" ];
-      _.each(methods, function(method) {
-        Container.prototype[method] = function() {
-          var views = _.values(this._views);
-          var args = [ views ].concat(_.toArray(arguments));
-          return _[method].apply(_, args);
-        };
-      });
-      // return the public API
-      return Container;
-    }(Backbone, _);
-    Backbone.ChildViewContainer.VERSION = "0.1.6";
-    Backbone.ChildViewContainer.noConflict = function() {
-      Backbone.ChildViewContainer = previousChildViewContainer;
-      return this;
-    };
-    return Backbone.ChildViewContainer;
-  })(Backbone, _);
+	  // Proxy `unbindRequests`
+	  unbindRequests: unbindRequests
 
-  /* istanbul ignore next */
-  // Backbone.Wreqr (Backbone.Marionette)
-  // ----------------------------------
-  // v1.3.1
-  //
-  // Copyright (c)2014 Derick Bailey, Muted Solutions, LLC.
-  // Distributed under MIT license
-  //
-  // http://github.com/marionettejs/backbone.wreqr
-  (function(Backbone, _) {
-    "use strict";
-    var previousWreqr = Backbone.Wreqr;
-    var Wreqr = Backbone.Wreqr = {};
-    Backbone.Wreqr.VERSION = "1.3.1";
-    Backbone.Wreqr.noConflict = function() {
-      Backbone.Wreqr = previousWreqr;
-      return this;
-    };
-    // Handlers
-    // --------
-    // A registry of functions to call, given a name
-    Wreqr.Handlers = function(Backbone, _) {
-      "use strict";
-      // Constructor
-      // -----------
-      var Handlers = function(options) {
-        this.options = options;
-        this._wreqrHandlers = {};
-        if (_.isFunction(this.initialize)) {
-          this.initialize(options);
-        }
-      };
-      Handlers.extend = Backbone.Model.extend;
-      // Instance Members
-      // ----------------
-      _.extend(Handlers.prototype, Backbone.Events, {
-        // Add multiple handlers using an object literal configuration
-        setHandlers: function(handlers) {
-          _.each(handlers, function(handler, name) {
-            var context = null;
-            if (_.isObject(handler) && !_.isFunction(handler)) {
-              context = handler.context;
-              handler = handler.callback;
-            }
-            this.setHandler(name, handler, context);
-          }, this);
-        },
-        // Add a handler for the given name, with an
-        // optional context to run the handler within
-        setHandler: function(name, handler, context) {
-          var config = {
-            callback: handler,
-            context: context
-          };
-          this._wreqrHandlers[name] = config;
-          this.trigger("handler:add", name, handler, context);
-        },
-        // Determine whether or not a handler is registered
-        hasHandler: function(name) {
-          return !!this._wreqrHandlers[name];
-        },
-        // Get the currently registered handler for
-        // the specified name. Throws an exception if
-        // no handler is found.
-        getHandler: function(name) {
-          var config = this._wreqrHandlers[name];
-          if (!config) {
-            return;
-          }
-          return function() {
-            var args = Array.prototype.slice.apply(arguments);
-            return config.callback.apply(config.context, args);
-          };
-        },
-        // Remove a handler for the specified name
-        removeHandler: function(name) {
-          delete this._wreqrHandlers[name];
-        },
-        // Remove all handlers from this registry
-        removeAllHandlers: function() {
-          this._wreqrHandlers = {};
-        }
-      });
-      return Handlers;
-    }(Backbone, _);
-    // Wreqr.CommandStorage
-    // --------------------
-    //
-    // Store and retrieve commands for execution.
-    Wreqr.CommandStorage = function() {
-      "use strict";
-      // Constructor function
-      var CommandStorage = function(options) {
-        this.options = options;
-        this._commands = {};
-        if (_.isFunction(this.initialize)) {
-          this.initialize(options);
-        }
-      };
-      // Instance methods
-      _.extend(CommandStorage.prototype, Backbone.Events, {
-        // Get an object literal by command name, that contains
-        // the `commandName` and the `instances` of all commands
-        // represented as an array of arguments to process
-        getCommands: function(commandName) {
-          var commands = this._commands[commandName];
-          // we don't have it, so add it
-          if (!commands) {
-            // build the configuration
-            commands = {
-              command: commandName,
-              instances: []
-            };
-            // store it
-            this._commands[commandName] = commands;
-          }
-          return commands;
-        },
-        // Add a command by name, to the storage and store the
-        // args for the command
-        addCommand: function(commandName, args) {
-          var command = this.getCommands(commandName);
-          command.instances.push(args);
-        },
-        // Clear all commands for the given `commandName`
-        clearCommands: function(commandName) {
-          var command = this.getCommands(commandName);
-          command.instances = [];
-        }
-      });
-      return CommandStorage;
-    }();
-    // Wreqr.Commands
-    // --------------
-    //
-    // A simple command pattern implementation. Register a command
-    // handler and execute it.
-    Wreqr.Commands = function(Wreqr) {
-      "use strict";
-      return Wreqr.Handlers.extend({
-        // default storage type
-        storageType: Wreqr.CommandStorage,
-        constructor: function(options) {
-          this.options = options || {};
-          this._initializeStorage(this.options);
-          this.on("handler:add", this._executeCommands, this);
-          var args = Array.prototype.slice.call(arguments);
-          Wreqr.Handlers.prototype.constructor.apply(this, args);
-        },
-        // Execute a named command with the supplied args
-        execute: function(name, args) {
-          name = arguments[0];
-          args = Array.prototype.slice.call(arguments, 1);
-          if (this.hasHandler(name)) {
-            this.getHandler(name).apply(this, args);
-          } else {
-            this.storage.addCommand(name, args);
-          }
-        },
-        // Internal method to handle bulk execution of stored commands
-        _executeCommands: function(name, handler, context) {
-          var command = this.storage.getCommands(name);
-          // loop through and execute all the stored command instances
-          _.each(command.instances, function(args) {
-            handler.apply(context, args);
-          });
-          this.storage.clearCommands(name);
-        },
-        // Internal method to initialize storage either from the type's
-        // `storageType` or the instance `options.storageType`.
-        _initializeStorage: function(options) {
-          var storage;
-          var StorageType = options.storageType || this.storageType;
-          if (_.isFunction(StorageType)) {
-            storage = new StorageType();
-          } else {
-            storage = StorageType;
-          }
-          this.storage = storage;
-        }
-      });
-    }(Wreqr);
-    // Wreqr.RequestResponse
-    // ---------------------
-    //
-    // A simple request/response implementation. Register a
-    // request handler, and return a response from it
-    Wreqr.RequestResponse = function(Wreqr) {
-      "use strict";
-      return Wreqr.Handlers.extend({
-        request: function() {
-          var name = arguments[0];
-          var args = Array.prototype.slice.call(arguments, 1);
-          if (this.hasHandler(name)) {
-            return this.getHandler(name).apply(this, args);
-          }
-        }
-      });
-    }(Wreqr);
-    // Event Aggregator
-    // ----------------
-    // A pub-sub object that can be used to decouple various parts
-    // of an application through event-driven architecture.
-    Wreqr.EventAggregator = function(Backbone, _) {
-      "use strict";
-      var EA = function() {};
-      // Copy the `extend` function used by Backbone's classes
-      EA.extend = Backbone.Model.extend;
-      // Copy the basic Backbone.Events on to the event aggregator
-      _.extend(EA.prototype, Backbone.Events);
-      return EA;
-    }(Backbone, _);
-    // Wreqr.Channel
-    // --------------
-    //
-    // An object that wraps the three messaging systems:
-    // EventAggregator, RequestResponse, Commands
-    Wreqr.Channel = function(Wreqr) {
-      "use strict";
-      var Channel = function(channelName) {
-        this.vent = new Backbone.Wreqr.EventAggregator();
-        this.reqres = new Backbone.Wreqr.RequestResponse();
-        this.commands = new Backbone.Wreqr.Commands();
-        this.channelName = channelName;
-      };
-      _.extend(Channel.prototype, {
-        // Remove all handlers from the messaging systems of this channel
-        reset: function() {
-          this.vent.off();
-          this.vent.stopListening();
-          this.reqres.removeAllHandlers();
-          this.commands.removeAllHandlers();
-          return this;
-        },
-        // Connect a hash of events; one for each messaging system
-        connectEvents: function(hash, context) {
-          this._connect("vent", hash, context);
-          return this;
-        },
-        connectCommands: function(hash, context) {
-          this._connect("commands", hash, context);
-          return this;
-        },
-        connectRequests: function(hash, context) {
-          this._connect("reqres", hash, context);
-          return this;
-        },
-        // Attach the handlers to a given message system `type`
-        _connect: function(type, hash, context) {
-          if (!hash) {
-            return;
-          }
-          context = context || this;
-          var method = type === "vent" ? "on" : "setHandler";
-          _.each(hash, function(fn, eventName) {
-            this[type][method](eventName, _.bind(fn, context));
-          }, this);
-        }
-      });
-      return Channel;
-    }(Wreqr);
-    // Wreqr.Radio
-    // --------------
-    //
-    // An object that lets you communicate with many channels.
-    Wreqr.radio = function(Wreqr) {
-      "use strict";
-      var Radio = function() {
-        this._channels = {};
-        this.vent = {};
-        this.commands = {};
-        this.reqres = {};
-        this._proxyMethods();
-      };
-      _.extend(Radio.prototype, {
-        channel: function(channelName) {
-          if (!channelName) {
-            throw new Error("Channel must receive a name");
-          }
-          return this._getChannel(channelName);
-        },
-        _getChannel: function(channelName) {
-          var channel = this._channels[channelName];
-          if (!channel) {
-            channel = new Wreqr.Channel(channelName);
-            this._channels[channelName] = channel;
-          }
-          return channel;
-        },
-        _proxyMethods: function() {
-          _.each([ "vent", "commands", "reqres" ], function(system) {
-            _.each(messageSystems[system], function(method) {
-              this[system][method] = proxyMethod(this, system, method);
-            }, this);
-          }, this);
-        }
-      });
-      var messageSystems = {
-        vent: [ "on", "off", "trigger", "once", "stopListening", "listenTo", "listenToOnce" ],
-        commands: [ "execute", "setHandler", "setHandlers", "removeHandler", "removeAllHandlers" ],
-        reqres: [ "request", "setHandler", "setHandlers", "removeHandler", "removeAllHandlers" ]
-      };
-      var proxyMethod = function(radio, system, method) {
-        return function(channelName) {
-          var messageSystem = radio._getChannel(channelName)[system];
-          var args = Array.prototype.slice.call(arguments, 1);
-          return messageSystem[method].apply(messageSystem, args);
-        };
-      };
-      return new Radio();
-    }(Wreqr);
-    return Backbone.Wreqr;
-  })(Backbone, _);
+	};
 
-  var previousMarionette = root.Marionette;
-  var previousMn = root.Mn;
+	var ClassOptions = ['channelName', 'radioEvents', 'radioRequests'];
 
-  var Marionette = Backbone.Marionette = {};
+	// A Base Class that other Classes should descend from.
+	// Object borrows many conventions and utilities from Backbone.
+	var MarionetteObject = function MarionetteObject(options) {
+	  this._setOptions(options);
+	  this.mergeOptions(options, ClassOptions);
+	  this.cid = _.uniqueId(this.cidPrefix);
+	  this._initRadio();
+	  this.initialize.apply(this, arguments);
+	};
 
-  Marionette.VERSION = '2.4.1';
+	MarionetteObject.extend = extend;
 
-  Marionette.noConflict = function() {
-    root.Marionette = previousMarionette;
-    root.Mn = previousMn;
-    return this;
-  };
+	// Object Methods
+	// --------------
 
-  Backbone.Marionette = Marionette;
+	// Ensure it can trigger events with Backbone.Events
+	_.extend(MarionetteObject.prototype, Backbone.Events, CommonMixin, RadioMixin, {
+	  cidPrefix: 'mno',
 
-  // Get the Deferred creator for later use
-  Marionette.Deferred = Backbone.$.Deferred;
+	  // for parity with Marionette.AbstractView lifecyle
+	  _isDestroyed: false,
 
-  /* jshint unused: false *//* global console */
-  
-  // Helpers
-  // -------
-  
-  // Marionette.extend
-  // -----------------
-  
-  // Borrow the Backbone `extend` method so we can use it as needed
-  Marionette.extend = Backbone.Model.extend;
-  
-  // Marionette.isNodeAttached
-  // -------------------------
-  
-  // Determine if `el` is a child of the document
-  Marionette.isNodeAttached = function(el) {
-    return Backbone.$.contains(document.documentElement, el);
-  };
-  
-  // Merge `keys` from `options` onto `this`
-  Marionette.mergeOptions = function(options, keys) {
-    if (!options) { return; }
-    _.extend(this, _.pick(options, keys));
-  };
-  
-  // Marionette.getOption
-  // --------------------
-  
-  // Retrieve an object, function or other value from a target
-  // object or its `options`, with `options` taking precedence.
-  Marionette.getOption = function(target, optionName) {
-    if (!target || !optionName) { return; }
-    if (target.options && (target.options[optionName] !== undefined)) {
-      return target.options[optionName];
-    } else {
-      return target[optionName];
-    }
-  };
-  
-  // Proxy `Marionette.getOption`
-  Marionette.proxyGetOption = function(optionName) {
-    return Marionette.getOption(this, optionName);
-  };
-  
-  // Similar to `_.result`, this is a simple helper
-  // If a function is provided we call it with context
-  // otherwise just return the value. If the value is
-  // undefined return a default value
-  Marionette._getValue = function(value, context, params) {
-    if (_.isFunction(value)) {
-      value = params ? value.apply(context, params) : value.call(context);
-    }
-    return value;
-  };
-  
-  // Marionette.normalizeMethods
-  // ----------------------
-  
-  // Pass in a mapping of events => functions or function names
-  // and return a mapping of events => functions
-  Marionette.normalizeMethods = function(hash) {
-    return _.reduce(hash, function(normalizedHash, method, name) {
-      if (!_.isFunction(method)) {
-        method = this[method];
-      }
-      if (method) {
-        normalizedHash[name] = method;
-      }
-      return normalizedHash;
-    }, {}, this);
-  };
-  
-  // utility method for parsing @ui. syntax strings
-  // into associated selector
-  Marionette.normalizeUIString = function(uiString, ui) {
-    return uiString.replace(/@ui\.[a-zA-Z_$0-9]*/g, function(r) {
-      return ui[r.slice(4)];
-    });
-  };
-  
-  // allows for the use of the @ui. syntax within
-  // a given key for triggers and events
-  // swaps the @ui with the associated selector.
-  // Returns a new, non-mutated, parsed events hash.
-  Marionette.normalizeUIKeys = function(hash, ui) {
-    return _.reduce(hash, function(memo, val, key) {
-      var normalizedKey = Marionette.normalizeUIString(key, ui);
-      memo[normalizedKey] = val;
-      return memo;
-    }, {});
-  };
-  
-  // allows for the use of the @ui. syntax within
-  // a given value for regions
-  // swaps the @ui with the associated selector
-  Marionette.normalizeUIValues = function(hash, ui, properties) {
-    _.each(hash, function(val, key) {
-      if (_.isString(val)) {
-        hash[key] = Marionette.normalizeUIString(val, ui);
-      } else if (_.isObject(val) && _.isArray(properties)) {
-        _.extend(val, Marionette.normalizeUIValues(_.pick(val, properties), ui));
-        /* Value is an object, and we got an array of embedded property names to normalize. */
-        _.each(properties, function(property) {
-          var propertyVal = val[property];
-          if (_.isString(propertyVal)) {
-            val[property] = Marionette.normalizeUIString(propertyVal, ui);
-          }
-        });
-      }
-    });
-    return hash;
-  };
-  
-  // Mix in methods from Underscore, for iteration, and other
-  // collection related features.
-  // Borrowing this code from Backbone.Collection:
-  // http://backbonejs.org/docs/backbone.html#section-121
-  Marionette.actAsCollection = function(object, listProperty) {
-    var methods = ['forEach', 'each', 'map', 'find', 'detect', 'filter',
-      'select', 'reject', 'every', 'all', 'some', 'any', 'include',
-      'contains', 'invoke', 'toArray', 'first', 'initial', 'rest',
-      'last', 'without', 'isEmpty', 'pluck'];
-  
-    _.each(methods, function(method) {
-      object[method] = function() {
-        var list = _.values(_.result(this, listProperty));
-        var args = [list].concat(_.toArray(arguments));
-        return _[method].apply(_, args);
-      };
-    });
-  };
-  
-  var deprecate = Marionette.deprecate = function(message, test) {
-    if (_.isObject(message)) {
-      message = (
-        message.prev + ' is going to be removed in the future. ' +
-        'Please use ' + message.next + ' instead.' +
-        (message.url ? ' See: ' + message.url : '')
-      );
-    }
-  
-    if ((test === undefined || !test) && !deprecate._cache[message]) {
-      deprecate._warn('Deprecation warning: ' + message);
-      deprecate._cache[message] = true;
-    }
-  };
-  
-  deprecate._warn = typeof console !== 'undefined' && (console.warn || console.log) || function() {};
-  deprecate._cache = {};
-  
-  /* jshint maxstatements: 14, maxcomplexity: 7 */
-  
-  // Trigger Method
-  // --------------
-  
-  Marionette._triggerMethod = (function() {
-    // split the event name on the ":"
-    var splitter = /(^|:)(\w)/gi;
-  
-    // take the event section ("section1:section2:section3")
-    // and turn it in to uppercase name
-    function getEventName(match, prefix, eventName) {
-      return eventName.toUpperCase();
-    }
-  
-    return function(context, event, args) {
-      var noEventArg = arguments.length < 3;
-      if (noEventArg) {
-        args = event;
-        event = args[0];
-      }
-  
-      // get the method name from the event name
-      var methodName = 'on' + event.replace(splitter, getEventName);
-      var method = context[methodName];
-      var result;
-  
-      // call the onMethodName if it exists
-      if (_.isFunction(method)) {
-        // pass all args, except the event name
-        result = method.apply(context, noEventArg ? _.rest(args) : args);
-      }
-  
-      // trigger the event, if a trigger method exists
-      if (_.isFunction(context.trigger)) {
-        if (noEventArg + args.length > 1) {
-          context.trigger.apply(context, noEventArg ? args : [event].concat(_.drop(args, 0)));
-        } else {
-          context.trigger(event);
-        }
-      }
-  
-      return result;
-    };
-  })();
-  
-  // Trigger an event and/or a corresponding method name. Examples:
-  //
-  // `this.triggerMethod("foo")` will trigger the "foo" event and
-  // call the "onFoo" method.
-  //
-  // `this.triggerMethod("foo:bar")` will trigger the "foo:bar" event and
-  // call the "onFooBar" method.
-  Marionette.triggerMethod = function(event) {
-    return Marionette._triggerMethod(this, arguments);
-  };
-  
-  // triggerMethodOn invokes triggerMethod on a specific context
-  //
-  // e.g. `Marionette.triggerMethodOn(view, 'show')`
-  // will trigger a "show" event or invoke onShow the view.
-  Marionette.triggerMethodOn = function(context) {
-    var fnc = _.isFunction(context.triggerMethod) ?
-                  context.triggerMethod :
-                  Marionette.triggerMethod;
-  
-    return fnc.apply(context, _.rest(arguments));
-  };
-  
-  // DOM Refresh
-  // -----------
-  
-  // Monitor a view's state, and after it has been rendered and shown
-  // in the DOM, trigger a "dom:refresh" event every time it is
-  // re-rendered.
-  
-  Marionette.MonitorDOMRefresh = function(view) {
-  
-    // track when the view has been shown in the DOM,
-    // using a Marionette.Region (or by other means of triggering "show")
-    function handleShow() {
-      view._isShown = true;
-      triggerDOMRefresh();
-    }
-  
-    // track when the view has been rendered
-    function handleRender() {
-      view._isRendered = true;
-      triggerDOMRefresh();
-    }
-  
-    // Trigger the "dom:refresh" event and corresponding "onDomRefresh" method
-    function triggerDOMRefresh() {
-      if (view._isShown && view._isRendered && Marionette.isNodeAttached(view.el)) {
-        if (_.isFunction(view.triggerMethod)) {
-          view.triggerMethod('dom:refresh');
-        }
-      }
-    }
-  
-    view.on({
-      show: handleShow,
-      render: handleRender
-    });
-  };
-  
-  /* jshint maxparams: 5 */
-  
-  // Bind Entity Events & Unbind Entity Events
-  // -----------------------------------------
-  //
-  // These methods are used to bind/unbind a backbone "entity" (e.g. collection/model)
-  // to methods on a target object.
-  //
-  // The first parameter, `target`, must have the Backbone.Events module mixed in.
-  //
-  // The second parameter is the `entity` (Backbone.Model, Backbone.Collection or
-  // any object that has Backbone.Events mixed in) to bind the events from.
-  //
-  // The third parameter is a hash of { "event:name": "eventHandler" }
-  // configuration. Multiple handlers can be separated by a space. A
-  // function can be supplied instead of a string handler name.
-  
-  (function(Marionette) {
-    'use strict';
-  
-    // Bind the event to handlers specified as a string of
-    // handler names on the target object
-    function bindFromStrings(target, entity, evt, methods) {
-      var methodNames = methods.split(/\s+/);
-  
-      _.each(methodNames, function(methodName) {
-  
-        var method = target[methodName];
-        if (!method) {
-          throw new Marionette.Error('Method "' + methodName +
-            '" was configured as an event handler, but does not exist.');
-        }
-  
-        target.listenTo(entity, evt, method);
-      });
-    }
-  
-    // Bind the event to a supplied callback function
-    function bindToFunction(target, entity, evt, method) {
-      target.listenTo(entity, evt, method);
-    }
-  
-    // Bind the event to handlers specified as a string of
-    // handler names on the target object
-    function unbindFromStrings(target, entity, evt, methods) {
-      var methodNames = methods.split(/\s+/);
-  
-      _.each(methodNames, function(methodName) {
-        var method = target[methodName];
-        target.stopListening(entity, evt, method);
-      });
-    }
-  
-    // Bind the event to a supplied callback function
-    function unbindToFunction(target, entity, evt, method) {
-      target.stopListening(entity, evt, method);
-    }
-  
-    // generic looping function
-    function iterateEvents(target, entity, bindings, functionCallback, stringCallback) {
-      if (!entity || !bindings) { return; }
-  
-      // type-check bindings
-      if (!_.isObject(bindings)) {
-        throw new Marionette.Error({
-          message: 'Bindings must be an object or function.',
-          url: 'marionette.functions.html#marionettebindentityevents'
-        });
-      }
-  
-      // allow the bindings to be a function
-      bindings = Marionette._getValue(bindings, target);
-  
-      // iterate the bindings and bind them
-      _.each(bindings, function(methods, evt) {
-  
-        // allow for a function as the handler,
-        // or a list of event names as a string
-        if (_.isFunction(methods)) {
-          functionCallback(target, entity, evt, methods);
-        } else {
-          stringCallback(target, entity, evt, methods);
-        }
-  
-      });
-    }
-  
-    // Export Public API
-    Marionette.bindEntityEvents = function(target, entity, bindings) {
-      iterateEvents(target, entity, bindings, bindToFunction, bindFromStrings);
-    };
-  
-    Marionette.unbindEntityEvents = function(target, entity, bindings) {
-      iterateEvents(target, entity, bindings, unbindToFunction, unbindFromStrings);
-    };
-  
-    // Proxy `bindEntityEvents`
-    Marionette.proxyBindEntityEvents = function(entity, bindings) {
-      return Marionette.bindEntityEvents(this, entity, bindings);
-    };
-  
-    // Proxy `unbindEntityEvents`
-    Marionette.proxyUnbindEntityEvents = function(entity, bindings) {
-      return Marionette.unbindEntityEvents(this, entity, bindings);
-    };
-  })(Marionette);
-  
+	  isDestroyed: function isDestroyed() {
+	    return this._isDestroyed;
+	  },
 
-  // Error
-  // -----
-  
-  var errorProps = ['description', 'fileName', 'lineNumber', 'name', 'message', 'number'];
-  
-  Marionette.Error = Marionette.extend.call(Error, {
-    urlRoot: 'http://marionettejs.com/docs/v' + Marionette.VERSION + '/',
-  
-    constructor: function(message, options) {
-      if (_.isObject(message)) {
-        options = message;
-        message = options.message;
-      } else if (!options) {
-        options = {};
-      }
-  
-      var error = Error.call(this, message);
-      _.extend(this, _.pick(error, errorProps), _.pick(options, errorProps));
-  
-      this.captureStackTrace();
-  
-      if (options.url) {
-        this.url = this.urlRoot + options.url;
-      }
-    },
-  
-    captureStackTrace: function() {
-      if (Error.captureStackTrace) {
-        Error.captureStackTrace(this, Marionette.Error);
-      }
-    },
-  
-    toString: function() {
-      return this.name + ': ' + this.message + (this.url ? ' See: ' + this.url : '');
-    }
-  });
-  
-  Marionette.Error.extend = Marionette.extend;
-  
-  // Callbacks
-  // ---------
-  
-  // A simple way of managing a collection of callbacks
-  // and executing them at a later point in time, using jQuery's
-  // `Deferred` object.
-  Marionette.Callbacks = function() {
-    this._deferred = Marionette.Deferred();
-    this._callbacks = [];
-  };
-  
-  _.extend(Marionette.Callbacks.prototype, {
-  
-    // Add a callback to be executed. Callbacks added here are
-    // guaranteed to execute, even if they are added after the
-    // `run` method is called.
-    add: function(callback, contextOverride) {
-      var promise = _.result(this._deferred, 'promise');
-  
-      this._callbacks.push({cb: callback, ctx: contextOverride});
-  
-      promise.then(function(args) {
-        if (contextOverride) { args.context = contextOverride; }
-        callback.call(args.context, args.options);
-      });
-    },
-  
-    // Run all registered callbacks with the context specified.
-    // Additional callbacks can be added after this has been run
-    // and they will still be executed.
-    run: function(options, context) {
-      this._deferred.resolve({
-        options: options,
-        context: context
-      });
-    },
-  
-    // Resets the list of callbacks to be run, allowing the same list
-    // to be run multiple times - whenever the `run` method is called.
-    reset: function() {
-      var callbacks = this._callbacks;
-      this._deferred = Marionette.Deferred();
-      this._callbacks = [];
-  
-      _.each(callbacks, function(cb) {
-        this.add(cb.cb, cb.ctx);
-      }, this);
-    }
-  });
-  
-  // Controller
-  // ----------
-  
-  // A multi-purpose object to use as a controller for
-  // modules and routers, and as a mediator for workflow
-  // and coordination of other objects, views, and more.
-  Marionette.Controller = function(options) {
-    this.options = options || {};
-  
-    if (_.isFunction(this.initialize)) {
-      this.initialize(this.options);
-    }
-  };
-  
-  Marionette.Controller.extend = Marionette.extend;
-  
-  // Controller Methods
-  // --------------
-  
-  // Ensure it can trigger events with Backbone.Events
-  _.extend(Marionette.Controller.prototype, Backbone.Events, {
-    destroy: function() {
-      Marionette._triggerMethod(this, 'before:destroy', arguments);
-      Marionette._triggerMethod(this, 'destroy', arguments);
-  
-      this.stopListening();
-      this.off();
-      return this;
-    },
-  
-    // import the `triggerMethod` to trigger events with corresponding
-    // methods if the method exists
-    triggerMethod: Marionette.triggerMethod,
-  
-    // A handy way to merge options onto the instance
-    mergeOptions: Marionette.mergeOptions,
-  
-    // Proxy `getOption` to enable getting options from this or this.options by name.
-    getOption: Marionette.proxyGetOption
-  
-  });
-  
-  // Object
-  // ------
-  
-  // A Base Class that other Classes should descend from.
-  // Object borrows many conventions and utilities from Backbone.
-  Marionette.Object = function(options) {
-    this.options = _.extend({}, _.result(this, 'options'), options);
-  
-    this.initialize.apply(this, arguments);
-  };
-  
-  Marionette.Object.extend = Marionette.extend;
-  
-  // Object Methods
-  // --------------
-  
-  // Ensure it can trigger events with Backbone.Events
-  _.extend(Marionette.Object.prototype, Backbone.Events, {
-  
-    //this is a noop method intended to be overridden by classes that extend from this base
-    initialize: function() {},
-  
-    destroy: function() {
-      this.triggerMethod('before:destroy');
-      this.triggerMethod('destroy');
-      this.stopListening();
-  
-      return this;
-    },
-  
-    // Import the `triggerMethod` to trigger events with corresponding
-    // methods if the method exists
-    triggerMethod: Marionette.triggerMethod,
-  
-    // A handy way to merge options onto the instance
-    mergeOptions: Marionette.mergeOptions,
-  
-    // Proxy `getOption` to enable getting options from this or this.options by name.
-    getOption: Marionette.proxyGetOption,
-  
-    // Proxy `bindEntityEvents` to enable binding view's events from another entity.
-    bindEntityEvents: Marionette.proxyBindEntityEvents,
-  
-    // Proxy `unbindEntityEvents` to enable unbinding view's events from another entity.
-    unbindEntityEvents: Marionette.proxyUnbindEntityEvents
-  });
-  
-  /* jshint maxcomplexity: 16, maxstatements: 45, maxlen: 120 */
-  
-  // Region
-  // ------
-  
-  // Manage the visual regions of your composite application. See
-  // http://lostechies.com/derickbailey/2011/12/12/composite-js-apps-regions-and-region-managers/
-  
-  Marionette.Region = Marionette.Object.extend({
-    constructor: function(options) {
-  
-      // set options temporarily so that we can get `el`.
-      // options will be overriden by Object.constructor
-      this.options = options || {};
-      this.el = this.getOption('el');
-  
-      // Handle when this.el is passed in as a $ wrapped element.
-      this.el = this.el instanceof Backbone.$ ? this.el[0] : this.el;
-  
-      if (!this.el) {
-        throw new Marionette.Error({
-          name: 'NoElError',
-          message: 'An "el" must be specified for a region.'
-        });
-      }
-  
-      this.$el = this.getEl(this.el);
-      Marionette.Object.call(this, options);
-    },
-  
-    // Displays a backbone view instance inside of the region.
-    // Handles calling the `render` method for you. Reads content
-    // directly from the `el` attribute. Also calls an optional
-    // `onShow` and `onDestroy` method on your view, just after showing
-    // or just before destroying the view, respectively.
-    // The `preventDestroy` option can be used to prevent a view from
-    // the old view being destroyed on show.
-    // The `forceShow` option can be used to force a view to be
-    // re-rendered if it's already shown in the region.
-    show: function(view, options) {
-      if (!this._ensureElement()) {
-        return;
-      }
-  
-      this._ensureViewIsIntact(view);
-  
-      var showOptions     = options || {};
-      var isDifferentView = view !== this.currentView;
-      var preventDestroy  = !!showOptions.preventDestroy;
-      var forceShow       = !!showOptions.forceShow;
-  
-      // We are only changing the view if there is a current view to change to begin with
-      var isChangingView = !!this.currentView;
-  
-      // Only destroy the current view if we don't want to `preventDestroy` and if
-      // the view given in the first argument is different than `currentView`
-      var _shouldDestroyView = isDifferentView && !preventDestroy;
-  
-      // Only show the view given in the first argument if it is different than
-      // the current view or if we want to re-show the view. Note that if
-      // `_shouldDestroyView` is true, then `_shouldShowView` is also necessarily true.
-      var _shouldShowView = isDifferentView || forceShow;
-  
-      if (isChangingView) {
-        this.triggerMethod('before:swapOut', this.currentView, this, options);
-      }
-  
-      if (this.currentView) {
-        delete this.currentView._parent;
-      }
-  
-      if (_shouldDestroyView) {
-        this.empty();
-  
-      // A `destroy` event is attached to the clean up manually removed views.
-      // We need to detach this event when a new view is going to be shown as it
-      // is no longer relevant.
-      } else if (isChangingView && _shouldShowView) {
-        this.currentView.off('destroy', this.empty, this);
-      }
-  
-      if (_shouldShowView) {
-  
-        // We need to listen for if a view is destroyed
-        // in a way other than through the region.
-        // If this happens we need to remove the reference
-        // to the currentView since once a view has been destroyed
-        // we can not reuse it.
-        view.once('destroy', this.empty, this);
-        view.render();
-  
-        view._parent = this;
-  
-        if (isChangingView) {
-          this.triggerMethod('before:swap', view, this, options);
-        }
-  
-        this.triggerMethod('before:show', view, this, options);
-        Marionette.triggerMethodOn(view, 'before:show', view, this, options);
-  
-        if (isChangingView) {
-          this.triggerMethod('swapOut', this.currentView, this, options);
-        }
-  
-        // An array of views that we're about to display
-        var attachedRegion = Marionette.isNodeAttached(this.el);
-  
-        // The views that we're about to attach to the document
-        // It's important that we prevent _getNestedViews from being executed unnecessarily
-        // as it's a potentially-slow method
-        var displayedViews = [];
-  
-        var triggerBeforeAttach = showOptions.triggerBeforeAttach || this.triggerBeforeAttach;
-        var triggerAttach = showOptions.triggerAttach || this.triggerAttach;
-  
-        if (attachedRegion && triggerBeforeAttach) {
-          displayedViews = this._displayedViews(view);
-          this._triggerAttach(displayedViews, 'before:');
-        }
-  
-        this.attachHtml(view);
-        this.currentView = view;
-  
-        if (attachedRegion && triggerAttach) {
-          displayedViews = this._displayedViews(view);
-          this._triggerAttach(displayedViews);
-        }
-  
-        if (isChangingView) {
-          this.triggerMethod('swap', view, this, options);
-        }
-  
-        this.triggerMethod('show', view, this, options);
-        Marionette.triggerMethodOn(view, 'show', view, this, options);
-  
-        return this;
-      }
-  
-      return this;
-    },
-  
-    triggerBeforeAttach: true,
-    triggerAttach: true,
-  
-    _triggerAttach: function(views, prefix) {
-      var eventName = (prefix || '') + 'attach';
-      _.each(views, function(view) {
-        Marionette.triggerMethodOn(view, eventName, view, this);
-      }, this);
-    },
-  
-    _displayedViews: function(view) {
-      return _.union([view], _.result(view, '_getNestedViews') || []);
-    },
-  
-    _ensureElement: function() {
-      if (!_.isObject(this.el)) {
-        this.$el = this.getEl(this.el);
-        this.el = this.$el[0];
-      }
-  
-      if (!this.$el || this.$el.length === 0) {
-        if (this.getOption('allowMissingEl')) {
-          return false;
-        } else {
-          throw new Marionette.Error('An "el" ' + this.$el.selector + ' must exist in DOM');
-        }
-      }
-      return true;
-    },
-  
-    _ensureViewIsIntact: function(view) {
-      if (!view) {
-        throw new Marionette.Error({
-          name: 'ViewNotValid',
-          message: 'The view passed is undefined and therefore invalid. You must pass a view instance to show.'
-        });
-      }
-  
-      if (view.isDestroyed) {
-        throw new Marionette.Error({
-          name: 'ViewDestroyedError',
-          message: 'View (cid: "' + view.cid + '") has already been destroyed and cannot be used.'
-        });
-      }
-    },
-  
-    // Override this method to change how the region finds the DOM
-    // element that it manages. Return a jQuery selector object scoped
-    // to a provided parent el or the document if none exists.
-    getEl: function(el) {
-      return Backbone.$(el, Marionette._getValue(this.options.parentEl, this));
-    },
-  
-    // Override this method to change how the new view is
-    // appended to the `$el` that the region is managing
-    attachHtml: function(view) {
-      this.$el.contents().detach();
-  
-      this.el.appendChild(view.el);
-    },
-  
-    // Destroy the current view, if there is one. If there is no
-    // current view, it does nothing and returns immediately.
-    empty: function(options) {
-      var view = this.currentView;
-  
-      var preventDestroy = Marionette._getValue(options, 'preventDestroy', this);
-      // If there is no view in the region
-      // we should not remove anything
-      if (!view) { return; }
-  
-      view.off('destroy', this.empty, this);
-      this.triggerMethod('before:empty', view);
-      if (!preventDestroy) {
-        this._destroyView();
-      }
-      this.triggerMethod('empty', view);
-  
-      // Remove region pointer to the currentView
-      delete this.currentView;
-  
-      if (preventDestroy) {
-        this.$el.contents().detach();
-      }
-  
-      return this;
-    },
-  
-    // call 'destroy' or 'remove', depending on which is found
-    // on the view (if showing a raw Backbone view or a Marionette View)
-    _destroyView: function() {
-      var view = this.currentView;
-  
-      if (view.destroy && !view.isDestroyed) {
-        view.destroy();
-      } else if (view.remove) {
-        view.remove();
-  
-        // appending isDestroyed to raw Backbone View allows regions
-        // to throw a ViewDestroyedError for this view
-        view.isDestroyed = true;
-      }
-    },
-  
-    // Attach an existing view to the region. This
-    // will not call `render` or `onShow` for the new view,
-    // and will not replace the current HTML for the `el`
-    // of the region.
-    attachView: function(view) {
-      this.currentView = view;
-      return this;
-    },
-  
-    // Checks whether a view is currently present within
-    // the region. Returns `true` if there is and `false` if
-    // no view is present.
-    hasView: function() {
-      return !!this.currentView;
-    },
-  
-    // Reset the region by destroying any existing view and
-    // clearing out the cached `$el`. The next time a view
-    // is shown via this region, the region will re-query the
-    // DOM for the region's `el`.
-    reset: function() {
-      this.empty();
-  
-      if (this.$el) {
-        this.el = this.$el.selector;
-      }
-  
-      delete this.$el;
-      return this;
-    }
-  
-  },
-  
-  // Static Methods
-  {
-  
-    // Build an instance of a region by passing in a configuration object
-    // and a default region class to use if none is specified in the config.
-    //
-    // The config object should either be a string as a jQuery DOM selector,
-    // a Region class directly, or an object literal that specifies a selector,
-    // a custom regionClass, and any options to be supplied to the region:
-    //
-    // ```js
-    // {
-    //   selector: "#foo",
-    //   regionClass: MyCustomRegion,
-    //   allowMissingEl: false
-    // }
-    // ```
-    //
-    buildRegion: function(regionConfig, DefaultRegionClass) {
-      if (_.isString(regionConfig)) {
-        return this._buildRegionFromSelector(regionConfig, DefaultRegionClass);
-      }
-  
-      if (regionConfig.selector || regionConfig.el || regionConfig.regionClass) {
-        return this._buildRegionFromObject(regionConfig, DefaultRegionClass);
-      }
-  
-      if (_.isFunction(regionConfig)) {
-        return this._buildRegionFromRegionClass(regionConfig);
-      }
-  
-      throw new Marionette.Error({
-        message: 'Improper region configuration type.',
-        url: 'marionette.region.html#region-configuration-types'
-      });
-    },
-  
-    // Build the region from a string selector like '#foo-region'
-    _buildRegionFromSelector: function(selector, DefaultRegionClass) {
-      return new DefaultRegionClass({el: selector});
-    },
-  
-    // Build the region from a configuration object
-    // ```js
-    // { selector: '#foo', regionClass: FooRegion, allowMissingEl: false }
-    // ```
-    _buildRegionFromObject: function(regionConfig, DefaultRegionClass) {
-      var RegionClass = regionConfig.regionClass || DefaultRegionClass;
-      var options = _.omit(regionConfig, 'selector', 'regionClass');
-  
-      if (regionConfig.selector && !options.el) {
-        options.el = regionConfig.selector;
-      }
-  
-      return new RegionClass(options);
-    },
-  
-    // Build the region directly from a given `RegionClass`
-    _buildRegionFromRegionClass: function(RegionClass) {
-      return new RegionClass();
-    }
-  });
-  
-  // Region Manager
-  // --------------
-  
-  // Manage one or more related `Marionette.Region` objects.
-  Marionette.RegionManager = Marionette.Controller.extend({
-    constructor: function(options) {
-      this._regions = {};
-      this.length = 0;
-  
-      Marionette.Controller.call(this, options);
-  
-      this.addRegions(this.getOption('regions'));
-    },
-  
-    // Add multiple regions using an object literal or a
-    // function that returns an object literal, where
-    // each key becomes the region name, and each value is
-    // the region definition.
-    addRegions: function(regionDefinitions, defaults) {
-      regionDefinitions = Marionette._getValue(regionDefinitions, this, arguments);
-  
-      return _.reduce(regionDefinitions, function(regions, definition, name) {
-        if (_.isString(definition)) {
-          definition = {selector: definition};
-        }
-        if (definition.selector) {
-          definition = _.defaults({}, definition, defaults);
-        }
-  
-        regions[name] = this.addRegion(name, definition);
-        return regions;
-      }, {}, this);
-    },
-  
-    // Add an individual region to the region manager,
-    // and return the region instance
-    addRegion: function(name, definition) {
-      var region;
-  
-      if (definition instanceof Marionette.Region) {
-        region = definition;
-      } else {
-        region = Marionette.Region.buildRegion(definition, Marionette.Region);
-      }
-  
-      this.triggerMethod('before:add:region', name, region);
-  
-      region._parent = this;
-      this._store(name, region);
-  
-      this.triggerMethod('add:region', name, region);
-      return region;
-    },
-  
-    // Get a region by name
-    get: function(name) {
-      return this._regions[name];
-    },
-  
-    // Gets all the regions contained within
-    // the `regionManager` instance.
-    getRegions: function() {
-      return _.clone(this._regions);
-    },
-  
-    // Remove a region by name
-    removeRegion: function(name) {
-      var region = this._regions[name];
-      this._remove(name, region);
-  
-      return region;
-    },
-  
-    // Empty all regions in the region manager, and
-    // remove them
-    removeRegions: function() {
-      var regions = this.getRegions();
-      _.each(this._regions, function(region, name) {
-        this._remove(name, region);
-      }, this);
-  
-      return regions;
-    },
-  
-    // Empty all regions in the region manager, but
-    // leave them attached
-    emptyRegions: function() {
-      var regions = this.getRegions();
-      _.invoke(regions, 'empty');
-      return regions;
-    },
-  
-    // Destroy all regions and shut down the region
-    // manager entirely
-    destroy: function() {
-      this.removeRegions();
-      return Marionette.Controller.prototype.destroy.apply(this, arguments);
-    },
-  
-    // internal method to store regions
-    _store: function(name, region) {
-      if (!this._regions[name]) {
-        this.length++;
-      }
-  
-      this._regions[name] = region;
-    },
-  
-    // internal method to remove a region
-    _remove: function(name, region) {
-      this.triggerMethod('before:remove:region', name, region);
-      region.empty();
-      region.stopListening();
-  
-      delete region._parent;
-      delete this._regions[name];
-      this.length--;
-      this.triggerMethod('remove:region', name, region);
-    }
-  });
-  
-  Marionette.actAsCollection(Marionette.RegionManager.prototype, '_regions');
-  
 
-  // Template Cache
-  // --------------
-  
-  // Manage templates stored in `<script>` blocks,
-  // caching them for faster access.
-  Marionette.TemplateCache = function(templateId) {
-    this.templateId = templateId;
-  };
-  
-  // TemplateCache object-level methods. Manage the template
-  // caches from these method calls instead of creating
-  // your own TemplateCache instances
-  _.extend(Marionette.TemplateCache, {
-    templateCaches: {},
-  
-    // Get the specified template by id. Either
-    // retrieves the cached version, or loads it
-    // from the DOM.
-    get: function(templateId, options) {
-      var cachedTemplate = this.templateCaches[templateId];
-  
-      if (!cachedTemplate) {
-        cachedTemplate = new Marionette.TemplateCache(templateId);
-        this.templateCaches[templateId] = cachedTemplate;
-      }
-  
-      return cachedTemplate.load(options);
-    },
-  
-    // Clear templates from the cache. If no arguments
-    // are specified, clears all templates:
-    // `clear()`
-    //
-    // If arguments are specified, clears each of the
-    // specified templates from the cache:
-    // `clear("#t1", "#t2", "...")`
-    clear: function() {
-      var i;
-      var args = _.toArray(arguments);
-      var length = args.length;
-  
-      if (length > 0) {
-        for (i = 0; i < length; i++) {
-          delete this.templateCaches[args[i]];
-        }
-      } else {
-        this.templateCaches = {};
-      }
-    }
-  });
-  
-  // TemplateCache instance methods, allowing each
-  // template cache object to manage its own state
-  // and know whether or not it has been loaded
-  _.extend(Marionette.TemplateCache.prototype, {
-  
-    // Internal method to load the template
-    load: function(options) {
-      // Guard clause to prevent loading this template more than once
-      if (this.compiledTemplate) {
-        return this.compiledTemplate;
-      }
-  
-      // Load the template and compile it
-      var template = this.loadTemplate(this.templateId, options);
-      this.compiledTemplate = this.compileTemplate(template, options);
-  
-      return this.compiledTemplate;
-    },
-  
-    // Load a template from the DOM, by default. Override
-    // this method to provide your own template retrieval
-    // For asynchronous loading with AMD/RequireJS, consider
-    // using a template-loader plugin as described here:
-    // https://github.com/marionettejs/backbone.marionette/wiki/Using-marionette-with-requirejs
-    loadTemplate: function(templateId, options) {
-      var template = Backbone.$(templateId).html();
-  
-      if (!template || template.length === 0) {
-        throw new Marionette.Error({
-          name: 'NoTemplateError',
-          message: 'Could not find template: "' + templateId + '"'
-        });
-      }
-  
-      return template;
-    },
-  
-    // Pre-compile the template before caching it. Override
-    // this method if you do not need to pre-compile a template
-    // (JST / RequireJS for example) or if you want to change
-    // the template engine used (Handebars, etc).
-    compileTemplate: function(rawTemplate, options) {
-      return _.template(rawTemplate, options);
-    }
-  });
-  
-  // Renderer
-  // --------
-  
-  // Render a template with data by passing in the template
-  // selector and the data to render.
-  Marionette.Renderer = {
-  
-    // Render a template with data. The `template` parameter is
-    // passed to the `TemplateCache` object to retrieve the
-    // template function. Override this method to provide your own
-    // custom rendering and template handling for all of Marionette.
-    render: function(template, data) {
-      if (!template) {
-        throw new Marionette.Error({
-          name: 'TemplateNotFoundError',
-          message: 'Cannot render the template since its false, null or undefined.'
-        });
-      }
-  
-      var templateFunc = _.isFunction(template) ? template : Marionette.TemplateCache.get(template);
-  
-      return templateFunc(data);
-    }
-  };
-  
+	  //this is a noop method intended to be overridden by classes that extend from this base
+	  initialize: function initialize() {},
+	  destroy: function destroy() {
+	    if (this._isDestroyed) {
+	      return this;
+	    }
 
-  /* jshint maxlen: 114, nonew: false */
-  // View
-  // ----
-  
-  // The core view class that other Marionette views extend from.
-  Marionette.View = Backbone.View.extend({
-    isDestroyed: false,
-  
-    constructor: function(options) {
-      _.bindAll(this, 'render');
-  
-      options = Marionette._getValue(options, this);
-  
-      // this exposes view options to the view initializer
-      // this is a backfill since backbone removed the assignment
-      // of this.options
-      // at some point however this may be removed
-      this.options = _.extend({}, _.result(this, 'options'), options);
-  
-      this._behaviors = Marionette.Behaviors(this);
-  
-      Backbone.View.call(this, this.options);
-  
-      Marionette.MonitorDOMRefresh(this);
-    },
-  
-    // Get the template for this view
-    // instance. You can set a `template` attribute in the view
-    // definition or pass a `template: "whatever"` parameter in
-    // to the constructor options.
-    getTemplate: function() {
-      return this.getOption('template');
-    },
-  
-    // Serialize a model by returning its attributes. Clones
-    // the attributes to allow modification.
-    serializeModel: function(model) {
-      return model.toJSON.apply(model, _.rest(arguments));
-    },
-  
-    // Mix in template helper methods. Looks for a
-    // `templateHelpers` attribute, which can either be an
-    // object literal, or a function that returns an object
-    // literal. All methods and attributes from this object
-    // are copies to the object passed in.
-    mixinTemplateHelpers: function(target) {
-      target = target || {};
-      var templateHelpers = this.getOption('templateHelpers');
-      templateHelpers = Marionette._getValue(templateHelpers, this);
-      return _.extend(target, templateHelpers);
-    },
-  
-    // normalize the keys of passed hash with the views `ui` selectors.
-    // `{"@ui.foo": "bar"}`
-    normalizeUIKeys: function(hash) {
-      var uiBindings = _.result(this, '_uiBindings');
-      return Marionette.normalizeUIKeys(hash, uiBindings || _.result(this, 'ui'));
-    },
-  
-    // normalize the values of passed hash with the views `ui` selectors.
-    // `{foo: "@ui.bar"}`
-    normalizeUIValues: function(hash, properties) {
-      var ui = _.result(this, 'ui');
-      var uiBindings = _.result(this, '_uiBindings');
-      return Marionette.normalizeUIValues(hash, uiBindings || ui, properties);
-    },
-  
-    // Configure `triggers` to forward DOM events to view
-    // events. `triggers: {"click .foo": "do:foo"}`
-    configureTriggers: function() {
-      if (!this.triggers) { return; }
-  
-      // Allow `triggers` to be configured as a function
-      var triggers = this.normalizeUIKeys(_.result(this, 'triggers'));
-  
-      // Configure the triggers, prevent default
-      // action and stop propagation of DOM events
-      return _.reduce(triggers, function(events, value, key) {
-        events[key] = this._buildViewTrigger(value);
-        return events;
-      }, {}, this);
-    },
-  
-    // Overriding Backbone.View's delegateEvents to handle
-    // the `triggers`, `modelEvents`, and `collectionEvents` configuration
-    delegateEvents: function(events) {
-      this._delegateDOMEvents(events);
-      this.bindEntityEvents(this.model, this.getOption('modelEvents'));
-      this.bindEntityEvents(this.collection, this.getOption('collectionEvents'));
-  
-      _.each(this._behaviors, function(behavior) {
-        behavior.bindEntityEvents(this.model, behavior.getOption('modelEvents'));
-        behavior.bindEntityEvents(this.collection, behavior.getOption('collectionEvents'));
-      }, this);
-  
-      return this;
-    },
-  
-    // internal method to delegate DOM events and triggers
-    _delegateDOMEvents: function(eventsArg) {
-      var events = Marionette._getValue(eventsArg || this.events, this);
-  
-      // normalize ui keys
-      events = this.normalizeUIKeys(events);
-      if (_.isUndefined(eventsArg)) {this.events = events;}
-  
-      var combinedEvents = {};
-  
-      // look up if this view has behavior events
-      var behaviorEvents = _.result(this, 'behaviorEvents') || {};
-      var triggers = this.configureTriggers();
-      var behaviorTriggers = _.result(this, 'behaviorTriggers') || {};
-  
-      // behavior events will be overriden by view events and or triggers
-      _.extend(combinedEvents, behaviorEvents, events, triggers, behaviorTriggers);
-  
-      Backbone.View.prototype.delegateEvents.call(this, combinedEvents);
-    },
-  
-    // Overriding Backbone.View's undelegateEvents to handle unbinding
-    // the `triggers`, `modelEvents`, and `collectionEvents` config
-    undelegateEvents: function() {
-      Backbone.View.prototype.undelegateEvents.apply(this, arguments);
-  
-      this.unbindEntityEvents(this.model, this.getOption('modelEvents'));
-      this.unbindEntityEvents(this.collection, this.getOption('collectionEvents'));
-  
-      _.each(this._behaviors, function(behavior) {
-        behavior.unbindEntityEvents(this.model, behavior.getOption('modelEvents'));
-        behavior.unbindEntityEvents(this.collection, behavior.getOption('collectionEvents'));
-      }, this);
-  
-      return this;
-    },
-  
-    // Internal helper method to verify whether the view hasn't been destroyed
-    _ensureViewIsIntact: function() {
-      if (this.isDestroyed) {
-        throw new Marionette.Error({
-          name: 'ViewDestroyedError',
-          message: 'View (cid: "' + this.cid + '") has already been destroyed and cannot be used.'
-        });
-      }
-    },
-  
-    // Default `destroy` implementation, for removing a view from the
-    // DOM and unbinding it. Regions will call this method
-    // for you. You can specify an `onDestroy` method in your view to
-    // add custom code that is called after the view is destroyed.
-    destroy: function() {
-      if (this.isDestroyed) { return this; }
-  
-      var args = _.toArray(arguments);
-  
-      this.triggerMethod.apply(this, ['before:destroy'].concat(args));
-  
-      // mark as destroyed before doing the actual destroy, to
-      // prevent infinite loops within "destroy" event handlers
-      // that are trying to destroy other views
-      this.isDestroyed = true;
-      this.triggerMethod.apply(this, ['destroy'].concat(args));
-  
-      // unbind UI elements
-      this.unbindUIElements();
-  
-      this.isRendered = false;
-  
-      // remove the view from the DOM
-      this.remove();
-  
-      // Call destroy on each behavior after
-      // destroying the view.
-      // This unbinds event listeners
-      // that behaviors have registered for.
-      _.invoke(this._behaviors, 'destroy', args);
-  
-      return this;
-    },
-  
-    bindUIElements: function() {
-      this._bindUIElements();
-      _.invoke(this._behaviors, this._bindUIElements);
-    },
-  
-    // This method binds the elements specified in the "ui" hash inside the view's code with
-    // the associated jQuery selectors.
-    _bindUIElements: function() {
-      if (!this.ui) { return; }
-  
-      // store the ui hash in _uiBindings so they can be reset later
-      // and so re-rendering the view will be able to find the bindings
-      if (!this._uiBindings) {
-        this._uiBindings = this.ui;
-      }
-  
-      // get the bindings result, as a function or otherwise
-      var bindings = _.result(this, '_uiBindings');
-  
-      // empty the ui so we don't have anything to start with
-      this.ui = {};
-  
-      // bind each of the selectors
-      _.each(bindings, function(selector, key) {
-        this.ui[key] = this.$(selector);
-      }, this);
-    },
-  
-    // This method unbinds the elements specified in the "ui" hash
-    unbindUIElements: function() {
-      this._unbindUIElements();
-      _.invoke(this._behaviors, this._unbindUIElements);
-    },
-  
-    _unbindUIElements: function() {
-      if (!this.ui || !this._uiBindings) { return; }
-  
-      // delete all of the existing ui bindings
-      _.each(this.ui, function($el, name) {
-        delete this.ui[name];
-      }, this);
-  
-      // reset the ui element to the original bindings configuration
-      this.ui = this._uiBindings;
-      delete this._uiBindings;
-    },
-  
-    // Internal method to create an event handler for a given `triggerDef` like
-    // 'click:foo'
-    _buildViewTrigger: function(triggerDef) {
-      var hasOptions = _.isObject(triggerDef);
-  
-      var options = _.defaults({}, (hasOptions ? triggerDef : {}), {
-        preventDefault: true,
-        stopPropagation: true
-      });
-  
-      var eventName = hasOptions ? options.event : triggerDef;
-  
-      return function(e) {
-        if (e) {
-          if (e.preventDefault && options.preventDefault) {
-            e.preventDefault();
-          }
-  
-          if (e.stopPropagation && options.stopPropagation) {
-            e.stopPropagation();
-          }
-        }
-  
-        var args = {
-          view: this,
-          model: this.model,
-          collection: this.collection
-        };
-  
-        this.triggerMethod(eventName, args);
-      };
-    },
-  
-    setElement: function() {
-      var ret = Backbone.View.prototype.setElement.apply(this, arguments);
-  
-      // proxy behavior $el to the view's $el.
-      // This is needed because a view's $el proxy
-      // is not set until after setElement is called.
-      _.invoke(this._behaviors, 'proxyViewProperties', this);
-  
-      return ret;
-    },
-  
-    // import the `triggerMethod` to trigger events with corresponding
-    // methods if the method exists
-    triggerMethod: function() {
-      var ret = Marionette._triggerMethod(this, arguments);
-  
-      this._triggerEventOnBehaviors(arguments);
-      this._triggerEventOnParentLayout(arguments[0], _.rest(arguments));
-  
-      return ret;
-    },
-  
-    _triggerEventOnBehaviors: function(args) {
-      var triggerMethod = Marionette._triggerMethod;
-      var behaviors = this._behaviors;
-      // Use good ol' for as this is a very hot function
-      for (var i = 0, length = behaviors && behaviors.length; i < length; i++) {
-        triggerMethod(behaviors[i], args);
-      }
-    },
-  
-    _triggerEventOnParentLayout: function(eventName, args) {
-      var layoutView = this._parentLayoutView();
-      if (!layoutView) {
-        return;
-      }
-  
-      // invoke triggerMethod on parent view
-      var eventPrefix = Marionette.getOption(layoutView, 'childViewEventPrefix');
-      var prefixedEventName = eventPrefix + ':' + eventName;
-  
-      Marionette._triggerMethod(layoutView, [prefixedEventName, this].concat(args));
-  
-      // call the parent view's childEvents handler
-      var childEvents = Marionette.getOption(layoutView, 'childEvents');
-      var normalizedChildEvents = layoutView.normalizeMethods(childEvents);
-  
-      if (!!normalizedChildEvents && _.isFunction(normalizedChildEvents[eventName])) {
-        normalizedChildEvents[eventName].apply(layoutView, [this].concat(args));
-      }
-    },
-  
-    // This method returns any views that are immediate
-    // children of this view
-    _getImmediateChildren: function() {
-      return [];
-    },
-  
-    // Returns an array of every nested view within this view
-    _getNestedViews: function() {
-      var children = this._getImmediateChildren();
-  
-      if (!children.length) { return children; }
-  
-      return _.reduce(children, function(memo, view) {
-        if (!view._getNestedViews) { return memo; }
-        return memo.concat(view._getNestedViews());
-      }, children);
-    },
-  
-    // Internal utility for building an ancestor
-    // view tree list.
-    _getAncestors: function() {
-      var ancestors = [];
-      var parent  = this._parent;
-  
-      while (parent) {
-        ancestors.push(parent);
-        parent = parent._parent;
-      }
-  
-      return ancestors;
-    },
-  
-    // Returns the containing parent view.
-    _parentLayoutView: function() {
-      var ancestors = this._getAncestors();
-      return _.find(ancestors, function(parent) {
-        return parent instanceof Marionette.LayoutView;
-      });
-    },
-  
-    // Imports the "normalizeMethods" to transform hashes of
-    // events=>function references/names to a hash of events=>function references
-    normalizeMethods: Marionette.normalizeMethods,
-  
-    // A handy way to merge passed-in options onto the instance
-    mergeOptions: Marionette.mergeOptions,
-  
-    // Proxy `getOption` to enable getting options from this or this.options by name.
-    getOption: Marionette.proxyGetOption,
-  
-    // Proxy `bindEntityEvents` to enable binding view's events from another entity.
-    bindEntityEvents: Marionette.proxyBindEntityEvents,
-  
-    // Proxy `unbindEntityEvents` to enable unbinding view's events from another entity.
-    unbindEntityEvents: Marionette.proxyUnbindEntityEvents
-  });
-  
-  // Item View
-  // ---------
-  
-  // A single item view implementation that contains code for rendering
-  // with underscore.js templates, serializing the view's model or collection,
-  // and calling several methods on extended views, such as `onRender`.
-  Marionette.ItemView = Marionette.View.extend({
-  
-    // Setting up the inheritance chain which allows changes to
-    // Marionette.View.prototype.constructor which allows overriding
-    constructor: function() {
-      Marionette.View.apply(this, arguments);
-    },
-  
-    // Serialize the model or collection for the view. If a model is
-    // found, the view's `serializeModel` is called. If a collection is found,
-    // each model in the collection is serialized by calling
-    // the view's `serializeCollection` and put into an `items` array in
-    // the resulting data. If both are found, defaults to the model.
-    // You can override the `serializeData` method in your own view definition,
-    // to provide custom serialization for your view's data.
-    serializeData: function() {
-      if (!this.model && !this.collection) {
-        return {};
-      }
-  
-      var args = [this.model || this.collection];
-      if (arguments.length) {
-        args.push.apply(args, arguments);
-      }
-  
-      if (this.model) {
-        return this.serializeModel.apply(this, args);
-      } else {
-        return {
-          items: this.serializeCollection.apply(this, args)
-        };
-      }
-    },
-  
-    // Serialize a collection by serializing each of its models.
-    serializeCollection: function(collection) {
-      return collection.toJSON.apply(collection, _.rest(arguments));
-    },
-  
-    // Render the view, defaulting to underscore.js templates.
-    // You can override this in your view definition to provide
-    // a very specific rendering for your view. In general, though,
-    // you should override the `Marionette.Renderer` object to
-    // change how Marionette renders views.
-    render: function() {
-      this._ensureViewIsIntact();
-  
-      this.triggerMethod('before:render', this);
-  
-      this._renderTemplate();
-      this.isRendered = true;
-      this.bindUIElements();
-  
-      this.triggerMethod('render', this);
-  
-      return this;
-    },
-  
-    // Internal method to render the template with the serialized data
-    // and template helpers via the `Marionette.Renderer` object.
-    // Throws an `UndefinedTemplateError` error if the template is
-    // any falsely value but literal `false`.
-    _renderTemplate: function() {
-      var template = this.getTemplate();
-  
-      // Allow template-less item views
-      if (template === false) {
-        return;
-      }
-  
-      if (!template) {
-        throw new Marionette.Error({
-          name: 'UndefinedTemplateError',
-          message: 'Cannot render the template since it is null or undefined.'
-        });
-      }
-  
-      // Add in entity data and template helpers
-      var data = this.mixinTemplateHelpers(this.serializeData());
-  
-      // Render and add to el
-      var html = Marionette.Renderer.render(template, data, this);
-      this.attachElContent(html);
-  
-      return this;
-    },
-  
-    // Attaches the content of a given view.
-    // This method can be overridden to optimize rendering,
-    // or to render in a non standard way.
-    //
-    // For example, using `innerHTML` instead of `$el.html`
-    //
-    // ```js
-    // attachElContent: function(html) {
-    //   this.el.innerHTML = html;
-    //   return this;
-    // }
-    // ```
-    attachElContent: function(html) {
-      this.$el.html(html);
-  
-      return this;
-    }
-  });
-  
-  /* jshint maxstatements: 14 */
-  
-  // Collection View
-  // ---------------
-  
-  // A view that iterates over a Backbone.Collection
-  // and renders an individual child view for each model.
-  Marionette.CollectionView = Marionette.View.extend({
-  
-    // used as the prefix for child view events
-    // that are forwarded through the collectionview
-    childViewEventPrefix: 'childview',
-  
-    // flag for maintaining the sorted order of the collection
-    sort: true,
-  
-    // constructor
-    // option to pass `{sort: false}` to prevent the `CollectionView` from
-    // maintaining the sorted order of the collection.
-    // This will fallback onto appending childView's to the end.
-    //
-    // option to pass `{comparator: compFunction()}` to allow the `CollectionView`
-    // to use a custom sort order for the collection.
-    constructor: function(options) {
-  
-      this.once('render', this._initialEvents);
-      this._initChildViewStorage();
-  
-      Marionette.View.apply(this, arguments);
-  
-      this.on('show', this._onShowCalled);
-  
-      this.initRenderBuffer();
-    },
-  
-    // Instead of inserting elements one by one into the page,
-    // it's much more performant to insert elements into a document
-    // fragment and then insert that document fragment into the page
-    initRenderBuffer: function() {
-      this._bufferedChildren = [];
-    },
-  
-    startBuffering: function() {
-      this.initRenderBuffer();
-      this.isBuffering = true;
-    },
-  
-    endBuffering: function() {
-      this.isBuffering = false;
-      this._triggerBeforeShowBufferedChildren();
-  
-      this.attachBuffer(this);
-  
-      this._triggerShowBufferedChildren();
-      this.initRenderBuffer();
-    },
-  
-    _triggerBeforeShowBufferedChildren: function() {
-      if (this._isShown) {
-        _.each(this._bufferedChildren, _.partial(this._triggerMethodOnChild, 'before:show'));
-      }
-    },
-  
-    _triggerShowBufferedChildren: function() {
-      if (this._isShown) {
-        _.each(this._bufferedChildren, _.partial(this._triggerMethodOnChild, 'show'));
-  
-        this._bufferedChildren = [];
-      }
-    },
-  
-    // Internal method for _.each loops to call `Marionette.triggerMethodOn` on
-    // a child view
-    _triggerMethodOnChild: function(event, childView) {
-      Marionette.triggerMethodOn(childView, event);
-    },
-  
-    // Configured the initial events that the collection view
-    // binds to.
-    _initialEvents: function() {
-      if (this.collection) {
-        this.listenTo(this.collection, 'add', this._onCollectionAdd);
-        this.listenTo(this.collection, 'remove', this._onCollectionRemove);
-        this.listenTo(this.collection, 'reset', this.render);
-  
-        if (this.getOption('sort')) {
-          this.listenTo(this.collection, 'sort', this._sortViews);
-        }
-      }
-    },
-  
-    // Handle a child added to the collection
-    _onCollectionAdd: function(child, collection, opts) {
-      var index;
-      if (opts.at !== undefined) {
-        index = opts.at;
-      } else {
-        index = _.indexOf(this._filteredSortedModels(), child);
-      }
-  
-      if (this._shouldAddChild(child, index)) {
-        this.destroyEmptyView();
-        var ChildView = this.getChildView(child);
-        this.addChild(child, ChildView, index);
-      }
-    },
-  
-    // get the child view by model it holds, and remove it
-    _onCollectionRemove: function(model) {
-      var view = this.children.findByModel(model);
-      this.removeChildView(view);
-      this.checkEmpty();
-    },
-  
-    _onShowCalled: function() {
-      this.children.each(_.partial(this._triggerMethodOnChild, 'show'));
-    },
-  
-    // Render children views. Override this method to
-    // provide your own implementation of a render function for
-    // the collection view.
-    render: function() {
-      this._ensureViewIsIntact();
-      this.triggerMethod('before:render', this);
-      this._renderChildren();
-      this.isRendered = true;
-      this.triggerMethod('render', this);
-      return this;
-    },
-  
-    // Reorder DOM after sorting. When your element's rendering
-    // do not use their index, you can pass reorderOnSort: true
-    // to only reorder the DOM after a sort instead of rendering
-    // all the collectionView
-    reorder: function() {
-      var children = this.children;
-      var models = this._filteredSortedModels();
-      var modelsChanged = _.find(models, function(model) {
-        return !children.findByModel(model);
-      });
-  
-      // If the models we're displaying have changed due to filtering
-      // We need to add and/or remove child views
-      // So render as normal
-      if (modelsChanged) {
-        this.render();
-      } else {
-        // get the DOM nodes in the same order as the models
-        var els = _.map(models, function(model) {
-          return children.findByModel(model).el;
-        });
-  
-        // since append moves elements that are already in the DOM,
-        // appending the elements will effectively reorder them
-        this.triggerMethod('before:reorder');
-        this._appendReorderedChildren(els);
-        this.triggerMethod('reorder');
-      }
-    },
-  
-    // Render view after sorting. Override this method to
-    // change how the view renders after a `sort` on the collection.
-    // An example of this would be to only `renderChildren` in a `CompositeView`
-    // rather than the full view.
-    resortView: function() {
-      if (Marionette.getOption(this, 'reorderOnSort')) {
-        this.reorder();
-      } else {
-        this.render();
-      }
-    },
-  
-    // Internal method. This checks for any changes in the order of the collection.
-    // If the index of any view doesn't match, it will render.
-    _sortViews: function() {
-      var models = this._filteredSortedModels();
-  
-      // check for any changes in sort order of views
-      var orderChanged = _.find(models, function(item, index) {
-        var view = this.children.findByModel(item);
-        return !view || view._index !== index;
-      }, this);
-  
-      if (orderChanged) {
-        this.resortView();
-      }
-    },
-  
-    // Internal reference to what index a `emptyView` is.
-    _emptyViewIndex: -1,
-  
-    // Internal method. Separated so that CompositeView can append to the childViewContainer
-    // if necessary
-    _appendReorderedChildren: function(children) {
-      this.$el.append(children);
-    },
-  
-    // Internal method. Separated so that CompositeView can have
-    // more control over events being triggered, around the rendering
-    // process
-    _renderChildren: function() {
-      this.destroyEmptyView();
-      this.destroyChildren();
-  
-      if (this.isEmpty(this.collection)) {
-        this.showEmptyView();
-      } else {
-        this.triggerMethod('before:render:collection', this);
-        this.startBuffering();
-        this.showCollection();
-        this.endBuffering();
-        this.triggerMethod('render:collection', this);
-  
-        // If we have shown children and none have passed the filter, show the empty view
-        if (this.children.isEmpty()) {
-          this.showEmptyView();
-        }
-      }
-    },
-  
-    // Internal method to loop through collection and show each child view.
-    showCollection: function() {
-      var ChildView;
-  
-      var models = this._filteredSortedModels();
-  
-      _.each(models, function(child, index) {
-        ChildView = this.getChildView(child);
-        this.addChild(child, ChildView, index);
-      }, this);
-    },
-  
-    // Allow the collection to be sorted by a custom view comparator
-    _filteredSortedModels: function() {
-      var models;
-      var viewComparator = this.getViewComparator();
-  
-      if (viewComparator) {
-        if (_.isString(viewComparator) || viewComparator.length === 1) {
-          models = this.collection.sortBy(viewComparator, this);
-        } else {
-          models = _.clone(this.collection.models).sort(_.bind(viewComparator, this));
-        }
-      } else {
-        models = this.collection.models;
-      }
-  
-      // Filter after sorting in case the filter uses the index
-      if (this.getOption('filter')) {
-        models = _.filter(models, function(model, index) {
-          return this._shouldAddChild(model, index);
-        }, this);
-      }
-  
-      return models;
-    },
-  
-    // Internal method to show an empty view in place of
-    // a collection of child views, when the collection is empty
-    showEmptyView: function() {
-      var EmptyView = this.getEmptyView();
-  
-      if (EmptyView && !this._showingEmptyView) {
-        this.triggerMethod('before:render:empty');
-  
-        this._showingEmptyView = true;
-        var model = new Backbone.Model();
-        this.addEmptyView(model, EmptyView);
-  
-        this.triggerMethod('render:empty');
-      }
-    },
-  
-    // Internal method to destroy an existing emptyView instance
-    // if one exists. Called when a collection view has been
-    // rendered empty, and then a child is added to the collection.
-    destroyEmptyView: function() {
-      if (this._showingEmptyView) {
-        this.triggerMethod('before:remove:empty');
-  
-        this.destroyChildren();
-        delete this._showingEmptyView;
-  
-        this.triggerMethod('remove:empty');
-      }
-    },
-  
-    // Retrieve the empty view class
-    getEmptyView: function() {
-      return this.getOption('emptyView');
-    },
-  
-    // Render and show the emptyView. Similar to addChild method
-    // but "add:child" events are not fired, and the event from
-    // emptyView are not forwarded
-    addEmptyView: function(child, EmptyView) {
-  
-      // get the emptyViewOptions, falling back to childViewOptions
-      var emptyViewOptions = this.getOption('emptyViewOptions') ||
-                            this.getOption('childViewOptions');
-  
-      if (_.isFunction(emptyViewOptions)) {
-        emptyViewOptions = emptyViewOptions.call(this, child, this._emptyViewIndex);
-      }
-  
-      // build the empty view
-      var view = this.buildChildView(child, EmptyView, emptyViewOptions);
-  
-      view._parent = this;
-  
-      // Proxy emptyView events
-      this.proxyChildEvents(view);
-  
-      // trigger the 'before:show' event on `view` if the collection view
-      // has already been shown
-      if (this._isShown) {
-        Marionette.triggerMethodOn(view, 'before:show');
-      }
-  
-      // Store the `emptyView` like a `childView` so we can properly
-      // remove and/or close it later
-      this.children.add(view);
-  
-      // Render it and show it
-      this.renderChildView(view, this._emptyViewIndex);
-  
-      // call the 'show' method if the collection view
-      // has already been shown
-      if (this._isShown) {
-        Marionette.triggerMethodOn(view, 'show');
-      }
-    },
-  
-    // Retrieve the `childView` class, either from `this.options.childView`
-    // or from the `childView` in the object definition. The "options"
-    // takes precedence.
-    // This method receives the model that will be passed to the instance
-    // created from this `childView`. Overriding methods may use the child
-    // to determine what `childView` class to return.
-    getChildView: function(child) {
-      var childView = this.getOption('childView');
-  
-      if (!childView) {
-        throw new Marionette.Error({
-          name: 'NoChildViewError',
-          message: 'A "childView" must be specified'
-        });
-      }
-  
-      return childView;
-    },
-  
-    // Render the child's view and add it to the
-    // HTML for the collection view at a given index.
-    // This will also update the indices of later views in the collection
-    // in order to keep the children in sync with the collection.
-    addChild: function(child, ChildView, index) {
-      var childViewOptions = this.getOption('childViewOptions');
-      childViewOptions = Marionette._getValue(childViewOptions, this, [child, index]);
-  
-      var view = this.buildChildView(child, ChildView, childViewOptions);
-  
-      // increment indices of views after this one
-      this._updateIndices(view, true, index);
-  
-      this._addChildView(view, index);
-  
-      view._parent = this;
-  
-      return view;
-    },
-  
-    // Internal method. This decrements or increments the indices of views after the
-    // added/removed view to keep in sync with the collection.
-    _updateIndices: function(view, increment, index) {
-      if (!this.getOption('sort')) {
-        return;
-      }
-  
-      if (increment) {
-        // assign the index to the view
-        view._index = index;
-      }
-  
-      // update the indexes of views after this one
-      this.children.each(function(laterView) {
-        if (laterView._index >= view._index) {
-          laterView._index += increment ? 1 : -1;
-        }
-      });
-    },
-  
-    // Internal Method. Add the view to children and render it at
-    // the given index.
-    _addChildView: function(view, index) {
-      // set up the child view event forwarding
-      this.proxyChildEvents(view);
-  
-      this.triggerMethod('before:add:child', view);
-  
-      // trigger the 'before:show' event on `view` if the collection view
-      // has already been shown
-      if (this._isShown && !this.isBuffering) {
-        Marionette.triggerMethodOn(view, 'before:show');
-      }
-  
-      // Store the child view itself so we can properly
-      // remove and/or destroy it later
-      this.children.add(view);
-      this.renderChildView(view, index);
-  
-      if (this._isShown && !this.isBuffering) {
-        Marionette.triggerMethodOn(view, 'show');
-      }
-  
-      this.triggerMethod('add:child', view);
-    },
-  
-    // render the child view
-    renderChildView: function(view, index) {
-      view.render();
-      this.attachHtml(this, view, index);
-      return view;
-    },
-  
-    // Build a `childView` for a model in the collection.
-    buildChildView: function(child, ChildViewClass, childViewOptions) {
-      var options = _.extend({model: child}, childViewOptions);
-      return new ChildViewClass(options);
-    },
-  
-    // Remove the child view and destroy it.
-    // This function also updates the indices of
-    // later views in the collection in order to keep
-    // the children in sync with the collection.
-    removeChildView: function(view) {
-  
-      if (view) {
-        this.triggerMethod('before:remove:child', view);
-  
-        // call 'destroy' or 'remove', depending on which is found
-        if (view.destroy) {
-          view.destroy();
-        } else if (view.remove) {
-          view.remove();
-        }
-  
-        delete view._parent;
-        this.stopListening(view);
-        this.children.remove(view);
-        this.triggerMethod('remove:child', view);
-  
-        // decrement the index of views after this one
-        this._updateIndices(view, false);
-      }
-  
-      return view;
-    },
-  
-    // check if the collection is empty
-    isEmpty: function() {
-      return !this.collection || this.collection.length === 0;
-    },
-  
-    // If empty, show the empty view
-    checkEmpty: function() {
-      if (this.isEmpty(this.collection)) {
-        this.showEmptyView();
-      }
-    },
-  
-    // You might need to override this if you've overridden attachHtml
-    attachBuffer: function(collectionView) {
-      collectionView.$el.append(this._createBuffer(collectionView));
-    },
-  
-    // Create a fragment buffer from the currently buffered children
-    _createBuffer: function(collectionView) {
-      var elBuffer = document.createDocumentFragment();
-      _.each(collectionView._bufferedChildren, function(b) {
-        elBuffer.appendChild(b.el);
-      });
-      return elBuffer;
-    },
-  
-    // Append the HTML to the collection's `el`.
-    // Override this method to do something other
-    // than `.append`.
-    attachHtml: function(collectionView, childView, index) {
-      if (collectionView.isBuffering) {
-        // buffering happens on reset events and initial renders
-        // in order to reduce the number of inserts into the
-        // document, which are expensive.
-        collectionView._bufferedChildren.splice(index, 0, childView);
-      } else {
-        // If we've already rendered the main collection, append
-        // the new child into the correct order if we need to. Otherwise
-        // append to the end.
-        if (!collectionView._insertBefore(childView, index)) {
-          collectionView._insertAfter(childView);
-        }
-      }
-    },
-  
-    // Internal method. Check whether we need to insert the view into
-    // the correct position.
-    _insertBefore: function(childView, index) {
-      var currentView;
-      var findPosition = this.getOption('sort') && (index < this.children.length - 1);
-      if (findPosition) {
-        // Find the view after this one
-        currentView = this.children.find(function(view) {
-          return view._index === index + 1;
-        });
-      }
-  
-      if (currentView) {
-        currentView.$el.before(childView.el);
-        return true;
-      }
-  
-      return false;
-    },
-  
-    // Internal method. Append a view to the end of the $el
-    _insertAfter: function(childView) {
-      this.$el.append(childView.el);
-    },
-  
-    // Internal method to set up the `children` object for
-    // storing all of the child views
-    _initChildViewStorage: function() {
-      this.children = new Backbone.ChildViewContainer();
-    },
-  
-    // Handle cleanup and other destroying needs for the collection of views
-    destroy: function() {
-      if (this.isDestroyed) { return this; }
-  
-      this.triggerMethod('before:destroy:collection');
-      this.destroyChildren();
-      this.triggerMethod('destroy:collection');
-  
-      return Marionette.View.prototype.destroy.apply(this, arguments);
-    },
-  
-    // Destroy the child views that this collection view
-    // is holding on to, if any
-    destroyChildren: function() {
-      var childViews = this.children.map(_.identity);
-      this.children.each(this.removeChildView, this);
-      this.checkEmpty();
-      return childViews;
-    },
-  
-    // Return true if the given child should be shown
-    // Return false otherwise
-    // The filter will be passed (child, index, collection)
-    // Where
-    //  'child' is the given model
-    //  'index' is the index of that model in the collection
-    //  'collection' is the collection referenced by this CollectionView
-    _shouldAddChild: function(child, index) {
-      var filter = this.getOption('filter');
-      return !_.isFunction(filter) || filter.call(this, child, index, this.collection);
-    },
-  
-    // Set up the child view event forwarding. Uses a "childview:"
-    // prefix in front of all forwarded events.
-    proxyChildEvents: function(view) {
-      var prefix = this.getOption('childViewEventPrefix');
-  
-      // Forward all child view events through the parent,
-      // prepending "childview:" to the event name
-      this.listenTo(view, 'all', function() {
-        var args = _.toArray(arguments);
-        var rootEvent = args[0];
-        var childEvents = this.normalizeMethods(_.result(this, 'childEvents'));
-  
-        args[0] = prefix + ':' + rootEvent;
-        args.splice(1, 0, view);
-  
-        // call collectionView childEvent if defined
-        if (typeof childEvents !== 'undefined' && _.isFunction(childEvents[rootEvent])) {
-          childEvents[rootEvent].apply(this, args.slice(1));
-        }
-  
-        this.triggerMethod.apply(this, args);
-      });
-    },
-  
-    _getImmediateChildren: function() {
-      return _.values(this.children._views);
-    },
-  
-    getViewComparator: function() {
-      return this.getOption('viewComparator');
-    }
-  });
-  
-  /* jshint maxstatements: 17, maxlen: 117 */
-  
-  // Composite View
-  // --------------
-  
-  // Used for rendering a branch-leaf, hierarchical structure.
-  // Extends directly from CollectionView and also renders an
-  // a child view as `modelView`, for the top leaf
-  Marionette.CompositeView = Marionette.CollectionView.extend({
-  
-    // Setting up the inheritance chain which allows changes to
-    // Marionette.CollectionView.prototype.constructor which allows overriding
-    // option to pass '{sort: false}' to prevent the CompositeView from
-    // maintaining the sorted order of the collection.
-    // This will fallback onto appending childView's to the end.
-    constructor: function() {
-      Marionette.CollectionView.apply(this, arguments);
-    },
-  
-    // Configured the initial events that the composite view
-    // binds to. Override this method to prevent the initial
-    // events, or to add your own initial events.
-    _initialEvents: function() {
-  
-      // Bind only after composite view is rendered to avoid adding child views
-      // to nonexistent childViewContainer
-  
-      if (this.collection) {
-        this.listenTo(this.collection, 'add', this._onCollectionAdd);
-        this.listenTo(this.collection, 'remove', this._onCollectionRemove);
-        this.listenTo(this.collection, 'reset', this._renderChildren);
-  
-        if (this.getOption('sort')) {
-          this.listenTo(this.collection, 'sort', this._sortViews);
-        }
-      }
-    },
-  
-    // Retrieve the `childView` to be used when rendering each of
-    // the items in the collection. The default is to return
-    // `this.childView` or Marionette.CompositeView if no `childView`
-    // has been defined
-    getChildView: function(child) {
-      var childView = this.getOption('childView') || this.constructor;
-  
-      return childView;
-    },
-  
-    // Serialize the model for the view.
-    // You can override the `serializeData` method in your own view
-    // definition, to provide custom serialization for your view's data.
-    serializeData: function() {
-      var data = {};
-  
-      if (this.model) {
-        data = _.partial(this.serializeModel, this.model).apply(this, arguments);
-      }
-  
-      return data;
-    },
-  
-    // Renders the model and the collection.
-    render: function() {
-      this._ensureViewIsIntact();
-      this._isRendering = true;
-      this.resetChildViewContainer();
-  
-      this.triggerMethod('before:render', this);
-  
-      this._renderTemplate();
-      this._renderChildren();
-  
-      this._isRendering = false;
-      this.isRendered = true;
-      this.triggerMethod('render', this);
-      return this;
-    },
-  
-    _renderChildren: function() {
-      if (this.isRendered || this._isRendering) {
-        Marionette.CollectionView.prototype._renderChildren.call(this);
-      }
-    },
-  
-    // Render the root template that the children
-    // views are appended to
-    _renderTemplate: function() {
-      var data = {};
-      data = this.serializeData();
-      data = this.mixinTemplateHelpers(data);
-  
-      this.triggerMethod('before:render:template');
-  
-      var template = this.getTemplate();
-      var html = Marionette.Renderer.render(template, data, this);
-      this.attachElContent(html);
-  
-      // the ui bindings is done here and not at the end of render since they
-      // will not be available until after the model is rendered, but should be
-      // available before the collection is rendered.
-      this.bindUIElements();
-      this.triggerMethod('render:template');
-    },
-  
-    // Attaches the content of the root.
-    // This method can be overridden to optimize rendering,
-    // or to render in a non standard way.
-    //
-    // For example, using `innerHTML` instead of `$el.html`
-    //
-    // ```js
-    // attachElContent: function(html) {
-    //   this.el.innerHTML = html;
-    //   return this;
-    // }
-    // ```
-    attachElContent: function(html) {
-      this.$el.html(html);
-  
-      return this;
-    },
-  
-    // You might need to override this if you've overridden attachHtml
-    attachBuffer: function(compositeView) {
-      var $container = this.getChildViewContainer(compositeView);
-      $container.append(this._createBuffer(compositeView));
-    },
-  
-    // Internal method. Append a view to the end of the $el.
-    // Overidden from CollectionView to ensure view is appended to
-    // childViewContainer
-    _insertAfter: function(childView) {
-      var $container = this.getChildViewContainer(this, childView);
-      $container.append(childView.el);
-    },
-  
-    // Internal method. Append reordered childView'.
-    // Overidden from CollectionView to ensure reordered views
-    // are appended to childViewContainer
-    _appendReorderedChildren: function(children) {
-      var $container = this.getChildViewContainer(this);
-      $container.append(children);
-    },
-  
-    // Internal method to ensure an `$childViewContainer` exists, for the
-    // `attachHtml` method to use.
-    getChildViewContainer: function(containerView, childView) {
-      if ('$childViewContainer' in containerView) {
-        return containerView.$childViewContainer;
-      }
-  
-      var container;
-      var childViewContainer = Marionette.getOption(containerView, 'childViewContainer');
-      if (childViewContainer) {
-  
-        var selector = Marionette._getValue(childViewContainer, containerView);
-  
-        if (selector.charAt(0) === '@' && containerView.ui) {
-          container = containerView.ui[selector.substr(4)];
-        } else {
-          container = containerView.$(selector);
-        }
-  
-        if (container.length <= 0) {
-          throw new Marionette.Error({
-            name: 'ChildViewContainerMissingError',
-            message: 'The specified "childViewContainer" was not found: ' + containerView.childViewContainer
-          });
-        }
-  
-      } else {
-        container = containerView.$el;
-      }
-  
-      containerView.$childViewContainer = container;
-      return container;
-    },
-  
-    // Internal method to reset the `$childViewContainer` on render
-    resetChildViewContainer: function() {
-      if (this.$childViewContainer) {
-        delete this.$childViewContainer;
-      }
-    }
-  });
-  
-  // Layout View
-  // -----------
-  
-  // Used for managing application layoutViews, nested layoutViews and
-  // multiple regions within an application or sub-application.
-  //
-  // A specialized view class that renders an area of HTML and then
-  // attaches `Region` instances to the specified `regions`.
-  // Used for composite view management and sub-application areas.
-  Marionette.LayoutView = Marionette.ItemView.extend({
-    regionClass: Marionette.Region,
-  
-    options: {
-      destroyImmediate: false
-    },
-  
-    // used as the prefix for child view events
-    // that are forwarded through the layoutview
-    childViewEventPrefix: 'childview',
-  
-    // Ensure the regions are available when the `initialize` method
-    // is called.
-    constructor: function(options) {
-      options = options || {};
-  
-      this._firstRender = true;
-      this._initializeRegions(options);
-  
-      Marionette.ItemView.call(this, options);
-    },
-  
-    // LayoutView's render will use the existing region objects the
-    // first time it is called. Subsequent calls will destroy the
-    // views that the regions are showing and then reset the `el`
-    // for the regions to the newly rendered DOM elements.
-    render: function() {
-      this._ensureViewIsIntact();
-  
-      if (this._firstRender) {
-        // if this is the first render, don't do anything to
-        // reset the regions
-        this._firstRender = false;
-      } else {
-        // If this is not the first render call, then we need to
-        // re-initialize the `el` for each region
-        this._reInitializeRegions();
-      }
-  
-      return Marionette.ItemView.prototype.render.apply(this, arguments);
-    },
-  
-    // Handle destroying regions, and then destroy the view itself.
-    destroy: function() {
-      if (this.isDestroyed) { return this; }
-      // #2134: remove parent element before destroying the child views, so
-      // removing the child views doesn't retrigger repaints
-      if (this.getOption('destroyImmediate') === true) {
-        this.$el.remove();
-      }
-      this.regionManager.destroy();
-      return Marionette.ItemView.prototype.destroy.apply(this, arguments);
-    },
-  
-    showChildView: function(regionName, view) {
-      return this.getRegion(regionName).show(view);
-    },
-  
-    getChildView: function(regionName) {
-      return this.getRegion(regionName).currentView;
-    },
-  
-    // Add a single region, by name, to the layoutView
-    addRegion: function(name, definition) {
-      var regions = {};
-      regions[name] = definition;
-      return this._buildRegions(regions)[name];
-    },
-  
-    // Add multiple regions as a {name: definition, name2: def2} object literal
-    addRegions: function(regions) {
-      this.regions = _.extend({}, this.regions, regions);
-      return this._buildRegions(regions);
-    },
-  
-    // Remove a single region from the LayoutView, by name
-    removeRegion: function(name) {
-      delete this.regions[name];
-      return this.regionManager.removeRegion(name);
-    },
-  
-    // Provides alternative access to regions
-    // Accepts the region name
-    // getRegion('main')
-    getRegion: function(region) {
-      return this.regionManager.get(region);
-    },
-  
-    // Get all regions
-    getRegions: function() {
-      return this.regionManager.getRegions();
-    },
-  
-    // internal method to build regions
-    _buildRegions: function(regions) {
-      var defaults = {
-        regionClass: this.getOption('regionClass'),
-        parentEl: _.partial(_.result, this, 'el')
-      };
-  
-      return this.regionManager.addRegions(regions, defaults);
-    },
-  
-    // Internal method to initialize the regions that have been defined in a
-    // `regions` attribute on this layoutView.
-    _initializeRegions: function(options) {
-      var regions;
-      this._initRegionManager();
-  
-      regions = Marionette._getValue(this.regions, this, [options]) || {};
-  
-      // Enable users to define `regions` as instance options.
-      var regionOptions = this.getOption.call(options, 'regions');
-  
-      // enable region options to be a function
-      regionOptions = Marionette._getValue(regionOptions, this, [options]);
-  
-      _.extend(regions, regionOptions);
-  
-      // Normalize region selectors hash to allow
-      // a user to use the @ui. syntax.
-      regions = this.normalizeUIValues(regions, ['selector', 'el']);
-  
-      this.addRegions(regions);
-    },
-  
-    // Internal method to re-initialize all of the regions by updating the `el` that
-    // they point to
-    _reInitializeRegions: function() {
-      this.regionManager.invoke('reset');
-    },
-  
-    // Enable easy overriding of the default `RegionManager`
-    // for customized region interactions and business specific
-    // view logic for better control over single regions.
-    getRegionManager: function() {
-      return new Marionette.RegionManager();
-    },
-  
-    // Internal method to initialize the region manager
-    // and all regions in it
-    _initRegionManager: function() {
-      this.regionManager = this.getRegionManager();
-      this.regionManager._parent = this;
-  
-      this.listenTo(this.regionManager, 'before:add:region', function(name) {
-        this.triggerMethod('before:add:region', name);
-      });
-  
-      this.listenTo(this.regionManager, 'add:region', function(name, region) {
-        this[name] = region;
-        this.triggerMethod('add:region', name, region);
-      });
-  
-      this.listenTo(this.regionManager, 'before:remove:region', function(name) {
-        this.triggerMethod('before:remove:region', name);
-      });
-  
-      this.listenTo(this.regionManager, 'remove:region', function(name, region) {
-        delete this[name];
-        this.triggerMethod('remove:region', name, region);
-      });
-    },
-  
-    _getImmediateChildren: function() {
-      return _.chain(this.regionManager.getRegions())
-        .pluck('currentView')
-        .compact()
-        .value();
-    }
-  });
-  
+	    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+	      args[_key] = arguments[_key];
+	    }
 
-  // Behavior
-  // --------
-  
-  // A Behavior is an isolated set of DOM /
-  // user interactions that can be mixed into any View.
-  // Behaviors allow you to blackbox View specific interactions
-  // into portable logical chunks, keeping your views simple and your code DRY.
-  
-  Marionette.Behavior = Marionette.Object.extend({
-    constructor: function(options, view) {
-      // Setup reference to the view.
-      // this comes in handle when a behavior
-      // wants to directly talk up the chain
-      // to the view.
-      this.view = view;
-      this.defaults = _.result(this, 'defaults') || {};
-      this.options  = _.extend({}, this.defaults, options);
-      // Construct an internal UI hash using
-      // the views UI hash and then the behaviors UI hash.
-      // This allows the user to use UI hash elements
-      // defined in the parent view as well as those
-      // defined in the given behavior.
-      this.ui = _.extend({}, _.result(view, 'ui'), _.result(this, 'ui'));
-  
-      Marionette.Object.apply(this, arguments);
-    },
-  
-    // proxy behavior $ method to the view
-    // this is useful for doing jquery DOM lookups
-    // scoped to behaviors view.
-    $: function() {
-      return this.view.$.apply(this.view, arguments);
-    },
-  
-    // Stops the behavior from listening to events.
-    // Overrides Object#destroy to prevent additional events from being triggered.
-    destroy: function() {
-      this.stopListening();
-  
-      return this;
-    },
-  
-    proxyViewProperties: function(view) {
-      this.$el = view.$el;
-      this.el = view.el;
-    }
-  });
-  
-  /* jshint maxlen: 143 */
-  // Behaviors
-  // ---------
-  
-  // Behaviors is a utility class that takes care of
-  // gluing your behavior instances to their given View.
-  // The most important part of this class is that you
-  // **MUST** override the class level behaviorsLookup
-  // method for things to work properly.
-  
-  Marionette.Behaviors = (function(Marionette, _) {
-    // Borrow event splitter from Backbone
-    var delegateEventSplitter = /^(\S+)\s*(.*)$/;
-  
-    function Behaviors(view, behaviors) {
-  
-      if (!_.isObject(view.behaviors)) {
-        return {};
-      }
-  
-      // Behaviors defined on a view can be a flat object literal
-      // or it can be a function that returns an object.
-      behaviors = Behaviors.parseBehaviors(view, behaviors || _.result(view, 'behaviors'));
-  
-      // Wraps several of the view's methods
-      // calling the methods first on each behavior
-      // and then eventually calling the method on the view.
-      Behaviors.wrap(view, behaviors, _.keys(methods));
-      return behaviors;
-    }
-  
-    var methods = {
-      behaviorTriggers: function(behaviorTriggers, behaviors) {
-        var triggerBuilder = new BehaviorTriggersBuilder(this, behaviors);
-        return triggerBuilder.buildBehaviorTriggers();
-      },
-  
-      behaviorEvents: function(behaviorEvents, behaviors) {
-        var _behaviorsEvents = {};
-  
-        _.each(behaviors, function(b, i) {
-          var _events = {};
-          var behaviorEvents = _.clone(_.result(b, 'events')) || {};
-  
-          // Normalize behavior events hash to allow
-          // a user to use the @ui. syntax.
-          behaviorEvents = Marionette.normalizeUIKeys(behaviorEvents, getBehaviorsUI(b));
-  
-          var j = 0;
-          _.each(behaviorEvents, function(behaviour, key) {
-            var match     = key.match(delegateEventSplitter);
-  
-            // Set event name to be namespaced using the view cid,
-            // the behavior index, and the behavior event index
-            // to generate a non colliding event namespace
-            // http://api.jquery.com/event.namespace/
-            var eventName = match[1] + '.' + [this.cid, i, j++, ' '].join('');
-            var selector  = match[2];
-  
-            var eventKey  = eventName + selector;
-            var handler   = _.isFunction(behaviour) ? behaviour : b[behaviour];
-  
-            _events[eventKey] = _.bind(handler, b);
-          }, this);
-  
-          _behaviorsEvents = _.extend(_behaviorsEvents, _events);
-        }, this);
-  
-        return _behaviorsEvents;
-      }
-    };
-  
-    _.extend(Behaviors, {
-  
-      // Placeholder method to be extended by the user.
-      // The method should define the object that stores the behaviors.
-      // i.e.
-      //
-      // ```js
-      // Marionette.Behaviors.behaviorsLookup: function() {
-      //   return App.Behaviors
-      // }
-      // ```
-      behaviorsLookup: function() {
-        throw new Marionette.Error({
-          message: 'You must define where your behaviors are stored.',
-          url: 'marionette.behaviors.html#behaviorslookup'
-        });
-      },
-  
-      // Takes care of getting the behavior class
-      // given options and a key.
-      // If a user passes in options.behaviorClass
-      // default to using that. Otherwise delegate
-      // the lookup to the users `behaviorsLookup` implementation.
-      getBehaviorClass: function(options, key) {
-        if (options.behaviorClass) {
-          return options.behaviorClass;
-        }
-  
-        // Get behavior class can be either a flat object or a method
-        return Marionette._getValue(Behaviors.behaviorsLookup, this, [options, key])[key];
-      },
-  
-      // Iterate over the behaviors object, for each behavior
-      // instantiate it and get its grouped behaviors.
-      parseBehaviors: function(view, behaviors) {
-        return _.chain(behaviors).map(function(options, key) {
-          var BehaviorClass = Behaviors.getBehaviorClass(options, key);
-  
-          var behavior = new BehaviorClass(options, view);
-          var nestedBehaviors = Behaviors.parseBehaviors(view, _.result(behavior, 'behaviors'));
-  
-          return [behavior].concat(nestedBehaviors);
-        }).flatten().value();
-      },
-  
-      // Wrap view internal methods so that they delegate to behaviors. For example,
-      // `onDestroy` should trigger destroy on all of the behaviors and then destroy itself.
-      // i.e.
-      //
-      // `view.delegateEvents = _.partial(methods.delegateEvents, view.delegateEvents, behaviors);`
-      wrap: function(view, behaviors, methodNames) {
-        _.each(methodNames, function(methodName) {
-          view[methodName] = _.partial(methods[methodName], view[methodName], behaviors);
-        });
-      }
-    });
-  
-    // Class to build handlers for `triggers` on behaviors
-    // for views
-    function BehaviorTriggersBuilder(view, behaviors) {
-      this._view      = view;
-      this._behaviors = behaviors;
-      this._triggers  = {};
-    }
-  
-    _.extend(BehaviorTriggersBuilder.prototype, {
-      // Main method to build the triggers hash with event keys and handlers
-      buildBehaviorTriggers: function() {
-        _.each(this._behaviors, this._buildTriggerHandlersForBehavior, this);
-        return this._triggers;
-      },
-  
-      // Internal method to build all trigger handlers for a given behavior
-      _buildTriggerHandlersForBehavior: function(behavior, i) {
-        var triggersHash = _.clone(_.result(behavior, 'triggers')) || {};
-  
-        triggersHash = Marionette.normalizeUIKeys(triggersHash, getBehaviorsUI(behavior));
-  
-        _.each(triggersHash, _.bind(this._setHandlerForBehavior, this, behavior, i));
-      },
-  
-      // Internal method to create and assign the trigger handler for a given
-      // behavior
-      _setHandlerForBehavior: function(behavior, i, eventName, trigger) {
-        // Unique identifier for the `this._triggers` hash
-        var triggerKey = trigger.replace(/^\S+/, function(triggerName) {
-          return triggerName + '.' + 'behaviortriggers' + i;
-        });
-  
-        this._triggers[triggerKey] = this._view._buildViewTrigger(eventName);
-      }
-    });
-  
-    function getBehaviorsUI(behavior) {
-      return behavior._uiBindings || behavior.ui;
-    }
-  
-    return Behaviors;
-  
-  })(Marionette, _);
-  
+	    this.triggerMethod.apply(this, ['before:destroy', this].concat(args));
 
-  // App Router
-  // ----------
-  
-  // Reduce the boilerplate code of handling route events
-  // and then calling a single method on another object.
-  // Have your routers configured to call the method on
-  // your object, directly.
-  //
-  // Configure an AppRouter with `appRoutes`.
-  //
-  // App routers can only take one `controller` object.
-  // It is recommended that you divide your controller
-  // objects in to smaller pieces of related functionality
-  // and have multiple routers / controllers, instead of
-  // just one giant router and controller.
-  //
-  // You can also add standard routes to an AppRouter.
-  
-  Marionette.AppRouter = Backbone.Router.extend({
-  
-    constructor: function(options) {
-      this.options = options || {};
-  
-      Backbone.Router.apply(this, arguments);
-  
-      var appRoutes = this.getOption('appRoutes');
-      var controller = this._getController();
-      this.processAppRoutes(controller, appRoutes);
-      this.on('route', this._processOnRoute, this);
-    },
-  
-    // Similar to route method on a Backbone Router but
-    // method is called on the controller
-    appRoute: function(route, methodName) {
-      var controller = this._getController();
-      this._addAppRoute(controller, route, methodName);
-    },
-  
-    // process the route event and trigger the onRoute
-    // method call, if it exists
-    _processOnRoute: function(routeName, routeArgs) {
-      // make sure an onRoute before trying to call it
-      if (_.isFunction(this.onRoute)) {
-        // find the path that matches the current route
-        var routePath = _.invert(this.getOption('appRoutes'))[routeName];
-        this.onRoute(routeName, routePath, routeArgs);
-      }
-    },
-  
-    // Internal method to process the `appRoutes` for the
-    // router, and turn them in to routes that trigger the
-    // specified method on the specified `controller`.
-    processAppRoutes: function(controller, appRoutes) {
-      if (!appRoutes) { return; }
-  
-      var routeNames = _.keys(appRoutes).reverse(); // Backbone requires reverted order of routes
-  
-      _.each(routeNames, function(route) {
-        this._addAppRoute(controller, route, appRoutes[route]);
-      }, this);
-    },
-  
-    _getController: function() {
-      return this.getOption('controller');
-    },
-  
-    _addAppRoute: function(controller, route, methodName) {
-      var method = controller[methodName];
-  
-      if (!method) {
-        throw new Marionette.Error('Method "' + methodName + '" was not found on the controller');
-      }
-  
-      this.route(route, methodName, _.bind(method, controller));
-    },
-  
-    mergeOptions: Marionette.mergeOptions,
-  
-    // Proxy `getOption` to enable getting options from this or this.options by name.
-    getOption: Marionette.proxyGetOption,
-  
-    triggerMethod: Marionette.triggerMethod,
-  
-    bindEntityEvents: Marionette.proxyBindEntityEvents,
-  
-    unbindEntityEvents: Marionette.proxyUnbindEntityEvents
-  });
-  
-  // Application
-  // -----------
-  
-  // Contain and manage the composite application as a whole.
-  // Stores and starts up `Region` objects, includes an
-  // event aggregator as `app.vent`
-  Marionette.Application = Marionette.Object.extend({
-    constructor: function(options) {
-      this._initializeRegions(options);
-      this._initCallbacks = new Marionette.Callbacks();
-      this.submodules = {};
-      _.extend(this, options);
-      this._initChannel();
-      Marionette.Object.call(this, options);
-    },
-  
-    // Command execution, facilitated by Backbone.Wreqr.Commands
-    execute: function() {
-      this.commands.execute.apply(this.commands, arguments);
-    },
-  
-    // Request/response, facilitated by Backbone.Wreqr.RequestResponse
-    request: function() {
-      return this.reqres.request.apply(this.reqres, arguments);
-    },
-  
-    // Add an initializer that is either run at when the `start`
-    // method is called, or run immediately if added after `start`
-    // has already been called.
-    addInitializer: function(initializer) {
-      this._initCallbacks.add(initializer);
-    },
-  
-    // kick off all of the application's processes.
-    // initializes all of the regions that have been added
-    // to the app, and runs all of the initializer functions
-    start: function(options) {
-      this.triggerMethod('before:start', options);
-      this._initCallbacks.run(options, this);
-      this.triggerMethod('start', options);
-    },
-  
-    // Add regions to your app.
-    // Accepts a hash of named strings or Region objects
-    // addRegions({something: "#someRegion"})
-    // addRegions({something: Region.extend({el: "#someRegion"}) });
-    addRegions: function(regions) {
-      return this._regionManager.addRegions(regions);
-    },
-  
-    // Empty all regions in the app, without removing them
-    emptyRegions: function() {
-      return this._regionManager.emptyRegions();
-    },
-  
-    // Removes a region from your app, by name
-    // Accepts the regions name
-    // removeRegion('myRegion')
-    removeRegion: function(region) {
-      return this._regionManager.removeRegion(region);
-    },
-  
-    // Provides alternative access to regions
-    // Accepts the region name
-    // getRegion('main')
-    getRegion: function(region) {
-      return this._regionManager.get(region);
-    },
-  
-    // Get all the regions from the region manager
-    getRegions: function() {
-      return this._regionManager.getRegions();
-    },
-  
-    // Create a module, attached to the application
-    module: function(moduleNames, moduleDefinition) {
-  
-      // Overwrite the module class if the user specifies one
-      var ModuleClass = Marionette.Module.getClass(moduleDefinition);
-  
-      var args = _.toArray(arguments);
-      args.unshift(this);
-  
-      // see the Marionette.Module object for more information
-      return ModuleClass.create.apply(ModuleClass, args);
-    },
-  
-    // Enable easy overriding of the default `RegionManager`
-    // for customized region interactions and business-specific
-    // view logic for better control over single regions.
-    getRegionManager: function() {
-      return new Marionette.RegionManager();
-    },
-  
-    // Internal method to initialize the regions that have been defined in a
-    // `regions` attribute on the application instance
-    _initializeRegions: function(options) {
-      var regions = _.isFunction(this.regions) ? this.regions(options) : this.regions || {};
-  
-      this._initRegionManager();
-  
-      // Enable users to define `regions` in instance options.
-      var optionRegions = Marionette.getOption(options, 'regions');
-  
-      // Enable region options to be a function
-      if (_.isFunction(optionRegions)) {
-        optionRegions = optionRegions.call(this, options);
-      }
-  
-      // Overwrite current regions with those passed in options
-      _.extend(regions, optionRegions);
-  
-      this.addRegions(regions);
-  
-      return this;
-    },
-  
-    // Internal method to set up the region manager
-    _initRegionManager: function() {
-      this._regionManager = this.getRegionManager();
-      this._regionManager._parent = this;
-  
-      this.listenTo(this._regionManager, 'before:add:region', function() {
-        Marionette._triggerMethod(this, 'before:add:region', arguments);
-      });
-  
-      this.listenTo(this._regionManager, 'add:region', function(name, region) {
-        this[name] = region;
-        Marionette._triggerMethod(this, 'add:region', arguments);
-      });
-  
-      this.listenTo(this._regionManager, 'before:remove:region', function() {
-        Marionette._triggerMethod(this, 'before:remove:region', arguments);
-      });
-  
-      this.listenTo(this._regionManager, 'remove:region', function(name) {
-        delete this[name];
-        Marionette._triggerMethod(this, 'remove:region', arguments);
-      });
-    },
-  
-    // Internal method to setup the Wreqr.radio channel
-    _initChannel: function() {
-      this.channelName = _.result(this, 'channelName') || 'global';
-      this.channel = _.result(this, 'channel') || Backbone.Wreqr.radio.channel(this.channelName);
-      this.vent = _.result(this, 'vent') || this.channel.vent;
-      this.commands = _.result(this, 'commands') || this.channel.commands;
-      this.reqres = _.result(this, 'reqres') || this.channel.reqres;
-    }
-  });
-  
-  /* jshint maxparams: 9 */
-  
-  // Module
-  // ------
-  
-  // A simple module system, used to create privacy and encapsulation in
-  // Marionette applications
-  Marionette.Module = function(moduleName, app, options) {
-    this.moduleName = moduleName;
-    this.options = _.extend({}, this.options, options);
-    // Allow for a user to overide the initialize
-    // for a given module instance.
-    this.initialize = options.initialize || this.initialize;
-  
-    // Set up an internal store for sub-modules.
-    this.submodules = {};
-  
-    this._setupInitializersAndFinalizers();
-  
-    // Set an internal reference to the app
-    // within a module.
-    this.app = app;
-  
-    if (_.isFunction(this.initialize)) {
-      this.initialize(moduleName, app, this.options);
-    }
-  };
-  
-  Marionette.Module.extend = Marionette.extend;
-  
-  // Extend the Module prototype with events / listenTo, so that the module
-  // can be used as an event aggregator or pub/sub.
-  _.extend(Marionette.Module.prototype, Backbone.Events, {
-  
-    // By default modules start with their parents.
-    startWithParent: true,
-  
-    // Initialize is an empty function by default. Override it with your own
-    // initialization logic when extending Marionette.Module.
-    initialize: function() {},
-  
-    // Initializer for a specific module. Initializers are run when the
-    // module's `start` method is called.
-    addInitializer: function(callback) {
-      this._initializerCallbacks.add(callback);
-    },
-  
-    // Finalizers are run when a module is stopped. They are used to teardown
-    // and finalize any variables, references, events and other code that the
-    // module had set up.
-    addFinalizer: function(callback) {
-      this._finalizerCallbacks.add(callback);
-    },
-  
-    // Start the module, and run all of its initializers
-    start: function(options) {
-      // Prevent re-starting a module that is already started
-      if (this._isInitialized) { return; }
-  
-      // start the sub-modules (depth-first hierarchy)
-      _.each(this.submodules, function(mod) {
-        // check to see if we should start the sub-module with this parent
-        if (mod.startWithParent) {
-          mod.start(options);
-        }
-      });
-  
-      // run the callbacks to "start" the current module
-      this.triggerMethod('before:start', options);
-  
-      this._initializerCallbacks.run(options, this);
-      this._isInitialized = true;
-  
-      this.triggerMethod('start', options);
-    },
-  
-    // Stop this module by running its finalizers and then stop all of
-    // the sub-modules for this module
-    stop: function() {
-      // if we are not initialized, don't bother finalizing
-      if (!this._isInitialized) { return; }
-      this._isInitialized = false;
-  
-      this.triggerMethod('before:stop');
-  
-      // stop the sub-modules; depth-first, to make sure the
-      // sub-modules are stopped / finalized before parents
-      _.invoke(this.submodules, 'stop');
-  
-      // run the finalizers
-      this._finalizerCallbacks.run(undefined, this);
-  
-      // reset the initializers and finalizers
-      this._initializerCallbacks.reset();
-      this._finalizerCallbacks.reset();
-  
-      this.triggerMethod('stop');
-    },
-  
-    // Configure the module with a definition function and any custom args
-    // that are to be passed in to the definition function
-    addDefinition: function(moduleDefinition, customArgs) {
-      this._runModuleDefinition(moduleDefinition, customArgs);
-    },
-  
-    // Internal method: run the module definition function with the correct
-    // arguments
-    _runModuleDefinition: function(definition, customArgs) {
-      // If there is no definition short circut the method.
-      if (!definition) { return; }
-  
-      // build the correct list of arguments for the module definition
-      var args = _.flatten([
-        this,
-        this.app,
-        Backbone,
-        Marionette,
-        Backbone.$, _,
-        customArgs
-      ]);
-  
-      definition.apply(this, args);
-    },
-  
-    // Internal method: set up new copies of initializers and finalizers.
-    // Calling this method will wipe out all existing initializers and
-    // finalizers.
-    _setupInitializersAndFinalizers: function() {
-      this._initializerCallbacks = new Marionette.Callbacks();
-      this._finalizerCallbacks = new Marionette.Callbacks();
-    },
-  
-    // import the `triggerMethod` to trigger events with corresponding
-    // methods if the method exists
-    triggerMethod: Marionette.triggerMethod
-  });
-  
-  // Class methods to create modules
-  _.extend(Marionette.Module, {
-  
-    // Create a module, hanging off the app parameter as the parent object.
-    create: function(app, moduleNames, moduleDefinition) {
-      var module = app;
-  
-      // get the custom args passed in after the module definition and
-      // get rid of the module name and definition function
-      var customArgs = _.drop(arguments, 3);
-  
-      // Split the module names and get the number of submodules.
-      // i.e. an example module name of `Doge.Wow.Amaze` would
-      // then have the potential for 3 module definitions.
-      moduleNames = moduleNames.split('.');
-      var length = moduleNames.length;
-  
-      // store the module definition for the last module in the chain
-      var moduleDefinitions = [];
-      moduleDefinitions[length - 1] = moduleDefinition;
-  
-      // Loop through all the parts of the module definition
-      _.each(moduleNames, function(moduleName, i) {
-        var parentModule = module;
-        module = this._getModule(parentModule, moduleName, app, moduleDefinition);
-        this._addModuleDefinition(parentModule, module, moduleDefinitions[i], customArgs);
-      }, this);
-  
-      // Return the last module in the definition chain
-      return module;
-    },
-  
-    _getModule: function(parentModule, moduleName, app, def, args) {
-      var options = _.extend({}, def);
-      var ModuleClass = this.getClass(def);
-  
-      // Get an existing module of this name if we have one
-      var module = parentModule[moduleName];
-  
-      if (!module) {
-        // Create a new module if we don't have one
-        module = new ModuleClass(moduleName, app, options);
-        parentModule[moduleName] = module;
-        // store the module on the parent
-        parentModule.submodules[moduleName] = module;
-      }
-  
-      return module;
-    },
-  
-    // ## Module Classes
-    //
-    // Module classes can be used as an alternative to the define pattern.
-    // The extend function of a Module is identical to the extend functions
-    // on other Backbone and Marionette classes.
-    // This allows module lifecyle events like `onStart` and `onStop` to be called directly.
-    getClass: function(moduleDefinition) {
-      var ModuleClass = Marionette.Module;
-  
-      if (!moduleDefinition) {
-        return ModuleClass;
-      }
-  
-      // If all of the module's functionality is defined inside its class,
-      // then the class can be passed in directly. `MyApp.module("Foo", FooModule)`.
-      if (moduleDefinition.prototype instanceof ModuleClass) {
-        return moduleDefinition;
-      }
-  
-      return moduleDefinition.moduleClass || ModuleClass;
-    },
-  
-    // Add the module definition and add a startWithParent initializer function.
-    // This is complicated because module definitions are heavily overloaded
-    // and support an anonymous function, module class, or options object
-    _addModuleDefinition: function(parentModule, module, def, args) {
-      var fn = this._getDefine(def);
-      var startWithParent = this._getStartWithParent(def, module);
-  
-      if (fn) {
-        module.addDefinition(fn, args);
-      }
-  
-      this._addStartWithParent(parentModule, module, startWithParent);
-    },
-  
-    _getStartWithParent: function(def, module) {
-      var swp;
-  
-      if (_.isFunction(def) && (def.prototype instanceof Marionette.Module)) {
-        swp = module.constructor.prototype.startWithParent;
-        return _.isUndefined(swp) ? true : swp;
-      }
-  
-      if (_.isObject(def)) {
-        swp = def.startWithParent;
-        return _.isUndefined(swp) ? true : swp;
-      }
-  
-      return true;
-    },
-  
-    _getDefine: function(def) {
-      if (_.isFunction(def) && !(def.prototype instanceof Marionette.Module)) {
-        return def;
-      }
-  
-      if (_.isObject(def)) {
-        return def.define;
-      }
-  
-      return null;
-    },
-  
-    _addStartWithParent: function(parentModule, module, startWithParent) {
-      module.startWithParent = module.startWithParent && startWithParent;
-  
-      if (!module.startWithParent || !!module.startWithParentIsConfigured) {
-        return;
-      }
-  
-      module.startWithParentIsConfigured = true;
-  
-      parentModule.addInitializer(function(options) {
-        if (module.startWithParent) {
-          module.start(options);
-        }
-      });
-    }
-  });
-  
+	    this._isDestroyed = true;
+	    this.triggerMethod.apply(this, ['destroy', this].concat(args));
+	    this.stopListening();
 
-  return Marionette;
+	    return this;
+	  },
+
+
+	  triggerMethod: triggerMethod
+	});
+
+	// Manage templates stored in `<script>` blocks,
+	// caching them for faster access.
+	var TemplateCache = function TemplateCache(templateId) {
+	  this.templateId = templateId;
+	};
+
+	// TemplateCache object-level methods. Manage the template
+	// caches from these method calls instead of creating
+	// your own TemplateCache instances
+	_.extend(TemplateCache, {
+	  templateCaches: {},
+
+	  // Get the specified template by id. Either
+	  // retrieves the cached version, or loads it
+	  // from the DOM.
+	  get: function get(templateId, options) {
+	    var cachedTemplate = this.templateCaches[templateId];
+
+	    if (!cachedTemplate) {
+	      cachedTemplate = new TemplateCache(templateId);
+	      this.templateCaches[templateId] = cachedTemplate;
+	    }
+
+	    return cachedTemplate.load(options);
+	  },
+
+
+	  // Clear templates from the cache. If no arguments
+	  // are specified, clears all templates:
+	  // `clear()`
+	  //
+	  // If arguments are specified, clears each of the
+	  // specified templates from the cache:
+	  // `clear("#t1", "#t2", "...")`
+	  clear: function clear() {
+	    var i = void 0;
+
+	    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+	      args[_key] = arguments[_key];
+	    }
+
+	    var length = args.length;
+
+	    if (length > 0) {
+	      for (i = 0; i < length; i++) {
+	        delete this.templateCaches[args[i]];
+	      }
+	    } else {
+	      this.templateCaches = {};
+	    }
+	  }
+	});
+
+	// TemplateCache instance methods, allowing each
+	// template cache object to manage its own state
+	// and know whether or not it has been loaded
+	_.extend(TemplateCache.prototype, {
+
+	  // Internal method to load the template
+	  load: function load(options) {
+	    // Guard clause to prevent loading this template more than once
+	    if (this.compiledTemplate) {
+	      return this.compiledTemplate;
+	    }
+
+	    // Load the template and compile it
+	    var template = this.loadTemplate(this.templateId, options);
+	    this.compiledTemplate = this.compileTemplate(template, options);
+
+	    return this.compiledTemplate;
+	  },
+
+
+	  // Load a template from the DOM, by default. Override
+	  // this method to provide your own template retrieval
+	  // For asynchronous loading with AMD/RequireJS, consider
+	  // using a template-loader plugin as described here:
+	  // https://github.com/marionettejs/backbone.marionette/wiki/Using-marionette-with-requirejs
+	  loadTemplate: function loadTemplate(templateId, options) {
+	    var $template = Backbone.$(templateId);
+
+	    if (!$template.length) {
+	      throw new MarionetteError({
+	        name: 'NoTemplateError',
+	        message: 'Could not find template: "' + templateId + '"'
+	      });
+	    }
+	    return $template.html();
+	  },
+
+
+	  // Pre-compile the template before caching it. Override
+	  // this method if you do not need to pre-compile a template
+	  // (JST / RequireJS for example) or if you want to change
+	  // the template engine used (Handebars, etc).
+	  compileTemplate: function compileTemplate(rawTemplate, options) {
+	    return _.template(rawTemplate, options);
+	  }
+	});
+
+	var _invoke = _.invokeMap || _.invoke;
+
+	var toConsumableArray = function (arr) {
+	  if (Array.isArray(arr)) {
+	    for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i];
+
+	    return arr2;
+	  } else {
+	    return Array.from(arr);
+	  }
+	};
+
+	// MixinOptions
+	// - behaviors
+
+	// Takes care of getting the behavior class
+	// given options and a key.
+	// If a user passes in options.behaviorClass
+	// default to using that.
+	// If a user passes in a Behavior Class directly, use that
+	// Otherwise delegate the lookup to the users `behaviorsLookup` implementation.
+	function getBehaviorClass(options, key) {
+	  if (options.behaviorClass) {
+	    return options.behaviorClass;
+	    //treat functions as a Behavior constructor
+	  } else if (_.isFunction(options)) {
+	    return options;
+	  }
+
+	  // behaviorsLookup can be either a flat object or a method
+	  if (_.isFunction(Marionette.Behaviors.behaviorsLookup)) {
+	    return Marionette.Behaviors.behaviorsLookup(options, key)[key];
+	  }
+
+	  return Marionette.Behaviors.behaviorsLookup[key];
+	}
+
+	// Iterate over the behaviors object, for each behavior
+	// instantiate it and get its grouped behaviors.
+	// This accepts a list of behaviors in either an object or array form
+	function parseBehaviors(view, behaviors) {
+	  return _.chain(behaviors).map(function (options, key) {
+	    var BehaviorClass = getBehaviorClass(options, key);
+	    //if we're passed a class directly instead of an object
+	    var _options = options === BehaviorClass ? {} : options;
+	    var behavior = new BehaviorClass(_options, view);
+	    var nestedBehaviors = parseBehaviors(view, _.result(behavior, 'behaviors'));
+
+	    return [behavior].concat(nestedBehaviors);
+	  }).flatten().value();
+	}
+
+	var BehaviorsMixin = {
+	  _initBehaviors: function _initBehaviors() {
+	    var behaviors = _.result(this, 'behaviors');
+
+	    // Behaviors defined on a view can be a flat object literal
+	    // or it can be a function that returns an object.
+	    this._behaviors = _.isObject(behaviors) ? parseBehaviors(this, behaviors) : {};
+	  },
+	  _getBehaviorTriggers: function _getBehaviorTriggers() {
+	    var triggers = _invoke(this._behaviors, 'getTriggers');
+	    return _.extend.apply(_, [{}].concat(toConsumableArray(triggers)));
+	  },
+	  _getBehaviorEvents: function _getBehaviorEvents() {
+	    var events = _invoke(this._behaviors, 'getEvents');
+	    return _.extend.apply(_, [{}].concat(toConsumableArray(events)));
+	  },
+
+
+	  // proxy behavior $el to the view's $el.
+	  _proxyBehaviorViewProperties: function _proxyBehaviorViewProperties() {
+	    _invoke(this._behaviors, 'proxyViewProperties');
+	  },
+
+
+	  // delegate modelEvents and collectionEvents
+	  _delegateBehaviorEntityEvents: function _delegateBehaviorEntityEvents() {
+	    _invoke(this._behaviors, 'delegateEntityEvents');
+	  },
+
+
+	  // undelegate modelEvents and collectionEvents
+	  _undelegateBehaviorEntityEvents: function _undelegateBehaviorEntityEvents() {
+	    _invoke(this._behaviors, 'undelegateEntityEvents');
+	  },
+	  _destroyBehaviors: function _destroyBehaviors(args) {
+	    // Call destroy on each behavior after
+	    // destroying the view.
+	    // This unbinds event listeners
+	    // that behaviors have registered for.
+	    _invoke.apply(undefined, [this._behaviors, 'destroy'].concat(toConsumableArray(args)));
+	  },
+	  _bindBehaviorUIElements: function _bindBehaviorUIElements() {
+	    _invoke(this._behaviors, 'bindUIElements');
+	  },
+	  _unbindBehaviorUIElements: function _unbindBehaviorUIElements() {
+	    _invoke(this._behaviors, 'unbindUIElements');
+	  },
+	  _triggerEventOnBehaviors: function _triggerEventOnBehaviors() {
+	    var behaviors = this._behaviors;
+	    // Use good ol' for as this is a very hot function
+
+	    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+	      args[_key] = arguments[_key];
+	    }
+
+	    for (var i = 0, length = behaviors && behaviors.length; i < length; i++) {
+	      triggerMethod.apply(behaviors[i], args);
+	    }
+	  }
+	};
+
+	// MixinOptions
+	// - collectionEvents
+	// - modelEvents
+
+	var DelegateEntityEventsMixin = {
+	  // Handle `modelEvents`, and `collectionEvents` configuration
+	  _delegateEntityEvents: function _delegateEntityEvents(model, collection) {
+	    this._undelegateEntityEvents(model, collection);
+
+	    var modelEvents = _.result(this, 'modelEvents');
+	    bindEvents.call(this, model, modelEvents);
+
+	    var collectionEvents = _.result(this, 'collectionEvents');
+	    bindEvents.call(this, collection, collectionEvents);
+	  },
+	  _undelegateEntityEvents: function _undelegateEntityEvents(model, collection) {
+	    var modelEvents = _.result(this, 'modelEvents');
+	    unbindEvents.call(this, model, modelEvents);
+
+	    var collectionEvents = _.result(this, 'collectionEvents');
+	    unbindEvents.call(this, collection, collectionEvents);
+	  }
+	};
+
+	// Borrow event splitter from Backbone
+	var delegateEventSplitter = /^(\S+)\s*(.*)$/;
+
+	function uniqueName(eventName, selector) {
+	  return [eventName + _.uniqueId('.evt'), selector].join(' ');
+	}
+
+	// Set event name to be namespaced using a unique index
+	// to generate a non colliding event namespace
+	// http://api.jquery.com/event.namespace/
+	var getUniqueEventName = function getUniqueEventName(eventName) {
+	  var match = eventName.match(delegateEventSplitter);
+	  return uniqueName(match[1], match[2]);
+	};
+
+	// Internal method to create an event handler for a given `triggerDef` like
+	// 'click:foo'
+	function buildViewTrigger(view, triggerDef) {
+	  if (_.isString(triggerDef)) {
+	    triggerDef = { event: triggerDef };
+	  }
+
+	  var eventName = triggerDef.event;
+	  var shouldPreventDefault = triggerDef.preventDefault !== false;
+	  var shouldStopPropagation = triggerDef.stopPropagation !== false;
+
+	  return function (e) {
+	    if (shouldPreventDefault) {
+	      e.preventDefault();
+	    }
+
+	    if (shouldStopPropagation) {
+	      e.stopPropagation();
+	    }
+
+	    view.triggerMethod(eventName, view);
+	  };
+	}
+
+	var TriggersMixin = {
+
+	  // Configure `triggers` to forward DOM events to view
+	  // events. `triggers: {"click .foo": "do:foo"}`
+	  _getViewTriggers: function _getViewTriggers(view, triggers) {
+	    // Configure the triggers, prevent default
+	    // action and stop propagation of DOM events
+	    return _.reduce(triggers, function (events, value, key) {
+	      key = getUniqueEventName(key);
+	      events[key] = buildViewTrigger(view, value);
+	      return events;
+	    }, {});
+	  }
+	};
+
+	// allows for the use of the @ui. syntax within
+	// a given key for triggers and events
+	// swaps the @ui with the associated selector.
+	// Returns a new, non-mutated, parsed events hash.
+	var _normalizeUIKeys = function _normalizeUIKeys(hash, ui) {
+	  return _.reduce(hash, function (memo, val, key) {
+	    var normalizedKey = normalizeUIString(key, ui);
+	    memo[normalizedKey] = val;
+	    return memo;
+	  }, {});
+	};
+
+	// utility method for parsing @ui. syntax strings
+	// into associated selector
+	var normalizeUIString = function normalizeUIString(uiString, ui) {
+	  return uiString.replace(/@ui\.[a-zA-Z-_$0-9]*/g, function (r) {
+	    return ui[r.slice(4)];
+	  });
+	};
+
+	// allows for the use of the @ui. syntax within
+	// a given value for regions
+	// swaps the @ui with the associated selector
+	var _normalizeUIValues = function _normalizeUIValues(hash, ui, properties) {
+	  _.each(hash, function (val, key) {
+	    if (_.isString(val)) {
+	      hash[key] = normalizeUIString(val, ui);
+	    } else if (_.isObject(val) && _.isArray(properties)) {
+	      _.extend(val, _normalizeUIValues(_.pick(val, properties), ui));
+	      /* Value is an object, and we got an array of embedded property names to normalize. */
+	      _.each(properties, function (property) {
+	        var propertyVal = val[property];
+	        if (_.isString(propertyVal)) {
+	          val[property] = normalizeUIString(propertyVal, ui);
+	        }
+	      });
+	    }
+	  });
+	  return hash;
+	};
+
+	var UIMixin = {
+
+	  // normalize the keys of passed hash with the views `ui` selectors.
+	  // `{"@ui.foo": "bar"}`
+	  normalizeUIKeys: function normalizeUIKeys(hash) {
+	    var uiBindings = this._getUIBindings();
+	    return _normalizeUIKeys(hash, uiBindings);
+	  },
+
+
+	  // normalize the values of passed hash with the views `ui` selectors.
+	  // `{foo: "@ui.bar"}`
+	  normalizeUIValues: function normalizeUIValues(hash, properties) {
+	    var uiBindings = this._getUIBindings();
+	    return _normalizeUIValues(hash, uiBindings, properties);
+	  },
+	  _getUIBindings: function _getUIBindings() {
+	    var uiBindings = _.result(this, '_uiBindings');
+	    var ui = _.result(this, 'ui');
+	    return uiBindings || ui;
+	  },
+
+
+	  // This method binds the elements specified in the "ui" hash inside the view's code with
+	  // the associated jQuery selectors.
+	  _bindUIElements: function _bindUIElements() {
+	    var _this = this;
+
+	    if (!this.ui) {
+	      return;
+	    }
+
+	    // store the ui hash in _uiBindings so they can be reset later
+	    // and so re-rendering the view will be able to find the bindings
+	    if (!this._uiBindings) {
+	      this._uiBindings = this.ui;
+	    }
+
+	    // get the bindings result, as a function or otherwise
+	    var bindings = _.result(this, '_uiBindings');
+
+	    // empty the ui so we don't have anything to start with
+	    this._ui = {};
+
+	    // bind each of the selectors
+	    _.each(bindings, function (selector, key) {
+	      _this._ui[key] = _this.$(selector);
+	    });
+
+	    this.ui = this._ui;
+	  },
+	  _unbindUIElements: function _unbindUIElements() {
+	    var _this2 = this;
+
+	    if (!this.ui || !this._uiBindings) {
+	      return;
+	    }
+
+	    // delete all of the existing ui bindings
+	    _.each(this.ui, function ($el, name) {
+	      delete _this2.ui[name];
+	    });
+
+	    // reset the ui element to the original bindings configuration
+	    this.ui = this._uiBindings;
+	    delete this._uiBindings;
+	    delete this._ui;
+	  },
+	  _getUI: function _getUI(name) {
+	    return this._ui[name];
+	  }
+	};
+
+	// MixinOptions
+	// - behaviors
+	// - childViewEventPrefix
+	// - childViewEvents
+	// - childViewTriggers
+	// - collectionEvents
+	// - modelEvents
+	// - triggers
+	// - ui
+
+
+	var ViewMixin = {
+	  supportsRenderLifecycle: true,
+	  supportsDestroyLifecycle: true,
+
+	  _isDestroyed: false,
+
+	  isDestroyed: function isDestroyed() {
+	    return !!this._isDestroyed;
+	  },
+
+
+	  _isRendered: false,
+
+	  isRendered: function isRendered() {
+	    return !!this._isRendered;
+	  },
+
+
+	  _isAttached: false,
+
+	  isAttached: function isAttached() {
+	    return !!this._isAttached;
+	  },
+
+
+	  // Overriding Backbone.View's `setElement` to handle
+	  // if an el was previously defined. If so, the view might be
+	  // rendered or attached on setElement.
+	  setElement: function setElement() {
+	    var hasEl = !!this.el;
+
+	    Backbone.View.prototype.setElement.apply(this, arguments);
+
+	    if (hasEl) {
+	      this._isRendered = !!this.$el.length;
+	      this._isAttached = isNodeAttached(this.el);
+	    }
+
+	    return this;
+	  },
+
+
+	  // Overriding Backbone.View's `delegateEvents` to handle
+	  // `events` and `triggers`
+	  delegateEvents: function delegateEvents(eventsArg) {
+
+	    this._proxyBehaviorViewProperties();
+	    this._buildEventProxies();
+
+	    var viewEvents = this._getEvents(eventsArg);
+
+	    if (typeof eventsArg === 'undefined') {
+	      this.events = viewEvents;
+	    }
+
+	    var combinedEvents = _.extend({}, this._getBehaviorEvents(), viewEvents, this._getBehaviorTriggers(), this.getTriggers());
+
+	    Backbone.View.prototype.delegateEvents.call(this, combinedEvents);
+
+	    return this;
+	  },
+	  _getEvents: function _getEvents(eventsArg) {
+	    var events = eventsArg || this.events;
+
+	    if (_.isFunction(events)) {
+	      return this.normalizeUIKeys(events.call(this));
+	    }
+
+	    return this.normalizeUIKeys(events);
+	  },
+
+
+	  // Configure `triggers` to forward DOM events to view
+	  // events. `triggers: {"click .foo": "do:foo"}`
+	  getTriggers: function getTriggers() {
+	    if (!this.triggers) {
+	      return;
+	    }
+
+	    // Allow `triggers` to be configured as a function
+	    var triggers = this.normalizeUIKeys(_.result(this, 'triggers'));
+
+	    // Configure the triggers, prevent default
+	    // action and stop propagation of DOM events
+	    return this._getViewTriggers(this, triggers);
+	  },
+
+
+	  // Handle `modelEvents`, and `collectionEvents` configuration
+	  delegateEntityEvents: function delegateEntityEvents() {
+	    this._delegateEntityEvents(this.model, this.collection);
+
+	    // bind each behaviors model and collection events
+	    this._delegateBehaviorEntityEvents();
+
+	    return this;
+	  },
+
+
+	  // Handle unbinding `modelEvents`, and `collectionEvents` configuration
+	  undelegateEntityEvents: function undelegateEntityEvents() {
+	    this._undelegateEntityEvents(this.model, this.collection);
+
+	    // unbind each behaviors model and collection events
+	    this._undelegateBehaviorEntityEvents();
+
+	    return this;
+	  },
+
+
+	  // Internal helper method to verify whether the view hasn't been destroyed
+	  _ensureViewIsIntact: function _ensureViewIsIntact() {
+	    if (this._isDestroyed) {
+	      throw new MarionetteError({
+	        name: 'ViewDestroyedError',
+	        message: 'View (cid: "' + this.cid + '") has already been destroyed and cannot be used.'
+	      });
+	    }
+	  },
+
+
+	  // Handle destroying the view and its children.
+	  destroy: function destroy() {
+	    if (this._isDestroyed) {
+	      return this;
+	    }
+	    var shouldTriggerDetach = !!this._isAttached;
+
+	    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+	      args[_key] = arguments[_key];
+	    }
+
+	    this.triggerMethod.apply(this, ['before:destroy', this].concat(args));
+	    if (shouldTriggerDetach) {
+	      this.triggerMethod('before:detach', this);
+	    }
+
+	    // unbind UI elements
+	    this.unbindUIElements();
+
+	    // remove the view from the DOM
+	    // https://github.com/jashkenas/backbone/blob/1.2.3/backbone.js#L1235
+	    this._removeElement();
+
+	    if (shouldTriggerDetach) {
+	      this._isAttached = false;
+	      this.triggerMethod('detach', this);
+	    }
+
+	    // remove children after the remove to prevent extra paints
+	    this._removeChildren();
+
+	    this._destroyBehaviors(args);
+
+	    this._isDestroyed = true;
+	    this._isRendered = false;
+	    this.triggerMethod.apply(this, ['destroy', this].concat(args));
+
+	    this.stopListening();
+
+	    return this;
+	  },
+	  bindUIElements: function bindUIElements() {
+	    this._bindUIElements();
+	    this._bindBehaviorUIElements();
+
+	    return this;
+	  },
+
+
+	  // This method unbinds the elements specified in the "ui" hash
+	  unbindUIElements: function unbindUIElements() {
+	    this._unbindUIElements();
+	    this._unbindBehaviorUIElements();
+
+	    return this;
+	  },
+	  getUI: function getUI(name) {
+	    this._ensureViewIsIntact();
+	    return this._getUI(name);
+	  },
+
+
+	  // used as the prefix for child view events
+	  // that are forwarded through the layoutview
+	  childViewEventPrefix: 'childview',
+
+	  // import the `triggerMethod` to trigger events with corresponding
+	  // methods if the method exists
+	  triggerMethod: function triggerMethod$$() {
+	    for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+	      args[_key2] = arguments[_key2];
+	    }
+
+	    var ret = triggerMethod.apply(this, args);
+
+	    this._triggerEventOnBehaviors.apply(this, args);
+	    this._triggerEventOnParentLayout.apply(this, args);
+
+	    return ret;
+	  },
+
+
+	  // Cache `childViewEvents` and `childViewTriggers`
+	  _buildEventProxies: function _buildEventProxies() {
+	    this._childViewEvents = _.result(this, 'childViewEvents');
+	    this._childViewTriggers = _.result(this, 'childViewTriggers');
+	  },
+	  _triggerEventOnParentLayout: function _triggerEventOnParentLayout(eventName) {
+	    var layoutView = this._parentView();
+	    if (!layoutView) {
+	      return;
+	    }
+
+	    // invoke triggerMethod on parent view
+	    var eventPrefix = _.result(layoutView, 'childViewEventPrefix');
+	    var prefixedEventName = eventPrefix + ':' + eventName;
+
+	    for (var _len3 = arguments.length, args = Array(_len3 > 1 ? _len3 - 1 : 0), _key3 = 1; _key3 < _len3; _key3++) {
+	      args[_key3 - 1] = arguments[_key3];
+	    }
+
+	    layoutView.triggerMethod.apply(layoutView, [prefixedEventName].concat(args));
+
+	    // use the parent view's childViewEvents handler
+	    var childViewEvents = layoutView.normalizeMethods(layoutView._childViewEvents);
+
+	    if (!!childViewEvents && _.isFunction(childViewEvents[eventName])) {
+	      childViewEvents[eventName].apply(layoutView, args);
+	    }
+
+	    // use the parent view's proxyEvent handlers
+	    var childViewTriggers = layoutView._childViewTriggers;
+
+	    // Call the event with the proxy name on the parent layout
+	    if (childViewTriggers && _.isString(childViewTriggers[eventName])) {
+	      layoutView.triggerMethod.apply(layoutView, [childViewTriggers[eventName]].concat(args));
+	    }
+	  },
+
+
+	  // Walk the _parent tree until we find a view (if one exists).
+	  // Returns the parent view hierarchically closest to this view.
+	  _parentView: function _parentView() {
+	    var parent = this._parent;
+
+	    while (parent) {
+	      if (parent instanceof View) {
+	        return parent;
+	      }
+	      parent = parent._parent;
+	    }
+	  }
+	};
+
+	_.extend(ViewMixin, BehaviorsMixin, CommonMixin, DelegateEntityEventsMixin, TriggersMixin, UIMixin);
+
+	function destroyBackboneView(view) {
+	  if (!view.supportsDestroyLifecycle) {
+	    triggerMethodOn(view, 'before:destroy', view);
+	  }
+
+	  var shouldTriggerDetach = !!view._isAttached;
+
+	  if (shouldTriggerDetach) {
+	    triggerMethodOn(view, 'before:detach', view);
+	  }
+
+	  view.remove();
+
+	  if (shouldTriggerDetach) {
+	    view._isAttached = false;
+	    triggerMethodOn(view, 'detach', view);
+	  }
+
+	  view._isDestroyed = true;
+
+	  if (!view.supportsDestroyLifecycle) {
+	    triggerMethodOn(view, 'destroy', view);
+	  }
+	}
+
+	var ClassOptions$2 = ['allowMissingEl', 'parentEl', 'replaceElement'];
+
+	var Region = MarionetteObject.extend({
+	  cidPrefix: 'mnr',
+	  replaceElement: false,
+	  _isReplaced: false,
+
+	  constructor: function constructor(options) {
+	    this._setOptions(options);
+
+	    this.mergeOptions(options, ClassOptions$2);
+
+	    // getOption necessary because options.el may be passed as undefined
+	    this._initEl = this.el = this.getOption('el');
+
+	    // Handle when this.el is passed in as a $ wrapped element.
+	    this.el = this.el instanceof Backbone.$ ? this.el[0] : this.el;
+
+	    if (!this.el) {
+	      throw new MarionetteError({
+	        name: 'NoElError',
+	        message: 'An "el" must be specified for a region.'
+	      });
+	    }
+
+	    this.$el = this.getEl(this.el);
+	    MarionetteObject.call(this, options);
+	  },
+
+
+	  // Displays a backbone view instance inside of the region. Handles calling the `render`
+	  // method for you. Reads content directly from the `el` attribute. The `preventDestroy`
+	  // option can be used to prevent a view from the old view being destroyed on show.
+	  show: function show(view, options) {
+	    if (!this._ensureElement(options)) {
+	      return;
+	    }
+	    this._ensureView(view);
+	    if (view === this.currentView) {
+	      return this;
+	    }
+
+	    this.triggerMethod('before:show', this, view, options);
+
+	    monitorViewEvents(view);
+
+	    this.empty(options);
+
+	    // We need to listen for if a view is destroyed in a way other than through the region.
+	    // If this happens we need to remove the reference to the currentView since once a view
+	    // has been destroyed we can not reuse it.
+	    view.on('destroy', this.empty, this);
+
+	    // Make this region the view's parent.
+	    // It's important that this parent binding happens before rendering so that any events
+	    // the child may trigger during render can also be triggered on the child's ancestor views.
+	    view._parent = this;
+
+	    this._renderView(view);
+
+	    this._attachView(view, options);
+
+	    this.triggerMethod('show', this, view, options);
+	    return this;
+	  },
+	  _renderView: function _renderView(view) {
+	    if (view._isRendered) {
+	      return;
+	    }
+
+	    if (!view.supportsRenderLifecycle) {
+	      triggerMethodOn(view, 'before:render', view);
+	    }
+
+	    view.render();
+
+	    if (!view.supportsRenderLifecycle) {
+	      view._isRendered = true;
+	      triggerMethodOn(view, 'render', view);
+	    }
+	  },
+	  _attachView: function _attachView(view) {
+	    var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+	    var shouldTriggerAttach = !view._isAttached && isNodeAttached(this.el);
+	    var shouldReplaceEl = typeof options.replaceElement === 'undefined' ? !!_.result(this, 'replaceElement') : !!options.replaceElement;
+
+	    if (shouldTriggerAttach) {
+	      triggerMethodOn(view, 'before:attach', view);
+	    }
+
+	    this.attachHtml(view, shouldReplaceEl);
+
+	    if (shouldTriggerAttach) {
+	      view._isAttached = true;
+	      triggerMethodOn(view, 'attach', view);
+	    }
+
+	    this.currentView = view;
+	  },
+	  _ensureElement: function _ensureElement() {
+	    var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+	    if (!_.isObject(this.el)) {
+	      this.$el = this.getEl(this.el);
+	      this.el = this.$el[0];
+	    }
+
+	    if (!this.$el || this.$el.length === 0) {
+	      var allowMissingEl = typeof options.allowMissingEl === 'undefined' ? !!_.result(this, 'allowMissingEl') : !!options.allowMissingEl;
+
+	      if (allowMissingEl) {
+	        return false;
+	      } else {
+	        throw new MarionetteError('An "el" must exist in DOM for this region ' + this.cid);
+	      }
+	    }
+	    return true;
+	  },
+	  _ensureView: function _ensureView(view) {
+	    if (!view) {
+	      throw new MarionetteError({
+	        name: 'ViewNotValid',
+	        message: 'The view passed is undefined and therefore invalid. You must pass a view instance to show.'
+	      });
+	    }
+
+	    if (view._isDestroyed) {
+	      throw new MarionetteError({
+	        name: 'ViewDestroyedError',
+	        message: 'View (cid: "' + view.cid + '") has already been destroyed and cannot be used.'
+	      });
+	    }
+	  },
+
+
+	  // Override this method to change how the region finds the DOM element that it manages. Return
+	  // a jQuery selector object scoped to a provided parent el or the document if none exists.
+	  getEl: function getEl(el) {
+	    return Backbone.$(el, _.result(this, 'parentEl'));
+	  },
+	  _replaceEl: function _replaceEl(view) {
+	    // always restore the el to ensure the regions el is present before replacing
+	    this._restoreEl();
+
+	    var parent = this.el.parentNode;
+
+	    parent.replaceChild(view.el, this.el);
+	    this._isReplaced = true;
+	  },
+
+
+	  // Restore the region's element in the DOM.
+	  _restoreEl: function _restoreEl() {
+	    // There is nothing to replace
+	    if (!this._isReplaced) {
+	      return;
+	    }
+
+	    var view = this.currentView;
+
+	    if (!view) {
+	      return;
+	    }
+
+	    var parent = view.el.parentNode;
+
+	    if (!parent) {
+	      return;
+	    }
+
+	    parent.replaceChild(this.el, view.el);
+	    this._isReplaced = false;
+	  },
+
+
+	  // Check to see if the region's el was replaced.
+	  isReplaced: function isReplaced() {
+	    return !!this._isReplaced;
+	  },
+
+
+	  // Override this method to change how the new view is appended to the `$el` that the
+	  // region is managing
+	  attachHtml: function attachHtml(view, shouldReplace) {
+	    if (shouldReplace) {
+	      // replace the region's node with the view's node
+	      this._replaceEl(view);
+	    } else {
+	      this.el.appendChild(view.el);
+	    }
+	  },
+
+
+	  // Destroy the current view, if there is one. If there is no current view, it does
+	  // nothing and returns immediately.
+	  empty: function empty() {
+	    var options = arguments.length <= 0 || arguments[0] === undefined ? { allowMissingEl: true } : arguments[0];
+
+	    var view = this.currentView;
+
+	    // If there is no view in the region we should only detach current html
+	    if (!view) {
+	      if (this._ensureElement(options)) {
+	        this.detachHtml();
+	      }
+	      return this;
+	    }
+
+	    view.off('destroy', this.empty, this);
+	    this.triggerMethod('before:empty', this, view);
+
+	    this._restoreEl();
+
+	    delete this.currentView;
+
+	    if (!view._isDestroyed) {
+	      this._removeView(view, options);
+	      delete view._parent;
+	    }
+
+	    this.triggerMethod('empty', this, view);
+	    return this;
+	  },
+	  _removeView: function _removeView(view) {
+	    var _ref = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+	    var preventDestroy = _ref.preventDestroy;
+
+	    var shouldPreventDestroy = !!preventDestroy;
+
+	    if (shouldPreventDestroy) {
+	      this._detachView(view);
+	      return;
+	    }
+
+	    if (view.destroy) {
+	      view.destroy();
+	    } else {
+	      destroyBackboneView(view);
+	    }
+	  },
+	  _detachView: function _detachView(view) {
+	    var shouldTriggerDetach = !!view._isAttached;
+	    if (shouldTriggerDetach) {
+	      triggerMethodOn(view, 'before:detach', view);
+	    }
+
+	    this.detachHtml();
+
+	    if (shouldTriggerDetach) {
+	      view._isAttached = false;
+	      triggerMethodOn(view, 'detach', view);
+	    }
+	  },
+
+
+	  // Override this method to change how the region detaches current content
+	  detachHtml: function detachHtml() {
+	    this.$el.contents().detach();
+	  },
+
+
+	  // Checks whether a view is currently present within the region. Returns `true` if there is
+	  // and `false` if no view is present.
+	  hasView: function hasView() {
+	    return !!this.currentView;
+	  },
+
+
+	  // Reset the region by destroying any existing view and clearing out the cached `$el`.
+	  // The next time a view is shown via this region, the region will re-query the DOM for
+	  // the region's `el`.
+	  reset: function reset(options) {
+	    this.empty(options);
+
+	    if (this.$el) {
+	      this.el = this._initEl;
+	    }
+
+	    delete this.$el;
+	    return this;
+	  },
+	  destroy: function destroy(options) {
+	    this.reset(options);
+	    return MarionetteObject.prototype.destroy.apply(this, arguments);
+	  }
+	});
+
+	// MixinOptions
+	// - regions
+	// - regionClass
+
+	var RegionsMixin = {
+	  regionClass: Region,
+
+	  // Internal method to initialize the regions that have been defined in a
+	  // `regions` attribute on this View.
+	  _initRegions: function _initRegions() {
+
+	    // init regions hash
+	    this.regions = this.regions || {};
+	    this._regions = {};
+
+	    this.addRegions(_.result(this, 'regions'));
+	  },
+
+
+	  // Internal method to re-initialize all of the regions by updating
+	  // the `el` that they point to
+	  _reInitRegions: function _reInitRegions() {
+	    _invoke(this._regions, 'reset');
+	  },
+
+
+	  // Add a single region, by name, to the View
+	  addRegion: function addRegion(name, definition) {
+	    var regions = {};
+	    regions[name] = definition;
+	    return this.addRegions(regions)[name];
+	  },
+
+
+	  // Add multiple regions as a {name: definition, name2: def2} object literal
+	  addRegions: function addRegions(regions) {
+	    // If there's nothing to add, stop here.
+	    if (_.isEmpty(regions)) {
+	      return;
+	    }
+
+	    // Normalize region selectors hash to allow
+	    // a user to use the @ui. syntax.
+	    regions = this.normalizeUIValues(regions, ['selector', 'el']);
+
+	    // Add the regions definitions to the regions property
+	    this.regions = _.extend({}, this.regions, regions);
+
+	    return this._addRegions(regions);
+	  },
+
+
+	  // internal method to build and add regions
+	  _addRegions: function _addRegions(regionDefinitions) {
+	    var _this = this;
+
+	    return _.reduce(regionDefinitions, function (regions, definition, name) {
+	      regions[name] = _this._buildRegion(definition);
+	      _this._addRegion(regions[name], name);
+	      return regions;
+	    }, {});
+	  },
+
+
+	  // return the region instance from the definition
+	  _buildRegion: function _buildRegion(definition) {
+	    if (definition instanceof Region) {
+	      return definition;
+	    }
+
+	    return this._buildRegionFromDefinition(definition);
+	  },
+	  _buildRegionFromDefinition: function _buildRegionFromDefinition(definition) {
+	    if (_.isString(definition)) {
+	      return this._buildRegionFromObject({ el: definition });
+	    }
+
+	    if (_.isFunction(definition)) {
+	      return this._buildRegionFromRegionClass(definition);
+	    }
+
+	    if (_.isObject(definition)) {
+	      return this._buildRegionFromObject(definition);
+	    }
+
+	    throw new MarionetteError({
+	      message: 'Improper region configuration type.',
+	      url: 'marionette.region.html#region-configuration-types'
+	    });
+	  },
+	  _buildRegionFromObject: function _buildRegionFromObject(definition) {
+	    var RegionClass = definition.regionClass || this.regionClass;
+
+	    var options = _.omit(definition, 'regionClass');
+
+	    _.defaults(options, {
+	      el: definition.selector,
+	      parentEl: _.partial(_.result, this, 'el')
+	    });
+
+	    return new RegionClass(options);
+	  },
+
+
+	  // Build the region directly from a given `RegionClass`
+	  _buildRegionFromRegionClass: function _buildRegionFromRegionClass(RegionClass) {
+	    return new RegionClass({
+	      parentEl: _.partial(_.result, this, 'el')
+	    });
+	  },
+	  _addRegion: function _addRegion(region, name) {
+	    this.triggerMethod('before:add:region', this, name, region);
+
+	    region._parent = this;
+
+	    this._regions[name] = region;
+
+	    this.triggerMethod('add:region', this, name, region);
+	  },
+
+
+	  // Remove a single region from the View, by name
+	  removeRegion: function removeRegion(name) {
+	    var region = this._regions[name];
+
+	    this._removeRegion(region, name);
+
+	    return region;
+	  },
+
+
+	  // Remove all regions from the View
+	  removeRegions: function removeRegions() {
+	    var regions = this.getRegions();
+
+	    _.each(this._regions, _.bind(this._removeRegion, this));
+
+	    return regions;
+	  },
+	  _removeRegion: function _removeRegion(region, name) {
+	    this.triggerMethod('before:remove:region', this, name, region);
+
+	    region.empty();
+	    region.stopListening();
+
+	    delete this.regions[name];
+	    delete this._regions[name];
+
+	    this.triggerMethod('remove:region', this, name, region);
+	  },
+
+
+	  // Empty all regions in the region manager, but
+	  // leave them attached
+	  emptyRegions: function emptyRegions() {
+	    var regions = this.getRegions();
+	    _invoke(regions, 'empty');
+	    return regions;
+	  },
+
+
+	  // Checks to see if view contains region
+	  // Accepts the region name
+	  // hasRegion('main')
+	  hasRegion: function hasRegion(name) {
+	    return !!this.getRegion(name);
+	  },
+
+
+	  // Provides access to regions
+	  // Accepts the region name
+	  // getRegion('main')
+	  getRegion: function getRegion(name) {
+	    return this._regions[name];
+	  },
+
+
+	  // Get all regions
+	  getRegions: function getRegions() {
+	    return _.clone(this._regions);
+	  },
+	  showChildView: function showChildView(name, view) {
+	    var region = this.getRegion(name);
+
+	    for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+	      args[_key - 2] = arguments[_key];
+	    }
+
+	    return region.show.apply(region, [view].concat(args));
+	  },
+	  getChildView: function getChildView(name) {
+	    return this.getRegion(name).currentView;
+	  }
+	};
+
+	// Render a template with data by passing in the template
+	// selector and the data to render.
+	var Renderer = {
+
+	  // Render a template with data. The `template` parameter is
+	  // passed to the `TemplateCache` object to retrieve the
+	  // template function. Override this method to provide your own
+	  // custom rendering and template handling for all of Marionette.
+	  render: function render(template, data) {
+	    if (!template) {
+	      throw new MarionetteError({
+	        name: 'TemplateNotFoundError',
+	        message: 'Cannot render the template since its false, null or undefined.'
+	      });
+	    }
+
+	    var templateFunc = _.isFunction(template) ? template : TemplateCache.get(template);
+
+	    return templateFunc(data);
+	  }
+	};
+
+	var ClassOptions$1 = ['behaviors', 'childViewEventPrefix', 'childViewEvents', 'childViewTriggers', 'collectionEvents', 'events', 'modelEvents', 'regionClass', 'regions', 'template', 'templateContext', 'triggers', 'ui'];
+
+	// The standard view. Includes view events, automatic rendering
+	// of Underscore templates, nested views, and more.
+	var View = Backbone.View.extend({
+	  constructor: function constructor(options) {
+	    this.render = _.bind(this.render, this);
+
+	    this._setOptions(options);
+
+	    this.mergeOptions(options, ClassOptions$1);
+
+	    monitorViewEvents(this);
+
+	    this._initBehaviors();
+	    this._initRegions();
+
+	    var args = Array.prototype.slice.call(arguments);
+	    args[0] = this.options;
+	    Backbone.View.prototype.constructor.apply(this, args);
+
+	    this.delegateEntityEvents();
+	  },
+
+
+	  // Serialize the view's model *or* collection, if
+	  // it exists, for the template
+	  serializeData: function serializeData() {
+	    if (!this.model && !this.collection) {
+	      return {};
+	    }
+
+	    // If we have a model, we serialize that
+	    if (this.model) {
+	      return this.serializeModel();
+	    }
+
+	    // Otherwise, we serialize the collection,
+	    // making it available under the `items` property
+	    return {
+	      items: this.serializeCollection()
+	    };
+	  },
+
+
+	  // Prepares the special `model` property of a view
+	  // for being displayed in the template. By default
+	  // we simply clone the attributes. Override this if
+	  // you need a custom transformation for your view's model
+	  serializeModel: function serializeModel() {
+	    if (!this.model) {
+	      return {};
+	    }
+	    return _.clone(this.model.attributes);
+	  },
+
+
+	  // Serialize a collection by cloning each of
+	  // its model's attributes
+	  serializeCollection: function serializeCollection() {
+	    if (!this.collection) {
+	      return {};
+	    }
+	    return this.collection.map(function (model) {
+	      return _.clone(model.attributes);
+	    });
+	  },
+
+
+	  // Render the view, defaulting to underscore.js templates.
+	  // You can override this in your view definition to provide
+	  // a very specific rendering for your view. In general, though,
+	  // you should override the `Marionette.Renderer` object to
+	  // change how Marionette renders views.
+	  // Subsequent renders after the first will re-render all nested
+	  // views.
+	  render: function render() {
+	    this._ensureViewIsIntact();
+
+	    this.triggerMethod('before:render', this);
+
+	    // If this is not the first render call, then we need to
+	    // re-initialize the `el` for each region
+	    if (this._isRendered) {
+	      this._reInitRegions();
+	    }
+
+	    this._renderTemplate();
+	    this.bindUIElements();
+
+	    this._isRendered = true;
+	    this.triggerMethod('render', this);
+
+	    return this;
+	  },
+
+
+	  // Internal method to render the template with the serialized data
+	  // and template context via the `Marionette.Renderer` object.
+	  _renderTemplate: function _renderTemplate() {
+	    var template = this.getTemplate();
+
+	    // Allow template-less views
+	    if (template === false) {
+	      return;
+	    }
+
+	    // Add in entity data and template context
+	    var data = this.mixinTemplateContext(this.serializeData());
+
+	    // Render and add to el
+	    var html = Renderer.render(template, data, this);
+	    this.attachElContent(html);
+	  },
+
+
+	  // Get the template for this view
+	  // instance. You can set a `template` attribute in the view
+	  // definition or pass a `template: "whatever"` parameter in
+	  // to the constructor options.
+	  getTemplate: function getTemplate() {
+	    return this.template;
+	  },
+
+
+	  // Mix in template context methods. Looks for a
+	  // `templateContext` attribute, which can either be an
+	  // object literal, or a function that returns an object
+	  // literal. All methods and attributes from this object
+	  // are copies to the object passed in.
+	  mixinTemplateContext: function mixinTemplateContext() {
+	    var target = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+	    var templateContext = _.result(this, 'templateContext');
+	    return _.extend(target, templateContext);
+	  },
+
+
+	  // Attaches the content of a given view.
+	  // This method can be overridden to optimize rendering,
+	  // or to render in a non standard way.
+	  //
+	  // For example, using `innerHTML` instead of `$el.html`
+	  //
+	  // ```js
+	  // attachElContent(html) {
+	  //   this.el.innerHTML = html;
+	  //   return this;
+	  // }
+	  // ```
+	  attachElContent: function attachElContent(html) {
+	    this.$el.html(html);
+
+	    return this;
+	  },
+
+
+	  // called by ViewMixin destroy
+	  _removeChildren: function _removeChildren() {
+	    this.removeRegions();
+	  },
+	  _getImmediateChildren: function _getImmediateChildren() {
+	    return _.chain(this.getRegions()).map('currentView').compact().value();
+	  }
+	});
+
+	_.extend(View.prototype, ViewMixin, RegionsMixin);
+
+	var methods = ['forEach', 'each', 'map', 'find', 'detect', 'filter', 'select', 'reject', 'every', 'all', 'some', 'any', 'include', 'contains', 'invoke', 'toArray', 'first', 'initial', 'rest', 'last', 'without', 'isEmpty', 'pluck', 'reduce'];
+
+	var emulateCollection = function emulateCollection(object, listProperty) {
+	  _.each(methods, function (method) {
+	    object[method] = function () {
+	      var list = _.values(_.result(this, listProperty));
+	      var args = [list].concat(_.toArray(arguments));
+	      return _[method].apply(_, args);
+	    };
+	  });
+	};
+
+	// Provide a container to store, retrieve and
+	// shut down child views.
+	var Container = function Container(views) {
+	  this._views = {};
+	  this._indexByModel = {};
+	  this._indexByCustom = {};
+	  this._updateLength();
+
+	  _.each(views, _.bind(this.add, this));
+	};
+
+	emulateCollection(Container.prototype, '_views');
+
+	// Container Methods
+	// -----------------
+
+	_.extend(Container.prototype, {
+
+	  // Add a view to this container. Stores the view
+	  // by `cid` and makes it searchable by the model
+	  // cid (and model itself). Optionally specify
+	  // a custom key to store an retrieve the view.
+	  add: function add(view, customIndex) {
+	    return this._add(view, customIndex)._updateLength();
+	  },
+
+
+	  // To be used when avoiding call _updateLength
+	  // When you are done adding all your new views
+	  // call _updateLength
+	  _add: function _add(view, customIndex) {
+	    var viewCid = view.cid;
+
+	    // store the view
+	    this._views[viewCid] = view;
+
+	    // index it by model
+	    if (view.model) {
+	      this._indexByModel[view.model.cid] = viewCid;
+	    }
+
+	    // index by custom
+	    if (customIndex) {
+	      this._indexByCustom[customIndex] = viewCid;
+	    }
+
+	    return this;
+	  },
+
+
+	  // Find a view by the model that was attached to
+	  // it. Uses the model's `cid` to find it.
+	  findByModel: function findByModel(model) {
+	    return this.findByModelCid(model.cid);
+	  },
+
+
+	  // Find a view by the `cid` of the model that was attached to
+	  // it. Uses the model's `cid` to find the view `cid` and
+	  // retrieve the view using it.
+	  findByModelCid: function findByModelCid(modelCid) {
+	    var viewCid = this._indexByModel[modelCid];
+	    return this.findByCid(viewCid);
+	  },
+
+
+	  // Find a view by a custom indexer.
+	  findByCustom: function findByCustom(index) {
+	    var viewCid = this._indexByCustom[index];
+	    return this.findByCid(viewCid);
+	  },
+
+
+	  // Find by index. This is not guaranteed to be a
+	  // stable index.
+	  findByIndex: function findByIndex(index) {
+	    return _.values(this._views)[index];
+	  },
+
+
+	  // retrieve a view by its `cid` directly
+	  findByCid: function findByCid(cid) {
+	    return this._views[cid];
+	  },
+
+
+	  // Remove a view
+	  remove: function remove(view) {
+	    return this._remove(view)._updateLength();
+	  },
+
+
+	  // To be used when avoiding call _updateLength
+	  // When you are done adding all your new views
+	  // call _updateLength
+	  _remove: function _remove(view) {
+	    var viewCid = view.cid;
+
+	    // delete model index
+	    if (view.model) {
+	      delete this._indexByModel[view.model.cid];
+	    }
+
+	    // delete custom index
+	    _.some(this._indexByCustom, _.bind(function (cid, key) {
+	      if (cid === viewCid) {
+	        delete this._indexByCustom[key];
+	        return true;
+	      }
+	    }, this));
+
+	    // remove the view from the container
+	    delete this._views[viewCid];
+
+	    return this;
+	  },
+
+
+	  // Update the `.length` attribute on this container
+	  _updateLength: function _updateLength() {
+	    this.length = _.size(this._views);
+
+	    return this;
+	  }
+	});
+
+	var ClassOptions$3 = ['behaviors', 'childView', 'childViewEventPrefix', 'childViewEvents', 'childViewOptions', 'childViewTriggers', 'collectionEvents', 'events', 'filter', 'emptyView', 'emptyViewOptions', 'modelEvents', 'reorderOnSort', 'sort', 'triggers', 'ui', 'viewComparator'];
+
+	// A view that iterates over a Backbone.Collection
+	// and renders an individual child view for each model.
+	var CollectionView = Backbone.View.extend({
+
+	  // flag for maintaining the sorted order of the collection
+	  sort: true,
+
+	  // constructor
+	  // option to pass `{sort: false}` to prevent the `CollectionView` from
+	  // maintaining the sorted order of the collection.
+	  // This will fallback onto appending childView's to the end.
+	  //
+	  // option to pass `{viewComparator: compFunction()}` to allow the `CollectionView`
+	  // to use a custom sort order for the collection.
+	  constructor: function constructor(options) {
+	    this.render = _.bind(this.render, this);
+
+	    this._setOptions(options);
+
+	    this.mergeOptions(options, ClassOptions$3);
+
+	    monitorViewEvents(this);
+
+	    this._initBehaviors();
+	    this.once('render', this._initialEvents);
+	    this._initChildViewStorage();
+	    this._bufferedChildren = [];
+
+	    var args = Array.prototype.slice.call(arguments);
+	    args[0] = this.options;
+	    Backbone.View.prototype.constructor.apply(this, args);
+
+	    this.delegateEntityEvents();
+	  },
+
+
+	  // Instead of inserting elements one by one into the page, it's much more performant to insert
+	  // elements into a document fragment and then insert that document fragment into the page
+	  _startBuffering: function _startBuffering() {
+	    this._isBuffering = true;
+	  },
+	  _endBuffering: function _endBuffering() {
+	    var shouldTriggerAttach = !!this._isAttached;
+	    var triggerOnChildren = shouldTriggerAttach ? this._getImmediateChildren() : [];
+
+	    this._isBuffering = false;
+
+	    _.each(triggerOnChildren, function (child) {
+	      triggerMethodOn(child, 'before:attach', child);
+	    });
+
+	    this.attachBuffer(this, this._createBuffer());
+
+	    _.each(triggerOnChildren, function (child) {
+	      child._isAttached = true;
+	      triggerMethodOn(child, 'attach', child);
+	    });
+
+	    this._bufferedChildren = [];
+	  },
+	  _getImmediateChildren: function _getImmediateChildren() {
+	    return _.values(this.children._views);
+	  },
+
+
+	  // Configured the initial events that the collection view binds to.
+	  _initialEvents: function _initialEvents() {
+	    if (this.collection) {
+	      this.listenTo(this.collection, 'add', this._onCollectionAdd);
+	      this.listenTo(this.collection, 'remove', this._onCollectionRemove);
+	      this.listenTo(this.collection, 'reset', this.render);
+
+	      if (this.sort) {
+	        this.listenTo(this.collection, 'sort', this._sortViews);
+	      }
+	    }
+	  },
+
+
+	  // Handle a child added to the collection
+	  _onCollectionAdd: function _onCollectionAdd(child, collection, opts) {
+	    // `index` is present when adding with `at` since BB 1.2; indexOf fallback for < 1.2
+	    var index = opts.at !== undefined && (opts.index || collection.indexOf(child));
+
+	    // When filtered or when there is no initial index, calculate index.
+	    if (this.filter || index === false) {
+	      index = _.indexOf(this._filteredSortedModels(index), child);
+	    }
+
+	    if (this._shouldAddChild(child, index)) {
+	      this._destroyEmptyView();
+	      var ChildView = this._getChildView(child);
+	      this._addChild(child, ChildView, index);
+	    }
+	  },
+
+
+	  // get the child view by model it holds, and remove it
+	  _onCollectionRemove: function _onCollectionRemove(model) {
+	    var view = this.children.findByModel(model);
+	    this.removeChildView(view);
+	    this._checkEmpty();
+	  },
+
+
+	  // Render children views. Override this method to provide your own implementation of a
+	  // render function for the collection view.
+	  render: function render() {
+	    this._ensureViewIsIntact();
+	    this.triggerMethod('before:render', this);
+	    this._renderChildren();
+	    this._isRendered = true;
+	    this.triggerMethod('render', this);
+	    return this;
+	  },
+
+
+	  // An efficient rendering used for filtering. Instead of modifying the whole DOM for the
+	  // collection view, we are only adding or removing the related childrenViews.
+	  setFilter: function setFilter(filter) {
+	    var _ref = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+	    var preventRender = _ref.preventRender;
+
+	    var canBeRendered = this._isRendered && !this._isDestroyed;
+	    var filterChanged = this.filter !== filter;
+	    var shouldRender = canBeRendered && filterChanged && !preventRender;
+
+	    if (shouldRender) {
+	      var previousModels = this._filteredSortedModels();
+	      this.filter = filter;
+	      var models = this._filteredSortedModels();
+	      this._applyModelDeltas(models, previousModels);
+	    } else {
+	      this.filter = filter;
+	    }
+
+	    return this;
+	  },
+
+
+	  // `removeFilter` is actually an alias for removing filters.
+	  removeFilter: function removeFilter(options) {
+	    return this.setFilter(null, options);
+	  },
+
+
+	  // Calculate and apply difference by cid between `models` and `previousModels`.
+	  _applyModelDeltas: function _applyModelDeltas(models, previousModels) {
+	    var _this = this;
+
+	    var currentIds = {};
+	    _.each(models, function (model, index) {
+	      var addedChildNotExists = !_this.children.findByModel(model);
+	      if (addedChildNotExists) {
+	        _this._onCollectionAdd(model, _this.collection, { at: index });
+	      }
+	      currentIds[model.cid] = true;
+	    });
+	    _.each(previousModels, function (prevModel) {
+	      var removedChildExists = !currentIds[prevModel.cid] && _this.children.findByModel(prevModel);
+	      if (removedChildExists) {
+	        _this._onCollectionRemove(prevModel);
+	      }
+	    });
+	  },
+
+
+	  // Reorder DOM after sorting. When your element's rendering do not use their index,
+	  // you can pass reorderOnSort: true to only reorder the DOM after a sort instead of
+	  // rendering all the collectionView.
+	  reorder: function reorder() {
+	    var _this2 = this;
+
+	    var children = this.children;
+	    var models = this._filteredSortedModels();
+
+	    if (!models.length && this._showingEmptyView) {
+	      return this;
+	    }
+
+	    var anyModelsAdded = _.some(models, function (model) {
+	      return !children.findByModel(model);
+	    });
+
+	    // If there are any new models added due to filtering we need to add child views,
+	    // so render as normal.
+	    if (anyModelsAdded) {
+	      this.render();
+	    } else {
+	      (function () {
+	        // Get the DOM nodes in the same order as the models.
+	        var elsToReorder = _.map(models, function (model, index) {
+	          var view = children.findByModel(model);
+	          view._index = index;
+	          return view.el;
+	        });
+
+	        // Find the views that were children before but aren't in this new ordering.
+	        var filteredOutViews = children.filter(function (view) {
+	          return !_.contains(elsToReorder, view.el);
+	        });
+
+	        _this2.triggerMethod('before:reorder', _this2);
+
+	        // Since append moves elements that are already in the DOM, appending the elements
+	        // will effectively reorder them.
+	        _this2._appendReorderedChildren(elsToReorder);
+
+	        // remove any views that have been filtered out
+	        _.each(filteredOutViews, _.bind(_this2.removeChildView, _this2));
+	        _this2._checkEmpty();
+
+	        _this2.triggerMethod('reorder', _this2);
+	      })();
+	    }
+	    return this;
+	  },
+
+
+	  // Render view after sorting. Override this method to change how the view renders
+	  // after a `sort` on the collection.
+	  resortView: function resortView() {
+	    if (this.reorderOnSort) {
+	      this.reorder();
+	    } else {
+	      this._renderChildren();
+	    }
+	    return this;
+	  },
+
+
+	  // Internal method. This checks for any changes in the order of the collection.
+	  // If the index of any view doesn't match, it will render.
+	  _sortViews: function _sortViews() {
+	    var _this3 = this;
+
+	    var models = this._filteredSortedModels();
+
+	    // check for any changes in sort order of views
+	    var orderChanged = _.find(models, function (item, index) {
+	      var view = _this3.children.findByModel(item);
+	      return !view || view._index !== index;
+	    });
+
+	    if (orderChanged) {
+	      this.resortView();
+	    }
+	  },
+
+
+	  // Internal reference to what index a `emptyView` is.
+	  _emptyViewIndex: -1,
+
+	  // Internal method. Separated so that CompositeView can append to the childViewContainer
+	  // if necessary
+	  _appendReorderedChildren: function _appendReorderedChildren(children) {
+	    this.$el.append(children);
+	  },
+
+
+	  // Internal method. Separated so that CompositeView can have more control over events
+	  // being triggered, around the rendering process
+	  _renderChildren: function _renderChildren() {
+	    if (this._isRendered) {
+	      this._destroyEmptyView();
+	      this._destroyChildren({ checkEmpty: false });
+	    }
+
+	    var models = this._filteredSortedModels();
+	    if (this.isEmpty({ processedModels: models })) {
+	      this._showEmptyView();
+	    } else {
+	      this.triggerMethod('before:render:children', this);
+	      this._startBuffering();
+	      this._showCollection(models);
+	      this._endBuffering();
+	      this.triggerMethod('render:children', this);
+	    }
+	  },
+
+
+	  // Internal method to loop through collection and show each child view.
+	  _showCollection: function _showCollection(models) {
+	    var _this4 = this;
+
+	    _.each(models, function (child, index) {
+	      var ChildView = _this4._getChildView(child);
+	      _this4._addChild(child, ChildView, index);
+	    });
+	  },
+
+
+	  // Allow the collection to be sorted by a custom view comparator
+	  _filteredSortedModels: function _filteredSortedModels(addedAt) {
+	    if (!this.collection || !this.collection.length) {
+	      return [];
+	    }
+
+	    var viewComparator = this.getViewComparator();
+	    var models = this.collection.models;
+	    addedAt = Math.min(Math.max(addedAt, 0), models.length - 1);
+
+	    if (viewComparator) {
+	      var addedModel = void 0;
+	      // Preserve `at` location, even for a sorted view
+	      if (addedAt) {
+	        addedModel = models[addedAt];
+	        models = models.slice(0, addedAt).concat(models.slice(addedAt + 1));
+	      }
+	      models = this._sortModelsBy(models, viewComparator);
+	      if (addedModel) {
+	        models.splice(addedAt, 0, addedModel);
+	      }
+	    }
+
+	    // Filter after sorting in case the filter uses the index
+	    models = this._filterModels(models);
+
+	    return models;
+	  },
+	  getViewComparator: function getViewComparator() {
+	    return this.viewComparator;
+	  },
+
+
+	  // Filter an array of models, if a filter exists
+	  _filterModels: function _filterModels(models) {
+	    var _this5 = this;
+
+	    if (this.filter) {
+	      models = _.filter(models, function (model, index) {
+	        return _this5._shouldAddChild(model, index);
+	      });
+	    }
+	    return models;
+	  },
+	  _sortModelsBy: function _sortModelsBy(models, comparator) {
+	    if (typeof comparator === 'string') {
+	      return _.sortBy(models, function (model) {
+	        return model.get(comparator);
+	      });
+	    } else if (comparator.length === 1) {
+	      return _.sortBy(models, _.bind(comparator, this));
+	    } else {
+	      return models.sort(_.bind(comparator, this));
+	    }
+	  },
+
+
+	  // Internal method to show an empty view in place of a collection of child views,
+	  // when the collection is empty
+	  _showEmptyView: function _showEmptyView() {
+	    var EmptyView = this._getEmptyView();
+
+	    if (EmptyView && !this._showingEmptyView) {
+	      this._showingEmptyView = true;
+
+	      var model = new Backbone.Model();
+	      var emptyViewOptions = this.emptyViewOptions || this.childViewOptions;
+	      if (_.isFunction(emptyViewOptions)) {
+	        emptyViewOptions = emptyViewOptions.call(this, model, this._emptyViewIndex);
+	      }
+
+	      var view = this.buildChildView(model, EmptyView, emptyViewOptions);
+
+	      this.triggerMethod('before:render:empty', this, view);
+	      this._addChildView(view, 0);
+	      this.triggerMethod('render:empty', this, view);
+
+	      view._parent = this;
+	    }
+	  },
+
+
+	  // Internal method to destroy an existing emptyView instance if one exists. Called when
+	  // a collection view has been rendered empty, and then a child is added to the collection.
+	  _destroyEmptyView: function _destroyEmptyView() {
+	    if (this._showingEmptyView) {
+	      this.triggerMethod('before:remove:empty', this);
+
+	      this._destroyChildren();
+	      delete this._showingEmptyView;
+
+	      this.triggerMethod('remove:empty', this);
+	    }
+	  },
+
+
+	  // Retrieve the empty view class
+	  _getEmptyView: function _getEmptyView() {
+	    var emptyView = this.emptyView;
+
+	    if (!emptyView) {
+	      return;
+	    }
+
+	    return this._getView(emptyView);
+	  },
+
+
+	  // Retrieve the `childView` class
+	  // The `childView` property can be either a view class or a function that
+	  // returns a view class. If it is a function, it will receive the model that
+	  // will be passed to the view instance (created from the returned view class)
+	  _getChildView: function _getChildView(child) {
+	    var childView = this.childView;
+
+	    if (!childView) {
+	      throw new MarionetteError({
+	        name: 'NoChildViewError',
+	        message: 'A "childView" must be specified'
+	      });
+	    }
+
+	    childView = this._getView(childView, child);
+
+	    if (!childView) {
+	      throw new MarionetteError({
+	        name: 'InvalidChildViewError',
+	        message: '"childView" must be a view class or a function that returns a view class'
+	      });
+	    }
+
+	    return childView;
+	  },
+
+
+	  // First check if the `view` is a view class (the common case)
+	  // Then check if it's a function (which we assume that returns a view class)
+	  _getView: function _getView(view, child) {
+	    if (view.prototype instanceof Backbone.View || view === Backbone.View) {
+	      return view;
+	    } else if (_.isFunction(view)) {
+	      return view.call(this, child);
+	    }
+	  },
+
+
+	  // Internal method for building and adding a child view
+	  _addChild: function _addChild(child, ChildView, index) {
+	    var childViewOptions = this._getChildViewOptions(child, index);
+
+	    var view = this.buildChildView(child, ChildView, childViewOptions);
+
+	    this.addChildView(view, index);
+
+	    return view;
+	  },
+	  _getChildViewOptions: function _getChildViewOptions(child, index) {
+	    if (_.isFunction(this.childViewOptions)) {
+	      return this.childViewOptions(child, index);
+	    }
+
+	    return this.childViewOptions;
+	  },
+
+
+	  // Render the child's view and add it to the HTML for the collection view at a given index.
+	  // This will also update the indices of later views in the collection in order to keep the
+	  // children in sync with the collection.
+	  addChildView: function addChildView(view, index) {
+	    this.triggerMethod('before:add:child', this, view);
+
+	    // increment indices of views after this one
+	    this._updateIndices(view, true, index);
+
+	    view._parent = this;
+
+	    this._addChildView(view, index);
+
+	    this.triggerMethod('add:child', this, view);
+
+	    return view;
+	  },
+
+
+	  // Internal method. This decrements or increments the indices of views after the added/removed
+	  // view to keep in sync with the collection.
+	  _updateIndices: function _updateIndices(view, increment, index) {
+	    if (!this.sort) {
+	      return;
+	    }
+
+	    if (increment) {
+	      // assign the index to the view
+	      view._index = index;
+	    }
+
+	    // update the indexes of views after this one
+	    this.children.each(function (laterView) {
+	      if (laterView._index >= view._index) {
+	        laterView._index += increment ? 1 : -1;
+	      }
+	    });
+	  },
+
+
+	  // Internal Method. Add the view to children and render it at the given index.
+	  _addChildView: function _addChildView(view, index) {
+	    // Only trigger attach if already attached and not buffering,
+	    // otherwise _endBuffering() or Region#show() handles this.
+	    var shouldTriggerAttach = !this._isBuffering && this._isAttached;
+
+	    monitorViewEvents(view);
+
+	    // set up the child view event forwarding
+	    this._proxyChildEvents(view);
+
+	    // Store the child view itself so we can properly remove and/or destroy it later
+	    this.children.add(view);
+
+	    if (!view.supportsRenderLifecycle) {
+	      triggerMethodOn(view, 'before:render', view);
+	    }
+
+	    // Render view
+	    view.render();
+
+	    if (!view.supportsRenderLifecycle) {
+	      view._isRendered = true;
+	      triggerMethodOn(view, 'render', view);
+	    }
+
+	    if (shouldTriggerAttach) {
+	      triggerMethodOn(view, 'before:attach', view);
+	    }
+
+	    // Attach view
+	    this.attachHtml(this, view, index);
+
+	    if (shouldTriggerAttach) {
+	      view._isAttached = true;
+	      triggerMethodOn(view, 'attach', view);
+	    }
+	  },
+
+
+	  // Build a `childView` for a model in the collection.
+	  buildChildView: function buildChildView(child, ChildViewClass, childViewOptions) {
+	    var options = _.extend({ model: child }, childViewOptions);
+	    return new ChildViewClass(options);
+	  },
+
+
+	  // Remove the child view and destroy it. This function also updates the indices of later views
+	  // in the collection in order to keep the children in sync with the collection.
+	  removeChildView: function removeChildView(view) {
+	    if (!view || view._isDestroyed) {
+	      return view;
+	    }
+
+	    this.triggerMethod('before:remove:child', this, view);
+
+	    if (view.destroy) {
+	      view.destroy();
+	    } else {
+	      destroyBackboneView(view);
+	    }
+
+	    delete view._parent;
+	    this.stopListening(view);
+	    this.children.remove(view);
+	    this.triggerMethod('remove:child', this, view);
+
+	    // decrement the index of views after this one
+	    this._updateIndices(view, false);
+
+	    return view;
+	  },
+
+
+	  // check if the collection is empty or optionally whether an array of pre-processed models is empty
+	  isEmpty: function isEmpty(options) {
+	    var models = void 0;
+	    if (_.result(options, 'processedModels')) {
+	      models = options.processedModels;
+	    } else {
+	      models = this.collection ? this.collection.models : [];
+	      models = this._filterModels(models);
+	    }
+	    return models.length === 0;
+	  },
+
+
+	  // If empty, show the empty view
+	  _checkEmpty: function _checkEmpty() {
+	    if (this.isEmpty()) {
+	      this._showEmptyView();
+	    }
+	  },
+
+
+	  // You might need to override this if you've overridden attachHtml
+	  attachBuffer: function attachBuffer(collectionView, buffer) {
+	    collectionView.$el.append(buffer);
+	  },
+
+
+	  // Create a fragment buffer from the currently buffered children
+	  _createBuffer: function _createBuffer() {
+	    var elBuffer = document.createDocumentFragment();
+	    _.each(this._bufferedChildren, function (b) {
+	      elBuffer.appendChild(b.el);
+	    });
+	    return elBuffer;
+	  },
+
+
+	  // Append the HTML to the collection's `el`. Override this method to do something other
+	  // than `.append`.
+	  attachHtml: function attachHtml(collectionView, childView, index) {
+	    if (collectionView._isBuffering) {
+	      // buffering happens on reset events and initial renders
+	      // in order to reduce the number of inserts into the
+	      // document, which are expensive.
+	      collectionView._bufferedChildren.splice(index, 0, childView);
+	    } else {
+	      // If we've already rendered the main collection, append
+	      // the new child into the correct order if we need to. Otherwise
+	      // append to the end.
+	      if (!collectionView._insertBefore(childView, index)) {
+	        collectionView._insertAfter(childView);
+	      }
+	    }
+	  },
+
+
+	  // Internal method. Check whether we need to insert the view into the correct position.
+	  _insertBefore: function _insertBefore(childView, index) {
+	    var currentView = void 0;
+	    var findPosition = this.sort && index < this.children.length - 1;
+	    if (findPosition) {
+	      // Find the view after this one
+	      currentView = this.children.find(function (view) {
+	        return view._index === index + 1;
+	      });
+	    }
+
+	    if (currentView) {
+	      currentView.$el.before(childView.el);
+	      return true;
+	    }
+
+	    return false;
+	  },
+
+
+	  // Internal method. Append a view to the end of the $el
+	  _insertAfter: function _insertAfter(childView) {
+	    this.$el.append(childView.el);
+	  },
+
+
+	  // Internal method to set up the `children` object for storing all of the child views
+	  _initChildViewStorage: function _initChildViewStorage() {
+	    this.children = new Container();
+	  },
+
+
+	  // called by ViewMixin destroy
+	  _removeChildren: function _removeChildren() {
+	    this._destroyChildren({ checkEmpty: false });
+	  },
+
+
+	  // Destroy the child views that this collection view is holding on to, if any
+	  _destroyChildren: function _destroyChildren() {
+	    var _ref2 = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+	    var checkEmpty = _ref2.checkEmpty;
+
+	    this.triggerMethod('before:destroy:children', this);
+	    var shouldCheckEmpty = checkEmpty !== false;
+	    var childViews = this.children.map(_.identity);
+
+	    this.children.each(_.bind(this.removeChildView, this));
+
+	    if (shouldCheckEmpty) {
+	      this._checkEmpty();
+	    }
+
+	    this.triggerMethod('destroy:children', this);
+	    return childViews;
+	  },
+
+
+	  // Return true if the given child should be shown. Return false otherwise.
+	  // The filter will be passed (child, index, collection), where
+	  //  'child' is the given model
+	  //  'index' is the index of that model in the collection
+	  //  'collection' is the collection referenced by this CollectionView
+	  _shouldAddChild: function _shouldAddChild(child, index) {
+	    var filter = this.filter;
+	    return !_.isFunction(filter) || filter.call(this, child, index, this.collection);
+	  },
+
+
+	  // Set up the child view event forwarding. Uses a "childview:" prefix in front of all forwarded events.
+	  _proxyChildEvents: function _proxyChildEvents(view) {
+	    var _this6 = this;
+
+	    var prefix = _.result(this, 'childViewEventPrefix');
+
+	    // Forward all child view events through the parent,
+	    // prepending "childview:" to the event name
+	    this.listenTo(view, 'all', function (eventName) {
+	      for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+	        args[_key - 1] = arguments[_key];
+	      }
+
+	      var childEventName = prefix + ':' + eventName;
+
+	      var childViewEvents = _this6.normalizeMethods(_this6._childViewEvents);
+
+	      // call collectionView childViewEvent if defined
+	      if (typeof childViewEvents !== 'undefined' && _.isFunction(childViewEvents[eventName])) {
+	        childViewEvents[eventName].apply(_this6, args);
+	      }
+
+	      // use the parent view's proxyEvent handlers
+	      var childViewTriggers = _this6._childViewTriggers;
+
+	      // Call the event with the proxy name on the parent layout
+	      if (childViewTriggers && _.isString(childViewTriggers[eventName])) {
+	        _this6.triggerMethod.apply(_this6, [childViewTriggers[eventName]].concat(args));
+	      }
+
+	      _this6.triggerMethod.apply(_this6, [childEventName].concat(args));
+	    });
+	  }
+	});
+
+	_.extend(CollectionView.prototype, ViewMixin);
+
+	var ClassOptions$4 = ['childViewContainer', 'template', 'templateContext'];
+
+	// Used for rendering a branch-leaf, hierarchical structure.
+	// Extends directly from CollectionView
+	// @deprecated
+	var CompositeView = CollectionView.extend({
+
+	  // Setting up the inheritance chain which allows changes to
+	  // Marionette.CollectionView.prototype.constructor which allows overriding
+	  // option to pass '{sort: false}' to prevent the CompositeView from
+	  // maintaining the sorted order of the collection.
+	  // This will fallback onto appending childView's to the end.
+	  constructor: function constructor(options) {
+	    deprecate('CompositeView is deprecated. Convert to View at your earliest convenience');
+
+	    this.mergeOptions(options, ClassOptions$4);
+
+	    CollectionView.prototype.constructor.apply(this, arguments);
+	  },
+
+
+	  // Configured the initial events that the composite view
+	  // binds to. Override this method to prevent the initial
+	  // events, or to add your own initial events.
+	  _initialEvents: function _initialEvents() {
+
+	    // Bind only after composite view is rendered to avoid adding child views
+	    // to nonexistent childViewContainer
+
+	    if (this.collection) {
+	      this.listenTo(this.collection, 'add', this._onCollectionAdd);
+	      this.listenTo(this.collection, 'remove', this._onCollectionRemove);
+	      this.listenTo(this.collection, 'reset', this.renderChildren);
+
+	      if (this.sort) {
+	        this.listenTo(this.collection, 'sort', this._sortViews);
+	      }
+	    }
+	  },
+
+
+	  // Retrieve the `childView` to be used when rendering each of
+	  // the items in the collection. The default is to return
+	  // `this.childView` or Marionette.CompositeView if no `childView`
+	  // has been defined. As happens in CollectionView, `childView` can
+	  // be a function (which should return a view class).
+	  _getChildView: function _getChildView(child) {
+	    var childView = this.childView;
+
+	    // for CompositeView, if `childView` is not specified, we'll get the same
+	    // composite view class rendered for each child in the collection
+	    // then check if the `childView` is a view class (the common case)
+	    // finally check if it's a function (which we assume that returns a view class)
+	    if (!childView) {
+	      return this.constructor;
+	    }
+
+	    childView = this._getView(childView, child);
+
+	    if (!childView) {
+	      throw new MarionetteError({
+	        name: 'InvalidChildViewError',
+	        message: '"childView" must be a view class or a function that returns a view class'
+	      });
+	    }
+
+	    return childView;
+	  },
+
+
+	  // Return the serialized model
+	  serializeData: function serializeData() {
+	    return this.serializeModel();
+	  },
+
+
+	  // Renders the model and the collection.
+	  render: function render() {
+	    this._ensureViewIsIntact();
+	    this._isRendering = true;
+	    this.resetChildViewContainer();
+
+	    this.triggerMethod('before:render', this);
+
+	    this._renderTemplate();
+	    this.bindUIElements();
+	    this.renderChildren();
+
+	    this._isRendering = false;
+	    this._isRendered = true;
+	    this.triggerMethod('render', this);
+	    return this;
+	  },
+	  renderChildren: function renderChildren() {
+	    if (this._isRendered || this._isRendering) {
+	      CollectionView.prototype._renderChildren.call(this);
+	    }
+	  },
+
+
+	  // You might need to override this if you've overridden attachHtml
+	  attachBuffer: function attachBuffer(compositeView, buffer) {
+	    var $container = this.getChildViewContainer(compositeView);
+	    $container.append(buffer);
+	  },
+
+
+	  // Internal method. Append a view to the end of the $el.
+	  // Overidden from CollectionView to ensure view is appended to
+	  // childViewContainer
+	  _insertAfter: function _insertAfter(childView) {
+	    var $container = this.getChildViewContainer(this, childView);
+	    $container.append(childView.el);
+	  },
+
+
+	  // Internal method. Append reordered childView'.
+	  // Overidden from CollectionView to ensure reordered views
+	  // are appended to childViewContainer
+	  _appendReorderedChildren: function _appendReorderedChildren(children) {
+	    var $container = this.getChildViewContainer(this);
+	    $container.append(children);
+	  },
+
+
+	  // Internal method to ensure an `$childViewContainer` exists, for the
+	  // `attachHtml` method to use.
+	  getChildViewContainer: function getChildViewContainer(containerView, childView) {
+	    if (!!containerView.$childViewContainer) {
+	      return containerView.$childViewContainer;
+	    }
+
+	    var container = void 0;
+	    var childViewContainer = containerView.childViewContainer;
+	    if (childViewContainer) {
+
+	      var selector = _.result(containerView, 'childViewContainer');
+
+	      if (selector.charAt(0) === '@' && containerView.ui) {
+	        container = containerView.ui[selector.substr(4)];
+	      } else {
+	        container = containerView.$(selector);
+	      }
+
+	      if (container.length <= 0) {
+	        throw new MarionetteError({
+	          name: 'ChildViewContainerMissingError',
+	          message: 'The specified "childViewContainer" was not found: ' + containerView.childViewContainer
+	        });
+	      }
+	    } else {
+	      container = containerView.$el;
+	    }
+
+	    containerView.$childViewContainer = container;
+	    return container;
+	  },
+
+
+	  // Internal method to reset the `$childViewContainer` on render
+	  resetChildViewContainer: function resetChildViewContainer() {
+	    if (this.$childViewContainer) {
+	      this.$childViewContainer = undefined;
+	    }
+	  }
+	});
+
+	// To prevent duplication but allow the best View organization
+	// Certain View methods are mixed directly into the deprecated CompositeView
+	var MixinFromView = _.pick(View.prototype, 'serializeModel', 'getTemplate', '_renderTemplate', 'mixinTemplateContext', 'attachElContent');
+	_.extend(CompositeView.prototype, MixinFromView);
+
+	var ClassOptions$5 = ['collectionEvents', 'events', 'modelEvents', 'triggers', 'ui'];
+
+	var Behavior = MarionetteObject.extend({
+	  cidPrefix: 'mnb',
+
+	  constructor: function constructor(options, view) {
+	    // Setup reference to the view.
+	    // this comes in handle when a behavior
+	    // wants to directly talk up the chain
+	    // to the view.
+	    this.view = view;
+	    this.defaults = _.clone(_.result(this, 'defaults', {}));
+	    this._setOptions(this.defaults, options);
+	    this.mergeOptions(this.options, ClassOptions$5);
+
+	    // Construct an internal UI hash using
+	    // the behaviors UI hash and then the view UI hash.
+	    // This allows the user to use UI hash elements
+	    // defined in the parent view as well as those
+	    // defined in the given behavior.
+	    // This order will help the reuse and share of a behavior
+	    // between multiple views, while letting a view override a
+	    // selector under an UI key.
+	    this.ui = _.extend({}, _.result(this, 'ui'), _.result(view, 'ui'));
+
+	    MarionetteObject.apply(this, arguments);
+	  },
+
+
+	  // proxy behavior $ method to the view
+	  // this is useful for doing jquery DOM lookups
+	  // scoped to behaviors view.
+	  $: function $() {
+	    return this.view.$.apply(this.view, arguments);
+	  },
+
+
+	  // Stops the behavior from listening to events.
+	  // Overrides Object#destroy to prevent additional events from being triggered.
+	  destroy: function destroy() {
+	    this.stopListening();
+
+	    return this;
+	  },
+	  proxyViewProperties: function proxyViewProperties() {
+	    this.$el = this.view.$el;
+	    this.el = this.view.el;
+
+	    return this;
+	  },
+	  bindUIElements: function bindUIElements() {
+	    this._bindUIElements();
+
+	    return this;
+	  },
+	  unbindUIElements: function unbindUIElements() {
+	    this._unbindUIElements();
+
+	    return this;
+	  },
+	  getUI: function getUI(name) {
+	    this.view._ensureViewIsIntact();
+	    return this._getUI(name);
+	  },
+
+
+	  // Handle `modelEvents`, and `collectionEvents` configuration
+	  delegateEntityEvents: function delegateEntityEvents() {
+	    this._delegateEntityEvents(this.view.model, this.view.collection);
+
+	    return this;
+	  },
+	  undelegateEntityEvents: function undelegateEntityEvents() {
+	    this._undelegateEntityEvents(this.view.model, this.view.collection);
+
+	    return this;
+	  },
+	  getEvents: function getEvents() {
+	    // Normalize behavior events hash to allow
+	    // a user to use the @ui. syntax.
+	    var behaviorEvents = this.normalizeUIKeys(_.result(this, 'events'));
+
+	    // binds the handler to the behavior and builds a unique eventName
+	    return _.reduce(behaviorEvents, function (events, behaviorHandler, key) {
+	      if (!_.isFunction(behaviorHandler)) {
+	        behaviorHandler = this[behaviorHandler];
+	      }
+	      if (!behaviorHandler) {
+	        return;
+	      }
+	      key = getUniqueEventName(key);
+	      events[key] = _.bind(behaviorHandler, this);
+	      return events;
+	    }, {}, this);
+	  },
+
+
+	  // Internal method to build all trigger handlers for a given behavior
+	  getTriggers: function getTriggers() {
+	    if (!this.triggers) {
+	      return;
+	    }
+
+	    // Normalize behavior triggers hash to allow
+	    // a user to use the @ui. syntax.
+	    var behaviorTriggers = this.normalizeUIKeys(_.result(this, 'triggers'));
+
+	    return this._getViewTriggers(this.view, behaviorTriggers);
+	  }
+	});
+
+	_.extend(Behavior.prototype, DelegateEntityEventsMixin, TriggersMixin, UIMixin);
+
+	var ClassOptions$6 = ['region', 'regionClass'];
+
+	// A container for a Marionette application.
+	var Application = MarionetteObject.extend({
+	  cidPrefix: 'mna',
+
+	  constructor: function constructor(options) {
+	    this._setOptions(options);
+
+	    this.mergeOptions(options, ClassOptions$6);
+
+	    this._initRegion();
+
+	    MarionetteObject.prototype.constructor.apply(this, arguments);
+	  },
+
+
+	  regionClass: Region,
+
+	  _initRegion: function _initRegion(options) {
+	    var region = this.region;
+	    var RegionClass = this.regionClass;
+
+	    // if the region is a string expect an el or selector
+	    // and instantiate a region
+	    if (_.isString(region)) {
+	      this._region = new RegionClass({
+	        el: region
+	      });
+	      return;
+	    }
+
+	    this._region = region;
+	  },
+	  getRegion: function getRegion() {
+	    return this._region;
+	  },
+	  showView: function showView(view) {
+	    var region = this.getRegion();
+
+	    for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+	      args[_key - 1] = arguments[_key];
+	    }
+
+	    return region.show.apply(region, [view].concat(args));
+	  },
+	  getView: function getView() {
+	    return this.getRegion().currentView;
+	  },
+
+
+	  // kick off all of the application's processes.
+	  start: function start(options) {
+	    this.triggerMethod('before:start', this, options);
+	    this.triggerMethod('start', this, options);
+	    return this;
+	  }
+	});
+
+	var ClassOptions$7 = ['appRoutes', 'controller'];
+
+	var AppRouter = Backbone.Router.extend({
+	  constructor: function constructor(options) {
+	    this._setOptions(options);
+
+	    this.mergeOptions(options, ClassOptions$7);
+
+	    Backbone.Router.apply(this, arguments);
+
+	    var appRoutes = this.appRoutes;
+	    var controller = this._getController();
+	    this.processAppRoutes(controller, appRoutes);
+	    this.on('route', this._processOnRoute, this);
+	  },
+
+
+	  // Similar to route method on a Backbone Router but
+	  // method is called on the controller
+	  appRoute: function appRoute(route, methodName) {
+	    var controller = this._getController();
+	    this._addAppRoute(controller, route, methodName);
+	    return this;
+	  },
+
+
+	  // process the route event and trigger the onRoute
+	  // method call, if it exists
+	  _processOnRoute: function _processOnRoute(routeName, routeArgs) {
+	    // make sure an onRoute before trying to call it
+	    if (_.isFunction(this.onRoute)) {
+	      // find the path that matches the current route
+	      var routePath = _.invert(this.appRoutes)[routeName];
+	      this.onRoute(routeName, routePath, routeArgs);
+	    }
+	  },
+
+
+	  // Internal method to process the `appRoutes` for the
+	  // router, and turn them in to routes that trigger the
+	  // specified method on the specified `controller`.
+	  processAppRoutes: function processAppRoutes(controller, appRoutes) {
+	    var _this = this;
+
+	    if (!appRoutes) {
+	      return this;
+	    }
+
+	    var routeNames = _.keys(appRoutes).reverse(); // Backbone requires reverted order of routes
+
+	    _.each(routeNames, function (route) {
+	      _this._addAppRoute(controller, route, appRoutes[route]);
+	    });
+
+	    return this;
+	  },
+	  _getController: function _getController() {
+	    return this.controller;
+	  },
+	  _addAppRoute: function _addAppRoute(controller, route, methodName) {
+	    var method = controller[methodName];
+
+	    if (!method) {
+	      throw new MarionetteError('Method "' + methodName + '" was not found on the controller');
+	    }
+
+	    this.route(route, methodName, _.bind(method, controller));
+	  },
+
+
+	  triggerMethod: triggerMethod
+	});
+
+	_.extend(AppRouter.prototype, CommonMixin);
+
+	// Placeholder method to be extended by the user.
+	// The method should define the object that stores the behaviors.
+	// i.e.
+	//
+	// ```js
+	// Marionette.Behaviors.behaviorsLookup: function() {
+	//   return App.Behaviors
+	// }
+	// ```
+	function behaviorsLookup() {
+	  throw new MarionetteError({
+	    message: 'You must define where your behaviors are stored.',
+	    url: 'marionette.behaviors.md#behaviorslookup'
+	  });
+	}
+
+	// Add Feature flags here
+	// e.g. 'class' => false
+	var FEATURES = {};
+
+	function isEnabled(name) {
+	  return !!FEATURES[name];
+	}
+
+	function setEnabled(name, state) {
+	  return FEATURES[name] = state;
+	}
+
+	var previousMarionette = Backbone.Marionette;
+	var Marionette = Backbone.Marionette = {};
+
+	// This allows you to run multiple instances of Marionette on the same
+	// webapp. After loading the new version, call `noConflict()` to
+	// get a reference to it. At the same time the old version will be
+	// returned to Backbone.Marionette.
+	Marionette.noConflict = function () {
+	  Backbone.Marionette = previousMarionette;
+	  return this;
+	};
+
+	// Utilities
+	Marionette.bindEvents = proxy(bindEvents);
+	Marionette.unbindEvents = proxy(unbindEvents);
+	Marionette.bindRequests = proxy(bindRequests);
+	Marionette.unbindRequests = proxy(unbindRequests);
+	Marionette.mergeOptions = proxy(mergeOptions);
+	Marionette.getOption = proxy(getOption);
+	Marionette.normalizeMethods = proxy(normalizeMethods);
+	Marionette.extend = extend;
+	Marionette.isNodeAttached = isNodeAttached;
+	Marionette.deprecate = deprecate;
+	Marionette.triggerMethod = proxy(triggerMethod);
+	Marionette.triggerMethodOn = triggerMethodOn;
+	Marionette.isEnabled = isEnabled;
+	Marionette.setEnabled = setEnabled;
+	Marionette.monitorViewEvents = monitorViewEvents;
+
+	Marionette.Behaviors = {};
+	Marionette.Behaviors.behaviorsLookup = behaviorsLookup;
+
+	// Classes
+	Marionette.Application = Application;
+	Marionette.AppRouter = AppRouter;
+	Marionette.Renderer = Renderer;
+	Marionette.TemplateCache = TemplateCache;
+	Marionette.View = View;
+	Marionette.CollectionView = CollectionView;
+	Marionette.CompositeView = CompositeView;
+	Marionette.Behavior = Behavior;
+	Marionette.Region = Region;
+	Marionette.Error = MarionetteError;
+	Marionette.Object = MarionetteObject;
+
+	// Configuration
+	Marionette.DEV_MODE = false;
+	Marionette.FEATURES = FEATURES;
+	Marionette.VERSION = version;
+
+	return Marionette;
+
 }));
+
+//# sourceMappingURL=backbone.marionette.js.map

--- a/examples/backbone_marionette/node_modules/backbone.radio/build/backbone.radio.js
+++ b/examples/backbone_marionette/node_modules/backbone.radio/build/backbone.radio.js
@@ -1,14 +1,25 @@
-// Backbone.Radio v1.0.2
+// Backbone.Radio v2.0.0
+
 (function (global, factory) {
-  typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory(require("underscore"), require("backbone")) : typeof define === "function" && define.amd ? define(["underscore", "backbone"], factory) : global.Backbone.Radio = factory(global._, global.Backbone);
-})(this, function (_, Backbone) {
-  "use strict";
+  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('underscore'), require('backbone')) :
+  typeof define === 'function' && define.amd ? define(['underscore', 'backbone'], factory) :
+  (global.Backbone = global.Backbone || {}, global.Backbone.Radio = factory(global._,global.Backbone));
+}(this, function (_,Backbone) { 'use strict';
+
+  _ = 'default' in _ ? _['default'] : _;
+  Backbone = 'default' in Backbone ? Backbone['default'] : Backbone;
+
+  var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) {
+    return typeof obj;
+  } : function (obj) {
+    return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj;
+  };
 
   var previousRadio = Backbone.Radio;
 
   var Radio = Backbone.Radio = {};
 
-  Radio.VERSION = "1.0.2";
+  Radio.VERSION = '2.0.0';
 
   // This allows you to run multiple instances of Radio on the same
   // webapp. After loading the new version, call `noConflict()` to
@@ -25,7 +36,7 @@
 
   // Format debug text.
   Radio._debugText = function (warning, eventName, channelName) {
-    return warning + (channelName ? " on the " + channelName + " channel" : "") + ": \"" + eventName + "\"";
+    return warning + (channelName ? ' on the ' + channelName + ' channel' : '') + ': "' + eventName + '"';
   };
 
   // This is the method that's called when an unregistered event was called.
@@ -52,7 +63,7 @@
     var results = {};
 
     // Handle event maps.
-    if (typeof name === "object") {
+    if ((typeof name === 'undefined' ? 'undefined' : _typeof(name)) === 'object') {
       for (var key in name) {
         var result = obj[action].apply(obj, [key, name[key]].concat(rest));
         eventSplitter.test(key) ? _.extend(results, result) : results[key] = result;
@@ -94,7 +105,7 @@
   // A helper used by `off` methods to the handler from the store
   function removeHandler(store, name, callback, context) {
     var event = store[name];
-    if ((!callback || (callback === event.callback || callback === event.callback._callback)) && (!context || context === event.context)) {
+    if ((!callback || callback === event.callback || callback === event.callback._callback) && (!context || context === event.context)) {
       delete store[name];
       return true;
     }
@@ -134,15 +145,18 @@
   // This is to produce an identical function in both tuneIn and tuneOut,
   // so that Backbone.Events unregisters it.
   function _partial(channelName) {
-    return _logs[channelName] || (_logs[channelName] = _.partial(Radio.log, channelName));
+    return _logs[channelName] || (_logs[channelName] = _.bind(Radio.log, Radio, channelName));
   }
 
   _.extend(Radio, {
 
     // Log information about the channel and event
     log: function log(channelName, eventName) {
-      var args = _.rest(arguments, 2);
-      console.log("[" + channelName + "] \"" + eventName + "\"", args);
+      if (typeof console === 'undefined') {
+        return;
+      }
+      var args = _.toArray(arguments).slice(2);
+      console.log('[' + channelName + '] "' + eventName + '"', args);
     },
 
     // Logs all events on this channel to the console. It sets an
@@ -151,7 +165,7 @@
     tuneIn: function tuneIn(channelName) {
       var channel = Radio.channel(channelName);
       channel._tunedIn = true;
-      channel.on("all", _partial(channelName));
+      channel.on('all', _partial(channelName));
       return this;
     },
 
@@ -159,7 +173,7 @@
     tuneOut: function tuneOut(channelName) {
       var channel = Radio.channel(channelName);
       channel._tunedIn = false;
-      channel.off("all", _partial(channelName));
+      channel.off('all', _partial(channelName));
       delete _logs[channelName];
       return this;
     }
@@ -182,8 +196,8 @@
 
     // Make a request
     request: function request(name) {
-      var args = _.rest(arguments);
-      var results = Radio._eventsApi(this, "request", name, args);
+      var args = _.toArray(arguments).slice(1);
+      var results = Radio._eventsApi(this, 'request', name, args);
       if (results) {
         return results;
       }
@@ -196,25 +210,25 @@
       }
 
       // If the request isn't handled, log it in DEBUG mode and exit
-      if (requests && (requests[name] || requests["default"])) {
-        var handler = requests[name] || requests["default"];
+      if (requests && (requests[name] || requests['default'])) {
+        var handler = requests[name] || requests['default'];
         args = requests[name] ? args : arguments;
         return Radio._callHandler(handler.callback, handler.context, args);
       } else {
-        Radio.debugLog("An unhandled request was fired", name, channelName);
+        Radio.debugLog('An unhandled request was fired', name, channelName);
       }
     },
 
     // Set up a handler for a request
     reply: function reply(name, callback, context) {
-      if (Radio._eventsApi(this, "reply", name, [callback, context])) {
+      if (Radio._eventsApi(this, 'reply', name, [callback, context])) {
         return this;
       }
 
       this._requests || (this._requests = {});
 
       if (this._requests[name]) {
-        Radio.debugLog("A request was overwritten", name, this.channelName);
+        Radio.debugLog('A request was overwritten', name, this.channelName);
       }
 
       this._requests[name] = {
@@ -227,7 +241,7 @@
 
     // Set up a handler that can only be requested once
     replyOnce: function replyOnce(name, callback, context) {
-      if (Radio._eventsApi(this, "replyOnce", name, [callback, context])) {
+      if (Radio._eventsApi(this, 'replyOnce', name, [callback, context])) {
         return this;
       }
 
@@ -243,7 +257,7 @@
 
     // Remove handler(s)
     stopReplying: function stopReplying(name, callback, context) {
-      if (Radio._eventsApi(this, "stopReplying", name)) {
+      if (Radio._eventsApi(this, 'stopReplying', name)) {
         return this;
       }
 
@@ -251,7 +265,7 @@
       if (!name && !callback && !context) {
         delete this._requests;
       } else if (!removeHandlers(this._requests, name, callback, context)) {
-        Radio.debugLog("Attempted to remove the unregistered request", name, this.channelName);
+        Radio.debugLog('Attempted to remove the unregistered request', name, this.channelName);
       }
 
       return this;
@@ -269,7 +283,7 @@
 
   Radio.channel = function (channelName) {
     if (!channelName) {
-      throw new Error("You must provide a name for the channel.");
+      throw new Error('You must provide a name for the channel.');
     }
 
     if (Radio._channels[channelName]) {
@@ -310,14 +324,13 @@
    *
    */
 
-  var channel,
-      args,
-      systems = [Backbone.Events, Radio.Commands, Radio.Requests];
-
+  var channel;
+  var args;
+  var systems = [Backbone.Events, Radio.Requests];
   _.each(systems, function (system) {
     _.each(system, function (method, methodName) {
       Radio[methodName] = function (channelName) {
-        args = _.rest(arguments);
+        args = _.toArray(arguments).slice(1);
         channel = this.channel(channelName);
         return channel[methodName].apply(channel, args);
       };
@@ -326,11 +339,12 @@
 
   Radio.reset = function (channelName) {
     var channels = !channelName ? this._channels : [this._channels[channelName]];
-    _.invoke(channels, "reset");
+    _.each(channels, function (channel) {
+      channel.reset();
+    });
   };
 
-  var backbone_radio = Radio;
+  return Radio;
 
-  return backbone_radio;
-});
+}));
 //# sourceMappingURL=./backbone.radio.js.map

--- a/examples/backbone_marionette/node_modules/backbone/backbone.js
+++ b/examples/backbone_marionette/node_modules/backbone/backbone.js
@@ -1,11 +1,16 @@
-//     Backbone.js 1.1.2
+//     Backbone.js 1.3.3
 
-//     (c) 2010-2014 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+//     (c) 2010-2016 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
 //     Backbone may be freely distributed under the MIT license.
 //     For all details and documentation:
 //     http://backbonejs.org
 
-(function(root, factory) {
+(function(factory) {
+
+  // Establish the root object, `window` (`self`) in the browser, or `global` on the server.
+  // We use `self` instead of `window` for `WebWorker` support.
+  var root = (typeof self == 'object' && self.self === self && self) ||
+            (typeof global == 'object' && global.global === global && global);
 
   // Set up Backbone appropriately for the environment. Start with AMD.
   if (typeof define === 'function' && define.amd) {
@@ -17,15 +22,16 @@
 
   // Next for Node.js or CommonJS. jQuery may not be needed as a module.
   } else if (typeof exports !== 'undefined') {
-    var _ = require('underscore');
-    factory(root, exports, _);
+    var _ = require('underscore'), $;
+    try { $ = require('jquery'); } catch (e) {}
+    factory(root, exports, _, $);
 
   // Finally, as a browser global.
   } else {
     root.Backbone = factory(root, {}, root._, (root.jQuery || root.Zepto || root.ender || root.$));
   }
 
-}(this, function(root, Backbone, _, $) {
+})(function(root, Backbone, _, $) {
 
   // Initial Setup
   // -------------
@@ -34,14 +40,11 @@
   // restored later on, if `noConflict` is used.
   var previousBackbone = root.Backbone;
 
-  // Create local references to array methods we'll want to use later.
-  var array = [];
-  var push = array.push;
-  var slice = array.slice;
-  var splice = array.splice;
+  // Create a local reference to a common array method we'll want to use later.
+  var slice = Array.prototype.slice;
 
   // Current version of the library. Keep in sync with `package.json`.
-  Backbone.VERSION = '1.1.2';
+  Backbone.VERSION = '1.3.3';
 
   // For Backbone's purposes, jQuery, Zepto, Ender, or My Library (kidding) owns
   // the `$` variable.
@@ -60,17 +63,65 @@
   Backbone.emulateHTTP = false;
 
   // Turn on `emulateJSON` to support legacy servers that can't deal with direct
-  // `application/json` requests ... will encode the body as
+  // `application/json` requests ... this will encode the body as
   // `application/x-www-form-urlencoded` instead and will send the model in a
   // form param named `model`.
   Backbone.emulateJSON = false;
+
+  // Proxy Backbone class methods to Underscore functions, wrapping the model's
+  // `attributes` object or collection's `models` array behind the scenes.
+  //
+  // collection.filter(function(model) { return model.get('age') > 10 });
+  // collection.each(this.addView);
+  //
+  // `Function#apply` can be slow so we use the method's arg count, if we know it.
+  var addMethod = function(length, method, attribute) {
+    switch (length) {
+      case 1: return function() {
+        return _[method](this[attribute]);
+      };
+      case 2: return function(value) {
+        return _[method](this[attribute], value);
+      };
+      case 3: return function(iteratee, context) {
+        return _[method](this[attribute], cb(iteratee, this), context);
+      };
+      case 4: return function(iteratee, defaultVal, context) {
+        return _[method](this[attribute], cb(iteratee, this), defaultVal, context);
+      };
+      default: return function() {
+        var args = slice.call(arguments);
+        args.unshift(this[attribute]);
+        return _[method].apply(_, args);
+      };
+    }
+  };
+  var addUnderscoreMethods = function(Class, methods, attribute) {
+    _.each(methods, function(length, method) {
+      if (_[method]) Class.prototype[method] = addMethod(length, method, attribute);
+    });
+  };
+
+  // Support `collection.sortBy('attr')` and `collection.findWhere({id: 1})`.
+  var cb = function(iteratee, instance) {
+    if (_.isFunction(iteratee)) return iteratee;
+    if (_.isObject(iteratee) && !instance._isModel(iteratee)) return modelMatcher(iteratee);
+    if (_.isString(iteratee)) return function(model) { return model.get(iteratee); };
+    return iteratee;
+  };
+  var modelMatcher = function(attrs) {
+    var matcher = _.matches(attrs);
+    return function(model) {
+      return matcher(model.attributes);
+    };
+  };
 
   // Backbone.Events
   // ---------------
 
   // A module that can be mixed in to *any object* in order to provide it with
-  // custom events. You may bind with `on` or remove with `off` callback
-  // functions to an event; `trigger`-ing an event fires all callbacks in
+  // a custom event channel. You may bind a callback to an event with `on` or
+  // remove with `off`; `trigger`-ing an event fires all callbacks in
   // succession.
   //
   //     var object = {};
@@ -78,123 +129,234 @@
   //     object.on('expand', function(){ alert('expanded'); });
   //     object.trigger('expand');
   //
-  var Events = Backbone.Events = {
-
-    // Bind an event to a `callback` function. Passing `"all"` will bind
-    // the callback to all events fired.
-    on: function(name, callback, context) {
-      if (!eventsApi(this, 'on', name, [callback, context]) || !callback) return this;
-      this._events || (this._events = {});
-      var events = this._events[name] || (this._events[name] = []);
-      events.push({callback: callback, context: context, ctx: context || this});
-      return this;
-    },
-
-    // Bind an event to only be triggered a single time. After the first time
-    // the callback is invoked, it will be removed.
-    once: function(name, callback, context) {
-      if (!eventsApi(this, 'once', name, [callback, context]) || !callback) return this;
-      var self = this;
-      var once = _.once(function() {
-        self.off(name, once);
-        callback.apply(this, arguments);
-      });
-      once._callback = callback;
-      return this.on(name, once, context);
-    },
-
-    // Remove one or many callbacks. If `context` is null, removes all
-    // callbacks with that function. If `callback` is null, removes all
-    // callbacks for the event. If `name` is null, removes all bound
-    // callbacks for all events.
-    off: function(name, callback, context) {
-      var retain, ev, events, names, i, l, j, k;
-      if (!this._events || !eventsApi(this, 'off', name, [callback, context])) return this;
-      if (!name && !callback && !context) {
-        this._events = void 0;
-        return this;
-      }
-      names = name ? [name] : _.keys(this._events);
-      for (i = 0, l = names.length; i < l; i++) {
-        name = names[i];
-        if (events = this._events[name]) {
-          this._events[name] = retain = [];
-          if (callback || context) {
-            for (j = 0, k = events.length; j < k; j++) {
-              ev = events[j];
-              if ((callback && callback !== ev.callback && callback !== ev.callback._callback) ||
-                  (context && context !== ev.context)) {
-                retain.push(ev);
-              }
-            }
-          }
-          if (!retain.length) delete this._events[name];
-        }
-      }
-
-      return this;
-    },
-
-    // Trigger one or many events, firing all bound callbacks. Callbacks are
-    // passed the same arguments as `trigger` is, apart from the event name
-    // (unless you're listening on `"all"`, which will cause your callback to
-    // receive the true name of the event as the first argument).
-    trigger: function(name) {
-      if (!this._events) return this;
-      var args = slice.call(arguments, 1);
-      if (!eventsApi(this, 'trigger', name, args)) return this;
-      var events = this._events[name];
-      var allEvents = this._events.all;
-      if (events) triggerEvents(events, args);
-      if (allEvents) triggerEvents(allEvents, arguments);
-      return this;
-    },
-
-    // Tell this object to stop listening to either specific events ... or
-    // to every object it's currently listening to.
-    stopListening: function(obj, name, callback) {
-      var listeningTo = this._listeningTo;
-      if (!listeningTo) return this;
-      var remove = !name && !callback;
-      if (!callback && typeof name === 'object') callback = this;
-      if (obj) (listeningTo = {})[obj._listenId] = obj;
-      for (var id in listeningTo) {
-        obj = listeningTo[id];
-        obj.off(name, callback, this);
-        if (remove || _.isEmpty(obj._events)) delete this._listeningTo[id];
-      }
-      return this;
-    }
-
-  };
+  var Events = Backbone.Events = {};
 
   // Regular expression used to split event strings.
   var eventSplitter = /\s+/;
 
-  // Implement fancy features of the Events API such as multiple event
-  // names `"change blur"` and jQuery-style event maps `{change: action}`
-  // in terms of the existing API.
-  var eventsApi = function(obj, action, name, rest) {
-    if (!name) return true;
-
-    // Handle event maps.
-    if (typeof name === 'object') {
-      for (var key in name) {
-        obj[action].apply(obj, [key, name[key]].concat(rest));
+  // Iterates over the standard `event, callback` (as well as the fancy multiple
+  // space-separated events `"change blur", callback` and jQuery-style event
+  // maps `{event: callback}`).
+  var eventsApi = function(iteratee, events, name, callback, opts) {
+    var i = 0, names;
+    if (name && typeof name === 'object') {
+      // Handle event maps.
+      if (callback !== void 0 && 'context' in opts && opts.context === void 0) opts.context = callback;
+      for (names = _.keys(name); i < names.length ; i++) {
+        events = eventsApi(iteratee, events, names[i], name[names[i]], opts);
       }
-      return false;
+    } else if (name && eventSplitter.test(name)) {
+      // Handle space-separated event names by delegating them individually.
+      for (names = name.split(eventSplitter); i < names.length; i++) {
+        events = iteratee(events, names[i], callback, opts);
+      }
+    } else {
+      // Finally, standard events.
+      events = iteratee(events, name, callback, opts);
+    }
+    return events;
+  };
+
+  // Bind an event to a `callback` function. Passing `"all"` will bind
+  // the callback to all events fired.
+  Events.on = function(name, callback, context) {
+    return internalOn(this, name, callback, context);
+  };
+
+  // Guard the `listening` argument from the public API.
+  var internalOn = function(obj, name, callback, context, listening) {
+    obj._events = eventsApi(onApi, obj._events || {}, name, callback, {
+      context: context,
+      ctx: obj,
+      listening: listening
+    });
+
+    if (listening) {
+      var listeners = obj._listeners || (obj._listeners = {});
+      listeners[listening.id] = listening;
     }
 
-    // Handle space separated event names.
-    if (eventSplitter.test(name)) {
-      var names = name.split(eventSplitter);
-      for (var i = 0, l = names.length; i < l; i++) {
-        obj[action].apply(obj, [names[i]].concat(rest));
-      }
-      return false;
+    return obj;
+  };
+
+  // Inversion-of-control versions of `on`. Tell *this* object to listen to
+  // an event in another object... keeping track of what it's listening to
+  // for easier unbinding later.
+  Events.listenTo = function(obj, name, callback) {
+    if (!obj) return this;
+    var id = obj._listenId || (obj._listenId = _.uniqueId('l'));
+    var listeningTo = this._listeningTo || (this._listeningTo = {});
+    var listening = listeningTo[id];
+
+    // This object is not listening to any other events on `obj` yet.
+    // Setup the necessary references to track the listening callbacks.
+    if (!listening) {
+      var thisId = this._listenId || (this._listenId = _.uniqueId('l'));
+      listening = listeningTo[id] = {obj: obj, objId: id, id: thisId, listeningTo: listeningTo, count: 0};
     }
 
-    return true;
+    // Bind callbacks on obj, and keep track of them on listening.
+    internalOn(obj, name, callback, this, listening);
+    return this;
+  };
+
+  // The reducing API that adds a callback to the `events` object.
+  var onApi = function(events, name, callback, options) {
+    if (callback) {
+      var handlers = events[name] || (events[name] = []);
+      var context = options.context, ctx = options.ctx, listening = options.listening;
+      if (listening) listening.count++;
+
+      handlers.push({callback: callback, context: context, ctx: context || ctx, listening: listening});
+    }
+    return events;
+  };
+
+  // Remove one or many callbacks. If `context` is null, removes all
+  // callbacks with that function. If `callback` is null, removes all
+  // callbacks for the event. If `name` is null, removes all bound
+  // callbacks for all events.
+  Events.off = function(name, callback, context) {
+    if (!this._events) return this;
+    this._events = eventsApi(offApi, this._events, name, callback, {
+      context: context,
+      listeners: this._listeners
+    });
+    return this;
+  };
+
+  // Tell this object to stop listening to either specific events ... or
+  // to every object it's currently listening to.
+  Events.stopListening = function(obj, name, callback) {
+    var listeningTo = this._listeningTo;
+    if (!listeningTo) return this;
+
+    var ids = obj ? [obj._listenId] : _.keys(listeningTo);
+
+    for (var i = 0; i < ids.length; i++) {
+      var listening = listeningTo[ids[i]];
+
+      // If listening doesn't exist, this object is not currently
+      // listening to obj. Break out early.
+      if (!listening) break;
+
+      listening.obj.off(name, callback, this);
+    }
+
+    return this;
+  };
+
+  // The reducing API that removes a callback from the `events` object.
+  var offApi = function(events, name, callback, options) {
+    if (!events) return;
+
+    var i = 0, listening;
+    var context = options.context, listeners = options.listeners;
+
+    // Delete all events listeners and "drop" events.
+    if (!name && !callback && !context) {
+      var ids = _.keys(listeners);
+      for (; i < ids.length; i++) {
+        listening = listeners[ids[i]];
+        delete listeners[listening.id];
+        delete listening.listeningTo[listening.objId];
+      }
+      return;
+    }
+
+    var names = name ? [name] : _.keys(events);
+    for (; i < names.length; i++) {
+      name = names[i];
+      var handlers = events[name];
+
+      // Bail out if there are no events stored.
+      if (!handlers) break;
+
+      // Replace events if there are any remaining.  Otherwise, clean up.
+      var remaining = [];
+      for (var j = 0; j < handlers.length; j++) {
+        var handler = handlers[j];
+        if (
+          callback && callback !== handler.callback &&
+            callback !== handler.callback._callback ||
+              context && context !== handler.context
+        ) {
+          remaining.push(handler);
+        } else {
+          listening = handler.listening;
+          if (listening && --listening.count === 0) {
+            delete listeners[listening.id];
+            delete listening.listeningTo[listening.objId];
+          }
+        }
+      }
+
+      // Update tail event if the list has any events.  Otherwise, clean up.
+      if (remaining.length) {
+        events[name] = remaining;
+      } else {
+        delete events[name];
+      }
+    }
+    return events;
+  };
+
+  // Bind an event to only be triggered a single time. After the first time
+  // the callback is invoked, its listener will be removed. If multiple events
+  // are passed in using the space-separated syntax, the handler will fire
+  // once for each event, not once for a combination of all events.
+  Events.once = function(name, callback, context) {
+    // Map the event into a `{event: once}` object.
+    var events = eventsApi(onceMap, {}, name, callback, _.bind(this.off, this));
+    if (typeof name === 'string' && context == null) callback = void 0;
+    return this.on(events, callback, context);
+  };
+
+  // Inversion-of-control versions of `once`.
+  Events.listenToOnce = function(obj, name, callback) {
+    // Map the event into a `{event: once}` object.
+    var events = eventsApi(onceMap, {}, name, callback, _.bind(this.stopListening, this, obj));
+    return this.listenTo(obj, events);
+  };
+
+  // Reduces the event callbacks into a map of `{event: onceWrapper}`.
+  // `offer` unbinds the `onceWrapper` after it has been called.
+  var onceMap = function(map, name, callback, offer) {
+    if (callback) {
+      var once = map[name] = _.once(function() {
+        offer(name, once);
+        callback.apply(this, arguments);
+      });
+      once._callback = callback;
+    }
+    return map;
+  };
+
+  // Trigger one or many events, firing all bound callbacks. Callbacks are
+  // passed the same arguments as `trigger` is, apart from the event name
+  // (unless you're listening on `"all"`, which will cause your callback to
+  // receive the true name of the event as the first argument).
+  Events.trigger = function(name) {
+    if (!this._events) return this;
+
+    var length = Math.max(0, arguments.length - 1);
+    var args = Array(length);
+    for (var i = 0; i < length; i++) args[i] = arguments[i + 1];
+
+    eventsApi(triggerApi, this._events, name, void 0, args);
+    return this;
+  };
+
+  // Handles triggering the appropriate event callbacks.
+  var triggerApi = function(objEvents, name, callback, args) {
+    if (objEvents) {
+      var events = objEvents[name];
+      var allEvents = objEvents.all;
+      if (events && allEvents) allEvents = allEvents.slice();
+      if (events) triggerEvents(events, args);
+      if (allEvents) triggerEvents(allEvents, [name].concat(args));
+    }
+    return objEvents;
   };
 
   // A difficult-to-believe, but optimized internal dispatch function for
@@ -210,22 +372,6 @@
       default: while (++i < l) (ev = events[i]).callback.apply(ev.ctx, args); return;
     }
   };
-
-  var listenMethods = {listenTo: 'on', listenToOnce: 'once'};
-
-  // Inversion-of-control versions of `on` and `once`. Tell *this* object to
-  // listen to an event in another object ... keeping track of what it's
-  // listening to.
-  _.each(listenMethods, function(implementation, method) {
-    Events[method] = function(obj, name, callback) {
-      var listeningTo = this._listeningTo || (this._listeningTo = {});
-      var id = obj._listenId || (obj._listenId = _.uniqueId('l'));
-      listeningTo[id] = obj;
-      if (!callback && typeof name === 'object') callback = this;
-      obj[implementation](name, callback, this);
-      return this;
-    };
-  });
 
   // Aliases for backwards compatibility.
   Events.bind   = Events.on;
@@ -248,11 +394,12 @@
   var Model = Backbone.Model = function(attributes, options) {
     var attrs = attributes || {};
     options || (options = {});
-    this.cid = _.uniqueId('c');
+    this.cid = _.uniqueId(this.cidPrefix);
     this.attributes = {};
     if (options.collection) this.collection = options.collection;
     if (options.parse) attrs = this.parse(attrs, options) || {};
-    attrs = _.defaults({}, attrs, _.result(this, 'defaults'));
+    var defaults = _.result(this, 'defaults');
+    attrs = _.defaults(_.extend({}, defaults, attrs), defaults);
     this.set(attrs, options);
     this.changed = {};
     this.initialize.apply(this, arguments);
@@ -270,6 +417,10 @@
     // The default name for the JSON `id` attribute is `"id"`. MongoDB and
     // CouchDB users may want to set this to `"_id"`.
     idAttribute: 'id',
+
+    // The prefix is used to create the client id which is used to identify models locally.
+    // You may want to override this if you're experiencing name clashes with model ids.
+    cidPrefix: 'c',
 
     // Initialize is an empty function by default. Override it with your own
     // initialization logic.
@@ -302,14 +453,19 @@
       return this.get(attr) != null;
     },
 
+    // Special-cased proxy to underscore's `_.matches` method.
+    matches: function(attrs) {
+      return !!_.iteratee(attrs, this)(this.attributes);
+    },
+
     // Set a hash of model attributes on the object, firing `"change"`. This is
     // the core primitive operation of a model, updating the data and notifying
     // anyone who needs to know about the change in state. The heart of the beast.
     set: function(key, val, options) {
-      var attr, attrs, unset, changes, silent, changing, prev, current;
       if (key == null) return this;
 
       // Handle both `"key", value` and `{key: value}` -style arguments.
+      var attrs;
       if (typeof key === 'object') {
         attrs = key;
         options = val;
@@ -323,37 +479,40 @@
       if (!this._validate(attrs, options)) return false;
 
       // Extract attributes and options.
-      unset           = options.unset;
-      silent          = options.silent;
-      changes         = [];
-      changing        = this._changing;
-      this._changing  = true;
+      var unset      = options.unset;
+      var silent     = options.silent;
+      var changes    = [];
+      var changing   = this._changing;
+      this._changing = true;
 
       if (!changing) {
         this._previousAttributes = _.clone(this.attributes);
         this.changed = {};
       }
-      current = this.attributes, prev = this._previousAttributes;
 
-      // Check for changes of `id`.
-      if (this.idAttribute in attrs) this.id = attrs[this.idAttribute];
+      var current = this.attributes;
+      var changed = this.changed;
+      var prev    = this._previousAttributes;
 
       // For each `set` attribute, update or delete the current value.
-      for (attr in attrs) {
+      for (var attr in attrs) {
         val = attrs[attr];
         if (!_.isEqual(current[attr], val)) changes.push(attr);
         if (!_.isEqual(prev[attr], val)) {
-          this.changed[attr] = val;
+          changed[attr] = val;
         } else {
-          delete this.changed[attr];
+          delete changed[attr];
         }
         unset ? delete current[attr] : current[attr] = val;
       }
 
+      // Update the `id`.
+      if (this.idAttribute in attrs) this.id = this.get(this.idAttribute);
+
       // Trigger all relevant attribute changes.
       if (!silent) {
         if (changes.length) this._pending = options;
-        for (var i = 0, l = changes.length; i < l; i++) {
+        for (var i = 0; i < changes.length; i++) {
           this.trigger('change:' + changes[i], this, current[changes[i]], options);
         }
       }
@@ -401,13 +560,14 @@
     // determining if there *would be* a change.
     changedAttributes: function(diff) {
       if (!diff) return this.hasChanged() ? _.clone(this.changed) : false;
-      var val, changed = false;
       var old = this._changing ? this._previousAttributes : this.attributes;
+      var changed = {};
       for (var attr in diff) {
-        if (_.isEqual(old[attr], (val = diff[attr]))) continue;
-        (changed || (changed = {}))[attr] = val;
+        var val = diff[attr];
+        if (_.isEqual(old[attr], val)) continue;
+        changed[attr] = val;
       }
-      return changed;
+      return _.size(changed) ? changed : false;
     },
 
     // Get the previous value of an attribute, recorded at the time the last
@@ -423,17 +583,16 @@
       return _.clone(this._previousAttributes);
     },
 
-    // Fetch the model from the server. If the server's representation of the
-    // model differs from its current attributes, they will be overridden,
-    // triggering a `"change"` event.
+    // Fetch the model from the server, merging the response with the model's
+    // local attributes. Any changed attributes will trigger a "change" event.
     fetch: function(options) {
-      options = options ? _.clone(options) : {};
-      if (options.parse === void 0) options.parse = true;
+      options = _.extend({parse: true}, options);
       var model = this;
       var success = options.success;
       options.success = function(resp) {
-        if (!model.set(model.parse(resp, options), options)) return false;
-        if (success) success(model, resp, options);
+        var serverAttrs = options.parse ? model.parse(resp, options) : resp;
+        if (!model.set(serverAttrs, options)) return false;
+        if (success) success.call(options.context, model, resp, options);
         model.trigger('sync', model, resp, options);
       };
       wrapError(this, options);
@@ -444,9 +603,8 @@
     // If the server returns an attributes hash that differs, the model's
     // state will be `set` again.
     save: function(key, val, options) {
-      var attrs, method, xhr, attributes = this.attributes;
-
       // Handle both `"key", value` and `{key: value}` -style arguments.
+      var attrs;
       if (key == null || typeof key === 'object') {
         attrs = key;
         options = val;
@@ -454,46 +612,43 @@
         (attrs = {})[key] = val;
       }
 
-      options = _.extend({validate: true}, options);
+      options = _.extend({validate: true, parse: true}, options);
+      var wait = options.wait;
 
       // If we're not waiting and attributes exist, save acts as
       // `set(attr).save(null, opts)` with validation. Otherwise, check if
       // the model will be valid when the attributes, if any, are set.
-      if (attrs && !options.wait) {
+      if (attrs && !wait) {
         if (!this.set(attrs, options)) return false;
-      } else {
-        if (!this._validate(attrs, options)) return false;
-      }
-
-      // Set temporary attributes if `{wait: true}`.
-      if (attrs && options.wait) {
-        this.attributes = _.extend({}, attributes, attrs);
+      } else if (!this._validate(attrs, options)) {
+        return false;
       }
 
       // After a successful server-side save, the client is (optionally)
       // updated with the server-side state.
-      if (options.parse === void 0) options.parse = true;
       var model = this;
       var success = options.success;
+      var attributes = this.attributes;
       options.success = function(resp) {
         // Ensure attributes are restored during synchronous saves.
         model.attributes = attributes;
-        var serverAttrs = model.parse(resp, options);
-        if (options.wait) serverAttrs = _.extend(attrs || {}, serverAttrs);
-        if (_.isObject(serverAttrs) && !model.set(serverAttrs, options)) {
-          return false;
-        }
-        if (success) success(model, resp, options);
+        var serverAttrs = options.parse ? model.parse(resp, options) : resp;
+        if (wait) serverAttrs = _.extend({}, attrs, serverAttrs);
+        if (serverAttrs && !model.set(serverAttrs, options)) return false;
+        if (success) success.call(options.context, model, resp, options);
         model.trigger('sync', model, resp, options);
       };
       wrapError(this, options);
 
-      method = this.isNew() ? 'create' : (options.patch ? 'patch' : 'update');
-      if (method === 'patch') options.attrs = attrs;
-      xhr = this.sync(method, this, options);
+      // Set temporary attributes if `{wait: true}` to properly find new ids.
+      if (attrs && wait) this.attributes = _.extend({}, attributes, attrs);
+
+      var method = this.isNew() ? 'create' : (options.patch ? 'patch' : 'update');
+      if (method === 'patch' && !options.attrs) options.attrs = attrs;
+      var xhr = this.sync(method, this, options);
 
       // Restore attributes.
-      if (attrs && options.wait) this.attributes = attributes;
+      this.attributes = attributes;
 
       return xhr;
     },
@@ -505,25 +660,27 @@
       options = options ? _.clone(options) : {};
       var model = this;
       var success = options.success;
+      var wait = options.wait;
 
       var destroy = function() {
+        model.stopListening();
         model.trigger('destroy', model, model.collection, options);
       };
 
       options.success = function(resp) {
-        if (options.wait || model.isNew()) destroy();
-        if (success) success(model, resp, options);
+        if (wait) destroy();
+        if (success) success.call(options.context, model, resp, options);
         if (!model.isNew()) model.trigger('sync', model, resp, options);
       };
 
+      var xhr = false;
       if (this.isNew()) {
-        options.success();
-        return false;
+        _.defer(options.success);
+      } else {
+        wrapError(this, options);
+        xhr = this.sync('delete', this, options);
       }
-      wrapError(this, options);
-
-      var xhr = this.sync('delete', this, options);
-      if (!options.wait) destroy();
+      if (!wait) destroy();
       return xhr;
     },
 
@@ -536,7 +693,8 @@
         _.result(this.collection, 'url') ||
         urlError();
       if (this.isNew()) return base;
-      return base.replace(/([^\/])$/, '$1/') + encodeURIComponent(this.id);
+      var id = this.get(this.idAttribute);
+      return base.replace(/[^\/]$/, '$&/') + encodeURIComponent(id);
     },
 
     // **parse** converts a response into the hash of attributes to be `set` on
@@ -557,7 +715,7 @@
 
     // Check if the model is currently in a valid state.
     isValid: function(options) {
-      return this._validate({}, _.extend(options || {}, { validate: true }));
+      return this._validate({}, _.extend({}, options, {validate: true}));
     },
 
     // Run validation against the next complete set of model attributes,
@@ -573,23 +731,19 @@
 
   });
 
-  // Underscore methods that we want to implement on the Model.
-  var modelMethods = ['keys', 'values', 'pairs', 'invert', 'pick', 'omit'];
+  // Underscore methods that we want to implement on the Model, mapped to the
+  // number of arguments they take.
+  var modelMethods = {keys: 1, values: 1, pairs: 1, invert: 1, pick: 0,
+      omit: 0, chain: 1, isEmpty: 1};
 
   // Mix in each Underscore method as a proxy to `Model#attributes`.
-  _.each(modelMethods, function(method) {
-    Model.prototype[method] = function() {
-      var args = slice.call(arguments);
-      args.unshift(this.attributes);
-      return _[method].apply(_, args);
-    };
-  });
+  addUnderscoreMethods(Model, modelMethods, 'attributes');
 
   // Backbone.Collection
   // -------------------
 
   // If models tend to represent a single row of data, a Backbone Collection is
-  // more analagous to a table full of data ... or a small slice or page of that
+  // more analogous to a table full of data ... or a small slice or page of that
   // table, or a collection of rows that belong together for a particular reason
   // -- all of the messages in this particular folder, all of the documents
   // belonging to this particular author, and so on. Collections maintain
@@ -611,6 +765,17 @@
   var setOptions = {add: true, remove: true, merge: true};
   var addOptions = {add: true, remove: false};
 
+  // Splices `insert` into `array` at index `at`.
+  var splice = function(array, insert, at) {
+    at = Math.min(Math.max(at, 0), array.length);
+    var tail = Array(array.length - at);
+    var length = insert.length;
+    var i;
+    for (i = 0; i < tail.length; i++) tail[i] = array[i + at];
+    for (i = 0; i < length; i++) array[i + at] = insert[i];
+    for (i = 0; i < tail.length; i++) array[i + length + at] = tail[i];
+  };
+
   // Define the Collection's inheritable methods.
   _.extend(Collection.prototype, Events, {
 
@@ -625,7 +790,7 @@
     // The JSON representation of a Collection is an array of the
     // models' attributes.
     toJSON: function(options) {
-      return this.map(function(model){ return model.toJSON(options); });
+      return this.map(function(model) { return model.toJSON(options); });
     },
 
     // Proxy `Backbone.sync` by default.
@@ -633,32 +798,24 @@
       return Backbone.sync.apply(this, arguments);
     },
 
-    // Add a model, or list of models to the set.
+    // Add a model, or list of models to the set. `models` may be Backbone
+    // Models or raw JavaScript objects to be converted to Models, or any
+    // combination of the two.
     add: function(models, options) {
       return this.set(models, _.extend({merge: false}, options, addOptions));
     },
 
     // Remove a model, or a list of models from the set.
     remove: function(models, options) {
+      options = _.extend({}, options);
       var singular = !_.isArray(models);
-      models = singular ? [models] : _.clone(models);
-      options || (options = {});
-      var i, l, index, model;
-      for (i = 0, l = models.length; i < l; i++) {
-        model = models[i] = this.get(models[i]);
-        if (!model) continue;
-        delete this._byId[model.id];
-        delete this._byId[model.cid];
-        index = this.indexOf(model);
-        this.models.splice(index, 1);
-        this.length--;
-        if (!options.silent) {
-          options.index = index;
-          model.trigger('remove', model, this, options);
-        }
-        this._removeReference(model, options);
+      models = singular ? [models] : models.slice();
+      var removed = this._removeModels(models, options);
+      if (!options.silent && removed.length) {
+        options.changes = {added: [], merged: [], removed: removed};
+        this.trigger('update', this, options);
       }
-      return singular ? models[0] : models;
+      return singular ? removed[0] : removed;
     },
 
     // Update a collection by `set`-ing a new list of models, adding new ones,
@@ -666,89 +823,114 @@
     // already exist in the collection, as necessary. Similar to **Model#set**,
     // the core operation for updating the data contained by the collection.
     set: function(models, options) {
-      options = _.defaults({}, options, setOptions);
-      if (options.parse) models = this.parse(models, options);
+      if (models == null) return;
+
+      options = _.extend({}, setOptions, options);
+      if (options.parse && !this._isModel(models)) {
+        models = this.parse(models, options) || [];
+      }
+
       var singular = !_.isArray(models);
-      models = singular ? (models ? [models] : []) : _.clone(models);
-      var i, l, id, model, attrs, existing, sort;
+      models = singular ? [models] : models.slice();
+
       var at = options.at;
-      var targetModel = this.model;
-      var sortable = this.comparator && (at == null) && options.sort !== false;
+      if (at != null) at = +at;
+      if (at > this.length) at = this.length;
+      if (at < 0) at += this.length + 1;
+
+      var set = [];
+      var toAdd = [];
+      var toMerge = [];
+      var toRemove = [];
+      var modelMap = {};
+
+      var add = options.add;
+      var merge = options.merge;
+      var remove = options.remove;
+
+      var sort = false;
+      var sortable = this.comparator && at == null && options.sort !== false;
       var sortAttr = _.isString(this.comparator) ? this.comparator : null;
-      var toAdd = [], toRemove = [], modelMap = {};
-      var add = options.add, merge = options.merge, remove = options.remove;
-      var order = !sortable && add && remove ? [] : false;
 
       // Turn bare objects into model references, and prevent invalid models
       // from being added.
-      for (i = 0, l = models.length; i < l; i++) {
-        attrs = models[i] || {};
-        if (attrs instanceof Model) {
-          id = model = attrs;
-        } else {
-          id = attrs[targetModel.prototype.idAttribute || 'id'];
-        }
+      var model, i;
+      for (i = 0; i < models.length; i++) {
+        model = models[i];
 
         // If a duplicate is found, prevent it from being added and
         // optionally merge it into the existing model.
-        if (existing = this.get(id)) {
-          if (remove) modelMap[existing.cid] = true;
-          if (merge) {
-            attrs = attrs === model ? model.attributes : attrs;
+        var existing = this.get(model);
+        if (existing) {
+          if (merge && model !== existing) {
+            var attrs = this._isModel(model) ? model.attributes : model;
             if (options.parse) attrs = existing.parse(attrs, options);
             existing.set(attrs, options);
-            if (sortable && !sort && existing.hasChanged(sortAttr)) sort = true;
+            toMerge.push(existing);
+            if (sortable && !sort) sort = existing.hasChanged(sortAttr);
+          }
+          if (!modelMap[existing.cid]) {
+            modelMap[existing.cid] = true;
+            set.push(existing);
           }
           models[i] = existing;
 
         // If this is a new, valid model, push it to the `toAdd` list.
         } else if (add) {
-          model = models[i] = this._prepareModel(attrs, options);
-          if (!model) continue;
-          toAdd.push(model);
-          this._addReference(model, options);
+          model = models[i] = this._prepareModel(model, options);
+          if (model) {
+            toAdd.push(model);
+            this._addReference(model, options);
+            modelMap[model.cid] = true;
+            set.push(model);
+          }
         }
-
-        // Do not add multiple models with the same `id`.
-        model = existing || model;
-        if (order && (model.isNew() || !modelMap[model.id])) order.push(model);
-        modelMap[model.id] = true;
       }
 
-      // Remove nonexistent models if appropriate.
+      // Remove stale models.
       if (remove) {
-        for (i = 0, l = this.length; i < l; ++i) {
-          if (!modelMap[(model = this.models[i]).cid]) toRemove.push(model);
+        for (i = 0; i < this.length; i++) {
+          model = this.models[i];
+          if (!modelMap[model.cid]) toRemove.push(model);
         }
-        if (toRemove.length) this.remove(toRemove, options);
+        if (toRemove.length) this._removeModels(toRemove, options);
       }
 
       // See if sorting is needed, update `length` and splice in new models.
-      if (toAdd.length || (order && order.length)) {
+      var orderChanged = false;
+      var replace = !sortable && add && remove;
+      if (set.length && replace) {
+        orderChanged = this.length !== set.length || _.some(this.models, function(m, index) {
+          return m !== set[index];
+        });
+        this.models.length = 0;
+        splice(this.models, set, 0);
+        this.length = this.models.length;
+      } else if (toAdd.length) {
         if (sortable) sort = true;
-        this.length += toAdd.length;
-        if (at != null) {
-          for (i = 0, l = toAdd.length; i < l; i++) {
-            this.models.splice(at + i, 0, toAdd[i]);
-          }
-        } else {
-          if (order) this.models.length = 0;
-          var orderedModels = order || toAdd;
-          for (i = 0, l = orderedModels.length; i < l; i++) {
-            this.models.push(orderedModels[i]);
-          }
-        }
+        splice(this.models, toAdd, at == null ? this.length : at);
+        this.length = this.models.length;
       }
 
       // Silently sort the collection if appropriate.
       if (sort) this.sort({silent: true});
 
-      // Unless silenced, it's time to fire all appropriate add/sort events.
+      // Unless silenced, it's time to fire all appropriate add/sort/update events.
       if (!options.silent) {
-        for (i = 0, l = toAdd.length; i < l; i++) {
-          (model = toAdd[i]).trigger('add', model, this, options);
+        for (i = 0; i < toAdd.length; i++) {
+          if (at != null) options.index = at + i;
+          model = toAdd[i];
+          model.trigger('add', model, this, options);
         }
-        if (sort || (order && order.length)) this.trigger('sort', this, options);
+        if (sort || orderChanged) this.trigger('sort', this, options);
+        if (toAdd.length || toRemove.length || toMerge.length) {
+          options.changes = {
+            added: toAdd,
+            removed: toRemove,
+            merged: toMerge
+          };
+          this.trigger('update', this, options);
+        }
       }
 
       // Return the added (or merged) model (or models).
@@ -760,8 +942,8 @@
     // any granular `add` or `remove` events. Fires `reset` when finished.
     // Useful for bulk operations and optimizations.
     reset: function(models, options) {
-      options || (options = {});
-      for (var i = 0, l = this.models.length; i < l; i++) {
+      options = options ? _.clone(options) : {};
+      for (var i = 0; i < this.models.length; i++) {
         this._removeReference(this.models[i], options);
       }
       options.previousModels = this.models;
@@ -779,8 +961,7 @@
     // Remove a model from the end of the collection.
     pop: function(options) {
       var model = this.at(this.length - 1);
-      this.remove(model, options);
-      return model;
+      return this.remove(model, options);
     },
 
     // Add a model to the beginning of the collection.
@@ -791,8 +972,7 @@
     // Remove a model from the beginning of the collection.
     shift: function(options) {
       var model = this.at(0);
-      this.remove(model, options);
-      return model;
+      return this.remove(model, options);
     },
 
     // Slice out a sub-array of models from the collection.
@@ -800,27 +980,30 @@
       return slice.apply(this.models, arguments);
     },
 
-    // Get a model from the set by id.
+    // Get a model from the set by id, cid, model object with id or cid
+    // properties, or an attributes object that is transformed through modelId.
     get: function(obj) {
       if (obj == null) return void 0;
-      return this._byId[obj] || this._byId[obj.id] || this._byId[obj.cid];
+      return this._byId[obj] ||
+        this._byId[this.modelId(obj.attributes || obj)] ||
+        obj.cid && this._byId[obj.cid];
+    },
+
+    // Returns `true` if the model is in the collection.
+    has: function(obj) {
+      return this.get(obj) != null;
     },
 
     // Get the model at the given index.
     at: function(index) {
+      if (index < 0) index += this.length;
       return this.models[index];
     },
 
     // Return models with matching attributes. Useful for simple cases of
     // `filter`.
     where: function(attrs, first) {
-      if (_.isEmpty(attrs)) return first ? void 0 : [];
-      return this[first ? 'find' : 'filter'](function(model) {
-        for (var key in attrs) {
-          if (attrs[key] !== model.get(key)) return false;
-        }
-        return true;
-      });
+      return this[first ? 'find' : 'filter'](attrs);
     },
 
     // Return the first model with matching attributes. Useful for simple cases
@@ -833,37 +1016,39 @@
     // normal circumstances, as the set will maintain sort order as each item
     // is added.
     sort: function(options) {
-      if (!this.comparator) throw new Error('Cannot sort a set without a comparator');
+      var comparator = this.comparator;
+      if (!comparator) throw new Error('Cannot sort a set without a comparator');
       options || (options = {});
 
-      // Run sort based on type of `comparator`.
-      if (_.isString(this.comparator) || this.comparator.length === 1) {
-        this.models = this.sortBy(this.comparator, this);
-      } else {
-        this.models.sort(_.bind(this.comparator, this));
-      }
+      var length = comparator.length;
+      if (_.isFunction(comparator)) comparator = _.bind(comparator, this);
 
+      // Run sort based on type of `comparator`.
+      if (length === 1 || _.isString(comparator)) {
+        this.models = this.sortBy(comparator);
+      } else {
+        this.models.sort(comparator);
+      }
       if (!options.silent) this.trigger('sort', this, options);
       return this;
     },
 
     // Pluck an attribute from each model in the collection.
     pluck: function(attr) {
-      return _.invoke(this.models, 'get', attr);
+      return this.map(attr + '');
     },
 
     // Fetch the default set of models for this collection, resetting the
     // collection when they arrive. If `reset: true` is passed, the response
     // data will be passed through the `reset` method instead of `set`.
     fetch: function(options) {
-      options = options ? _.clone(options) : {};
-      if (options.parse === void 0) options.parse = true;
+      options = _.extend({parse: true}, options);
       var success = options.success;
       var collection = this;
       options.success = function(resp) {
         var method = options.reset ? 'reset' : 'set';
         collection[method](resp, options);
-        if (success) success(collection, resp, options);
+        if (success) success.call(options.context, collection, resp, options);
         collection.trigger('sync', collection, resp, options);
       };
       wrapError(this, options);
@@ -875,13 +1060,15 @@
     // wait for the server to agree.
     create: function(model, options) {
       options = options ? _.clone(options) : {};
-      if (!(model = this._prepareModel(model, options))) return false;
-      if (!options.wait) this.add(model, options);
+      var wait = options.wait;
+      model = this._prepareModel(model, options);
+      if (!model) return false;
+      if (!wait) this.add(model, options);
       var collection = this;
       var success = options.success;
-      options.success = function(model, resp) {
-        if (options.wait) collection.add(model, options);
-        if (success) success(model, resp, options);
+      options.success = function(m, resp, callbackOpts) {
+        if (wait) collection.add(m, callbackOpts);
+        if (success) success.call(callbackOpts.context, m, resp, callbackOpts);
       };
       model.save(null, options);
       return model;
@@ -895,7 +1082,15 @@
 
     // Create a new collection with an identical list of models as this one.
     clone: function() {
-      return new this.constructor(this.models);
+      return new this.constructor(this.models, {
+        model: this.model,
+        comparator: this.comparator
+      });
+    },
+
+    // Define how to uniquely identify models in the collection.
+    modelId: function(attrs) {
+      return attrs[this.model.prototype.idAttribute || 'id'];
     },
 
     // Private method to reset all internal state. Called when the collection
@@ -909,7 +1104,10 @@
     // Prepare a hash of attributes (or other model) to be added to this
     // collection.
     _prepareModel: function(attrs, options) {
-      if (attrs instanceof Model) return attrs;
+      if (this._isModel(attrs)) {
+        if (!attrs.collection) attrs.collection = this;
+        return attrs;
+      }
       options = options ? _.clone(options) : {};
       options.collection = this;
       var model = new this.model(attrs, options);
@@ -918,16 +1116,53 @@
       return false;
     },
 
+    // Internal method called by both remove and set.
+    _removeModels: function(models, options) {
+      var removed = [];
+      for (var i = 0; i < models.length; i++) {
+        var model = this.get(models[i]);
+        if (!model) continue;
+
+        var index = this.indexOf(model);
+        this.models.splice(index, 1);
+        this.length--;
+
+        // Remove references before triggering 'remove' event to prevent an
+        // infinite loop. #3693
+        delete this._byId[model.cid];
+        var id = this.modelId(model.attributes);
+        if (id != null) delete this._byId[id];
+
+        if (!options.silent) {
+          options.index = index;
+          model.trigger('remove', model, this, options);
+        }
+
+        removed.push(model);
+        this._removeReference(model, options);
+      }
+      return removed;
+    },
+
+    // Method for checking whether an object should be considered a model for
+    // the purposes of adding to the collection.
+    _isModel: function(model) {
+      return model instanceof Model;
+    },
+
     // Internal method to create a model's ties to a collection.
     _addReference: function(model, options) {
       this._byId[model.cid] = model;
-      if (model.id != null) this._byId[model.id] = model;
-      if (!model.collection) model.collection = this;
+      var id = this.modelId(model.attributes);
+      if (id != null) this._byId[id] = model;
       model.on('all', this._onModelEvent, this);
     },
 
     // Internal method to sever a model's ties to a collection.
     _removeReference: function(model, options) {
+      delete this._byId[model.cid];
+      var id = this.modelId(model.attributes);
+      if (id != null) delete this._byId[id];
       if (this === model.collection) delete model.collection;
       model.off('all', this._onModelEvent, this);
     },
@@ -937,11 +1172,17 @@
     // events simply proxy through. "add" and "remove" events that originate
     // in other collections are ignored.
     _onModelEvent: function(event, model, collection, options) {
-      if ((event === 'add' || event === 'remove') && collection !== this) return;
-      if (event === 'destroy') this.remove(model, options);
-      if (model && event === 'change:' + model.idAttribute) {
-        delete this._byId[model.previous(model.idAttribute)];
-        if (model.id != null) this._byId[model.id] = model;
+      if (model) {
+        if ((event === 'add' || event === 'remove') && collection !== this) return;
+        if (event === 'destroy') this.remove(model, options);
+        if (event === 'change') {
+          var prevId = this.modelId(model.previousAttributes());
+          var id = this.modelId(model.attributes);
+          if (prevId !== id) {
+            if (prevId != null) delete this._byId[prevId];
+            if (id != null) this._byId[id] = model;
+          }
+        }
       }
       this.trigger.apply(this, arguments);
     }
@@ -951,34 +1192,17 @@
   // Underscore methods that we want to implement on the Collection.
   // 90% of the core usefulness of Backbone Collections is actually implemented
   // right here:
-  var methods = ['forEach', 'each', 'map', 'collect', 'reduce', 'foldl',
-    'inject', 'reduceRight', 'foldr', 'find', 'detect', 'filter', 'select',
-    'reject', 'every', 'all', 'some', 'any', 'include', 'contains', 'invoke',
-    'max', 'min', 'toArray', 'size', 'first', 'head', 'take', 'initial', 'rest',
-    'tail', 'drop', 'last', 'without', 'difference', 'indexOf', 'shuffle',
-    'lastIndexOf', 'isEmpty', 'chain', 'sample'];
+  var collectionMethods = {forEach: 3, each: 3, map: 3, collect: 3, reduce: 0,
+      foldl: 0, inject: 0, reduceRight: 0, foldr: 0, find: 3, detect: 3, filter: 3,
+      select: 3, reject: 3, every: 3, all: 3, some: 3, any: 3, include: 3, includes: 3,
+      contains: 3, invoke: 0, max: 3, min: 3, toArray: 1, size: 1, first: 3,
+      head: 3, take: 3, initial: 3, rest: 3, tail: 3, drop: 3, last: 3,
+      without: 0, difference: 0, indexOf: 3, shuffle: 1, lastIndexOf: 3,
+      isEmpty: 1, chain: 1, sample: 3, partition: 3, groupBy: 3, countBy: 3,
+      sortBy: 3, indexBy: 3, findIndex: 3, findLastIndex: 3};
 
   // Mix in each Underscore method as a proxy to `Collection#models`.
-  _.each(methods, function(method) {
-    Collection.prototype[method] = function() {
-      var args = slice.call(arguments);
-      args.unshift(this.models);
-      return _[method].apply(_, args);
-    };
-  });
-
-  // Underscore methods that take a property name as an argument.
-  var attributeMethods = ['groupBy', 'countBy', 'sortBy', 'indexBy'];
-
-  // Use attributes instead of properties.
-  _.each(attributeMethods, function(method) {
-    Collection.prototype[method] = function(value, context) {
-      var iterator = _.isFunction(value) ? value : function(model) {
-        return model.get(value);
-      };
-      return _[method](this.models, iterator, context);
-    };
-  });
+  addUnderscoreMethods(Collection, collectionMethods, 'models');
 
   // Backbone.View
   // -------------
@@ -995,17 +1219,15 @@
   // if an existing element is not provided...
   var View = Backbone.View = function(options) {
     this.cid = _.uniqueId('view');
-    options || (options = {});
     _.extend(this, _.pick(options, viewOptions));
     this._ensureElement();
     this.initialize.apply(this, arguments);
-    this.delegateEvents();
   };
 
   // Cached regex to split keys for `delegate`.
   var delegateEventSplitter = /^(\S+)\s*(.*)$/;
 
-  // List of view options to be merged as properties.
+  // List of view options to be set as properties.
   var viewOptions = ['model', 'collection', 'el', 'id', 'attributes', 'className', 'tagName', 'events'];
 
   // Set up all inheritable **Backbone.View** properties and methods.
@@ -1034,19 +1256,35 @@
     // Remove this view by taking the element out of the DOM, and removing any
     // applicable Backbone.Events listeners.
     remove: function() {
-      this.$el.remove();
+      this._removeElement();
       this.stopListening();
       return this;
     },
 
-    // Change the view's element (`this.el` property), including event
-    // re-delegation.
-    setElement: function(element, delegate) {
-      if (this.$el) this.undelegateEvents();
-      this.$el = element instanceof Backbone.$ ? element : Backbone.$(element);
-      this.el = this.$el[0];
-      if (delegate !== false) this.delegateEvents();
+    // Remove this view's element from the document and all event listeners
+    // attached to it. Exposed for subclasses using an alternative DOM
+    // manipulation API.
+    _removeElement: function() {
+      this.$el.remove();
+    },
+
+    // Change the view's element (`this.el` property) and re-delegate the
+    // view's events on the new element.
+    setElement: function(element) {
+      this.undelegateEvents();
+      this._setElement(element);
+      this.delegateEvents();
       return this;
+    },
+
+    // Creates the `this.el` and `this.$el` references for this view using the
+    // given `el`. `el` can be a CSS selector or an HTML string, a jQuery
+    // context or an element. Subclasses can override this to utilize an
+    // alternative DOM manipulation API and are only required to set the
+    // `this.el` property.
+    _setElement: function(el) {
+      this.$el = el instanceof Backbone.$ ? el : Backbone.$(el);
+      this.el = this.$el[0];
     },
 
     // Set callbacks, where `this.events` is a hash of
@@ -1062,35 +1300,47 @@
     // pairs. Callbacks will be bound to the view, with `this` set properly.
     // Uses event delegation for efficiency.
     // Omitting the selector binds the event to `this.el`.
-    // This only works for delegate-able events: not `focus`, `blur`, and
-    // not `change`, `submit`, and `reset` in Internet Explorer.
     delegateEvents: function(events) {
-      if (!(events || (events = _.result(this, 'events')))) return this;
+      events || (events = _.result(this, 'events'));
+      if (!events) return this;
       this.undelegateEvents();
       for (var key in events) {
         var method = events[key];
-        if (!_.isFunction(method)) method = this[events[key]];
+        if (!_.isFunction(method)) method = this[method];
         if (!method) continue;
-
         var match = key.match(delegateEventSplitter);
-        var eventName = match[1], selector = match[2];
-        method = _.bind(method, this);
-        eventName += '.delegateEvents' + this.cid;
-        if (selector === '') {
-          this.$el.on(eventName, method);
-        } else {
-          this.$el.on(eventName, selector, method);
-        }
+        this.delegate(match[1], match[2], _.bind(method, this));
       }
       return this;
     },
 
-    // Clears all callbacks previously bound to the view with `delegateEvents`.
+    // Add a single event listener to the view's element (or a child element
+    // using `selector`). This only works for delegate-able events: not `focus`,
+    // `blur`, and not `change`, `submit`, and `reset` in Internet Explorer.
+    delegate: function(eventName, selector, listener) {
+      this.$el.on(eventName + '.delegateEvents' + this.cid, selector, listener);
+      return this;
+    },
+
+    // Clears all callbacks previously bound to the view by `delegateEvents`.
     // You usually don't need to use this, but may wish to if you have multiple
     // Backbone views attached to the same DOM element.
     undelegateEvents: function() {
-      this.$el.off('.delegateEvents' + this.cid);
+      if (this.$el) this.$el.off('.delegateEvents' + this.cid);
       return this;
+    },
+
+    // A finer-grained `undelegateEvents` for removing a single delegated event.
+    // `selector` and `listener` are both optional.
+    undelegate: function(eventName, selector, listener) {
+      this.$el.off(eventName + '.delegateEvents' + this.cid, selector, listener);
+      return this;
+    },
+
+    // Produces a DOM element to be assigned to your view. Exposed for
+    // subclasses using an alternative DOM manipulation API.
+    _createElement: function(tagName) {
+      return document.createElement(tagName);
     },
 
     // Ensure that the View has a DOM element to render into.
@@ -1102,11 +1352,17 @@
         var attrs = _.extend({}, _.result(this, 'attributes'));
         if (this.id) attrs.id = _.result(this, 'id');
         if (this.className) attrs['class'] = _.result(this, 'className');
-        var $el = Backbone.$('<' + _.result(this, 'tagName') + '>').attr(attrs);
-        this.setElement($el, false);
+        this.setElement(this._createElement(_.result(this, 'tagName')));
+        this._setAttributes(attrs);
       } else {
-        this.setElement(_.result(this, 'el'), false);
+        this.setElement(_.result(this, 'el'));
       }
+    },
+
+    // Set attributes from a hash on this view's element.  Exposed for
+    // subclasses using an alternative DOM manipulation API.
+    _setAttributes: function(attributes) {
+      this.$el.attr(attributes);
     }
 
   });
@@ -1175,14 +1431,13 @@
       params.processData = false;
     }
 
-    // If we're sending a `PATCH` request, and we're in an old Internet Explorer
-    // that still has ActiveX enabled by default, override jQuery to use that
-    // for XHR instead. Remove this line when jQuery supports `PATCH` on IE8.
-    if (params.type === 'PATCH' && noXhrPatch) {
-      params.xhr = function() {
-        return new ActiveXObject("Microsoft.XMLHTTP");
-      };
-    }
+    // Pass along `textStatus` and `errorThrown` from jQuery.
+    var error = options.error;
+    options.error = function(xhr, textStatus, errorThrown) {
+      options.textStatus = textStatus;
+      options.errorThrown = errorThrown;
+      if (error) error.call(options.context, xhr, textStatus, errorThrown);
+    };
 
     // Make the request, allowing the user to override any Ajax options.
     var xhr = options.xhr = Backbone.ajax(_.extend(params, options));
@@ -1190,17 +1445,13 @@
     return xhr;
   };
 
-  var noXhrPatch =
-    typeof window !== 'undefined' && !!window.ActiveXObject &&
-      !(window.XMLHttpRequest && (new XMLHttpRequest).dispatchEvent);
-
   // Map from CRUD to HTTP for our default `Backbone.sync` implementation.
   var methodMap = {
     'create': 'POST',
     'update': 'PUT',
-    'patch':  'PATCH',
+    'patch': 'PATCH',
     'delete': 'DELETE',
-    'read':   'GET'
+    'read': 'GET'
   };
 
   // Set the default implementation of `Backbone.ajax` to proxy through to `$`.
@@ -1251,17 +1502,18 @@
       var router = this;
       Backbone.history.route(route, function(fragment) {
         var args = router._extractParameters(route, fragment);
-        router.execute(callback, args);
-        router.trigger.apply(router, ['route:' + name].concat(args));
-        router.trigger('route', name, args);
-        Backbone.history.trigger('route', router, name, args);
+        if (router.execute(callback, args, name) !== false) {
+          router.trigger.apply(router, ['route:' + name].concat(args));
+          router.trigger('route', name, args);
+          Backbone.history.trigger('route', router, name, args);
+        }
       });
       return this;
     },
 
     // Execute a route handler with the provided parameters.  This is an
     // excellent place to do pre-route setup or post-route cleanup.
-    execute: function(callback, args) {
+    execute: function(callback, args, name) {
       if (callback) callback.apply(this, args);
     },
 
@@ -1319,7 +1571,7 @@
   // falls back to polling.
   var History = Backbone.History = function() {
     this.handlers = [];
-    _.bindAll(this, 'checkUrl');
+    this.checkUrl = _.bind(this.checkUrl, this);
 
     // Ensure that `History` can be used outside of the browser.
     if (typeof window !== 'undefined') {
@@ -1333,12 +1585,6 @@
 
   // Cached regex for stripping leading and trailing slashes.
   var rootStripper = /^\/+|\/+$/g;
-
-  // Cached regex for detecting MSIE.
-  var isExplorer = /msie [\w.]+/;
-
-  // Cached regex for removing a trailing slash.
-  var trailingSlash = /\/$/;
 
   // Cached regex for stripping urls of hash.
   var pathStripper = /#.*$/;
@@ -1355,7 +1601,29 @@
 
     // Are we at the app root?
     atRoot: function() {
-      return this.location.pathname.replace(/[^\/]$/, '$&/') === this.root;
+      var path = this.location.pathname.replace(/[^\/]$/, '$&/');
+      return path === this.root && !this.getSearch();
+    },
+
+    // Does the pathname match the root?
+    matchRoot: function() {
+      var path = this.decodeFragment(this.location.pathname);
+      var rootPath = path.slice(0, this.root.length - 1) + '/';
+      return rootPath === this.root;
+    },
+
+    // Unicode characters in `location.pathname` are percent encoded so they're
+    // decoded for comparison. `%25` should not be decoded since it may be part
+    // of an encoded parameter.
+    decodeFragment: function(fragment) {
+      return decodeURI(fragment.replace(/%25/g, '%2525'));
+    },
+
+    // In IE6, the hash fragment and search params are incorrect if the
+    // fragment contains `?`.
+    getSearch: function() {
+      var match = this.location.href.replace(/#.*/, '').match(/\?.+/);
+      return match ? match[0] : '';
     },
 
     // Gets the true hash value. Cannot use location.hash directly due to bug
@@ -1365,14 +1633,19 @@
       return match ? match[1] : '';
     },
 
-    // Get the cross-browser normalized URL fragment, either from the URL,
-    // the hash, or the override.
-    getFragment: function(fragment, forcePushState) {
+    // Get the pathname and search params, without the root.
+    getPath: function() {
+      var path = this.decodeFragment(
+        this.location.pathname + this.getSearch()
+      ).slice(this.root.length - 1);
+      return path.charAt(0) === '/' ? path.slice(1) : path;
+    },
+
+    // Get the cross-browser normalized URL fragment from the path or hash.
+    getFragment: function(fragment) {
       if (fragment == null) {
-        if (this._hasPushState || !this._wantsHashChange || forcePushState) {
-          fragment = decodeURI(this.location.pathname + this.location.search);
-          var root = this.root.replace(trailingSlash, '');
-          if (!fragment.indexOf(root)) fragment = fragment.slice(root.length);
+        if (this._usePushState || !this._wantsHashChange) {
+          fragment = this.getPath();
         } else {
           fragment = this.getHash();
         }
@@ -1383,7 +1656,7 @@
     // Start the hash change handling, returning `true` if the current URL matches
     // an existing route, and `false` otherwise.
     start: function(options) {
-      if (History.started) throw new Error("Backbone.history has already been started");
+      if (History.started) throw new Error('Backbone.history has already been started');
       History.started = true;
 
       // Figure out the initial configuration. Do we need an iframe?
@@ -1391,35 +1664,15 @@
       this.options          = _.extend({root: '/'}, this.options, options);
       this.root             = this.options.root;
       this._wantsHashChange = this.options.hashChange !== false;
+      this._hasHashChange   = 'onhashchange' in window && (document.documentMode === void 0 || document.documentMode > 7);
+      this._useHashChange   = this._wantsHashChange && this._hasHashChange;
       this._wantsPushState  = !!this.options.pushState;
-      this._hasPushState    = !!(this.options.pushState && this.history && this.history.pushState);
-      var fragment          = this.getFragment();
-      var docMode           = document.documentMode;
-      var oldIE             = (isExplorer.exec(navigator.userAgent.toLowerCase()) && (!docMode || docMode <= 7));
+      this._hasPushState    = !!(this.history && this.history.pushState);
+      this._usePushState    = this._wantsPushState && this._hasPushState;
+      this.fragment         = this.getFragment();
 
       // Normalize root to always include a leading and trailing slash.
       this.root = ('/' + this.root + '/').replace(rootStripper, '/');
-
-      if (oldIE && this._wantsHashChange) {
-        var frame = Backbone.$('<iframe src="javascript:0" tabindex="-1">');
-        this.iframe = frame.hide().appendTo('body')[0].contentWindow;
-        this.navigate(fragment);
-      }
-
-      // Depending on whether we're using pushState or hashes, and whether
-      // 'onhashchange' is supported, determine how we check the URL state.
-      if (this._hasPushState) {
-        Backbone.$(window).on('popstate', this.checkUrl);
-      } else if (this._wantsHashChange && ('onhashchange' in window) && !oldIE) {
-        Backbone.$(window).on('hashchange', this.checkUrl);
-      } else if (this._wantsHashChange) {
-        this._checkUrlInterval = setInterval(this.checkUrl, this.interval);
-      }
-
-      // Determine if we need to change the base url, for a pushState link
-      // opened by a non-pushState browser.
-      this.fragment = fragment;
-      var loc = this.location;
 
       // Transition from hashChange to pushState or vice versa if both are
       // requested.
@@ -1428,18 +1681,48 @@
         // If we've started off with a route from a `pushState`-enabled
         // browser, but we're currently in a browser that doesn't support it...
         if (!this._hasPushState && !this.atRoot()) {
-          this.fragment = this.getFragment(null, true);
-          this.location.replace(this.root + '#' + this.fragment);
+          var rootPath = this.root.slice(0, -1) || '/';
+          this.location.replace(rootPath + '#' + this.getPath());
           // Return immediately as browser will do redirect to new url
           return true;
 
         // Or if we've started out with a hash-based route, but we're currently
         // in a browser where it could be `pushState`-based instead...
-        } else if (this._hasPushState && this.atRoot() && loc.hash) {
-          this.fragment = this.getHash().replace(routeStripper, '');
-          this.history.replaceState({}, document.title, this.root + this.fragment);
+        } else if (this._hasPushState && this.atRoot()) {
+          this.navigate(this.getHash(), {replace: true});
         }
 
+      }
+
+      // Proxy an iframe to handle location events if the browser doesn't
+      // support the `hashchange` event, HTML5 history, or the user wants
+      // `hashChange` but not `pushState`.
+      if (!this._hasHashChange && this._wantsHashChange && !this._usePushState) {
+        this.iframe = document.createElement('iframe');
+        this.iframe.src = 'javascript:0';
+        this.iframe.style.display = 'none';
+        this.iframe.tabIndex = -1;
+        var body = document.body;
+        // Using `appendChild` will throw on IE < 9 if the document is not ready.
+        var iWindow = body.insertBefore(this.iframe, body.firstChild).contentWindow;
+        iWindow.document.open();
+        iWindow.document.close();
+        iWindow.location.hash = '#' + this.fragment;
+      }
+
+      // Add a cross-platform `addEventListener` shim for older browsers.
+      var addEventListener = window.addEventListener || function(eventName, listener) {
+        return attachEvent('on' + eventName, listener);
+      };
+
+      // Depending on whether we're using pushState or hashes, and whether
+      // 'onhashchange' is supported, determine how we check the URL state.
+      if (this._usePushState) {
+        addEventListener('popstate', this.checkUrl, false);
+      } else if (this._useHashChange && !this.iframe) {
+        addEventListener('hashchange', this.checkUrl, false);
+      } else if (this._wantsHashChange) {
+        this._checkUrlInterval = setInterval(this.checkUrl, this.interval);
       }
 
       if (!this.options.silent) return this.loadUrl();
@@ -1448,7 +1731,25 @@
     // Disable Backbone.history, perhaps temporarily. Not useful in a real app,
     // but possibly useful for unit testing Routers.
     stop: function() {
-      Backbone.$(window).off('popstate', this.checkUrl).off('hashchange', this.checkUrl);
+      // Add a cross-platform `removeEventListener` shim for older browsers.
+      var removeEventListener = window.removeEventListener || function(eventName, listener) {
+        return detachEvent('on' + eventName, listener);
+      };
+
+      // Remove window listeners.
+      if (this._usePushState) {
+        removeEventListener('popstate', this.checkUrl, false);
+      } else if (this._useHashChange && !this.iframe) {
+        removeEventListener('hashchange', this.checkUrl, false);
+      }
+
+      // Clean up the iframe if necessary.
+      if (this.iframe) {
+        document.body.removeChild(this.iframe);
+        this.iframe = null;
+      }
+
+      // Some environments will throw when clearing an undefined interval.
       if (this._checkUrlInterval) clearInterval(this._checkUrlInterval);
       History.started = false;
     },
@@ -1463,9 +1764,13 @@
     // calls `loadUrl`, normalizing across the hidden iframe.
     checkUrl: function(e) {
       var current = this.getFragment();
+
+      // If the user pressed the back button, the iframe's hash will have
+      // changed and we should use that for comparison.
       if (current === this.fragment && this.iframe) {
-        current = this.getFragment(this.getHash(this.iframe));
+        current = this.getHash(this.iframe.contentWindow);
       }
+
       if (current === this.fragment) return false;
       if (this.iframe) this.navigate(current);
       this.loadUrl();
@@ -1475,8 +1780,10 @@
     // match, returns `true`. If no defined routes matches the fragment,
     // returns `false`.
     loadUrl: function(fragment) {
+      // If the root doesn't match, no routes can match either.
+      if (!this.matchRoot()) return false;
       fragment = this.fragment = this.getFragment(fragment);
-      return _.any(this.handlers, function(handler) {
+      return _.some(this.handlers, function(handler) {
         if (handler.route.test(fragment)) {
           handler.callback(fragment);
           return true;
@@ -1495,31 +1802,42 @@
       if (!History.started) return false;
       if (!options || options === true) options = {trigger: !!options};
 
-      var url = this.root + (fragment = this.getFragment(fragment || ''));
+      // Normalize the fragment.
+      fragment = this.getFragment(fragment || '');
 
-      // Strip the hash for matching.
-      fragment = fragment.replace(pathStripper, '');
+      // Don't include a trailing slash on the root.
+      var rootPath = this.root;
+      if (fragment === '' || fragment.charAt(0) === '?') {
+        rootPath = rootPath.slice(0, -1) || '/';
+      }
+      var url = rootPath + fragment;
+
+      // Strip the hash and decode for matching.
+      fragment = this.decodeFragment(fragment.replace(pathStripper, ''));
 
       if (this.fragment === fragment) return;
       this.fragment = fragment;
 
-      // Don't include a trailing slash on the root.
-      if (fragment === '' && url !== '/') url = url.slice(0, -1);
-
       // If pushState is available, we use it to set the fragment as a real URL.
-      if (this._hasPushState) {
+      if (this._usePushState) {
         this.history[options.replace ? 'replaceState' : 'pushState']({}, document.title, url);
 
       // If hash changes haven't been explicitly disabled, update the hash
       // fragment to store history.
       } else if (this._wantsHashChange) {
         this._updateHash(this.location, fragment, options.replace);
-        if (this.iframe && (fragment !== this.getFragment(this.getHash(this.iframe)))) {
+        if (this.iframe && fragment !== this.getHash(this.iframe.contentWindow)) {
+          var iWindow = this.iframe.contentWindow;
+
           // Opening and closing the iframe tricks IE7 and earlier to push a
           // history entry on hash-tag change.  When replace is true, we don't
           // want this.
-          if(!options.replace) this.iframe.document.open().close();
-          this._updateHash(this.iframe.location, fragment, options.replace);
+          if (!options.replace) {
+            iWindow.document.open();
+            iWindow.document.close();
+          }
+
+          this._updateHash(iWindow.location, fragment, options.replace);
         }
 
       // If you've told us that you explicitly don't want fallback hashchange-
@@ -1550,7 +1868,7 @@
   // Helpers
   // -------
 
-  // Helper function to correctly set up the prototype chain, for subclasses.
+  // Helper function to correctly set up the prototype chain for subclasses.
   // Similar to `goog.inherits`, but uses a hash of prototype properties and
   // class properties to be extended.
   var extend = function(protoProps, staticProps) {
@@ -1559,7 +1877,7 @@
 
     // The constructor function for the new subclass is either defined by you
     // (the "constructor" property in your `extend` definition), or defaulted
-    // by us to simply call the parent's constructor.
+    // by us to simply call the parent constructor.
     if (protoProps && _.has(protoProps, 'constructor')) {
       child = protoProps.constructor;
     } else {
@@ -1570,14 +1888,9 @@
     _.extend(child, parent, staticProps);
 
     // Set the prototype chain to inherit from `parent`, without calling
-    // `parent`'s constructor function.
-    var Surrogate = function(){ this.constructor = child; };
-    Surrogate.prototype = parent.prototype;
-    child.prototype = new Surrogate;
-
-    // Add prototype properties (instance properties) to the subclass,
-    // if supplied.
-    if (protoProps) _.extend(child.prototype, protoProps);
+    // `parent`'s constructor function and add the prototype properties.
+    child.prototype = _.create(parent.prototype, protoProps);
+    child.prototype.constructor = child;
 
     // Set a convenience property in case the parent's prototype is needed
     // later.
@@ -1598,11 +1911,10 @@
   var wrapError = function(model, options) {
     var error = options.error;
     options.error = function(resp) {
-      if (error) error(model, resp, options);
+      if (error) error.call(options.context, model, resp, options);
       model.trigger('error', model, resp, options);
     };
   };
 
   return Backbone;
-
-}));
+});

--- a/examples/backbone_marionette/node_modules/jquery/dist/jquery.js
+++ b/examples/backbone_marionette/node_modules/jquery/dist/jquery.js
@@ -1,27 +1,27 @@
 /*!
- * jQuery JavaScript Library v1.11.2
+ * jQuery JavaScript Library v1.12.4
  * http://jquery.com/
  *
  * Includes Sizzle.js
  * http://sizzlejs.com/
  *
- * Copyright 2005, 2014 jQuery Foundation, Inc. and other contributors
+ * Copyright jQuery Foundation and other contributors
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2014-12-17T15:27Z
+ * Date: 2016-05-20T17:17Z
  */
 
 (function( global, factory ) {
 
 	if ( typeof module === "object" && typeof module.exports === "object" ) {
-		// For CommonJS and CommonJS-like environments where a proper window is present,
-		// execute the factory and get jQuery
-		// For environments that do not inherently posses a window with a document
-		// (such as Node.js), expose a jQuery-making factory as module.exports
-		// This accentuates the need for the creation of a real window
+		// For CommonJS and CommonJS-like environments where a proper `window`
+		// is present, execute the factory and get jQuery.
+		// For environments that do not have a `window` with a `document`
+		// (such as Node.js), expose a factory as module.exports.
+		// This accentuates the need for the creation of a real `window`.
 		// e.g. var jQuery = require("jquery")(window);
-		// See ticket #14549 for more info
+		// See ticket #14549 for more info.
 		module.exports = global.document ?
 			factory( global, true ) :
 			function( w ) {
@@ -37,13 +37,14 @@
 // Pass this if window is not defined yet
 }(typeof window !== "undefined" ? window : this, function( window, noGlobal ) {
 
-// Can't do this because several apps including ASP.NET trace
+// Support: Firefox 18+
+// Can't be in strict mode, several libs including ASP.NET trace
 // the stack via arguments.caller.callee and Firefox dies if
 // you try to trace through "use strict" call chains. (#13335)
-// Support: Firefox 18+
-//
-
+//"use strict";
 var deletedIds = [];
+
+var document = window.document;
 
 var slice = deletedIds.slice;
 
@@ -64,10 +65,11 @@ var support = {};
 
 
 var
-	version = "1.11.2",
+	version = "1.12.4",
 
 	// Define a local copy of jQuery
 	jQuery = function( selector, context ) {
+
 		// The jQuery object is actually just the init constructor 'enhanced'
 		// Need init if jQuery is called (just allow error to be thrown if not included)
 		return new jQuery.fn.init( selector, context );
@@ -87,6 +89,7 @@ var
 	};
 
 jQuery.fn = jQuery.prototype = {
+
 	// The current version of jQuery being used
 	jquery: version,
 
@@ -130,16 +133,14 @@ jQuery.fn = jQuery.prototype = {
 	},
 
 	// Execute a callback for every element in the matched set.
-	// (You can seed the arguments with an array of args, but this is
-	// only used internally.)
-	each: function( callback, args ) {
-		return jQuery.each( this, callback, args );
+	each: function( callback ) {
+		return jQuery.each( this, callback );
 	},
 
 	map: function( callback ) {
-		return this.pushStack( jQuery.map(this, function( elem, i ) {
+		return this.pushStack( jQuery.map( this, function( elem, i ) {
 			return callback.call( elem, i, elem );
-		}));
+		} ) );
 	},
 
 	slice: function() {
@@ -157,11 +158,11 @@ jQuery.fn = jQuery.prototype = {
 	eq: function( i ) {
 		var len = this.length,
 			j = +i + ( i < 0 ? len : 0 );
-		return this.pushStack( j >= 0 && j < len ? [ this[j] ] : [] );
+		return this.pushStack( j >= 0 && j < len ? [ this[ j ] ] : [] );
 	},
 
 	end: function() {
-		return this.prevObject || this.constructor(null);
+		return this.prevObject || this.constructor();
 	},
 
 	// For internal use only.
@@ -173,7 +174,7 @@ jQuery.fn = jQuery.prototype = {
 
 jQuery.extend = jQuery.fn.extend = function() {
 	var src, copyIsArray, copy, name, options, clone,
-		target = arguments[0] || {},
+		target = arguments[ 0 ] || {},
 		i = 1,
 		length = arguments.length,
 		deep = false;
@@ -188,7 +189,7 @@ jQuery.extend = jQuery.fn.extend = function() {
 	}
 
 	// Handle case when target is a string or something (possible in deep copy)
-	if ( typeof target !== "object" && !jQuery.isFunction(target) ) {
+	if ( typeof target !== "object" && !jQuery.isFunction( target ) ) {
 		target = {};
 	}
 
@@ -199,8 +200,10 @@ jQuery.extend = jQuery.fn.extend = function() {
 	}
 
 	for ( ; i < length; i++ ) {
+
 		// Only deal with non-null/undefined values
-		if ( (options = arguments[ i ]) != null ) {
+		if ( ( options = arguments[ i ] ) != null ) {
+
 			// Extend the base object
 			for ( name in options ) {
 				src = target[ name ];
@@ -212,13 +215,15 @@ jQuery.extend = jQuery.fn.extend = function() {
 				}
 
 				// Recurse if we're merging plain objects or arrays
-				if ( deep && copy && ( jQuery.isPlainObject(copy) || (copyIsArray = jQuery.isArray(copy)) ) ) {
+				if ( deep && copy && ( jQuery.isPlainObject( copy ) ||
+					( copyIsArray = jQuery.isArray( copy ) ) ) ) {
+
 					if ( copyIsArray ) {
 						copyIsArray = false;
-						clone = src && jQuery.isArray(src) ? src : [];
+						clone = src && jQuery.isArray( src ) ? src : [];
 
 					} else {
-						clone = src && jQuery.isPlainObject(src) ? src : {};
+						clone = src && jQuery.isPlainObject( src ) ? src : {};
 					}
 
 					// Never move original objects, clone them
@@ -236,7 +241,8 @@ jQuery.extend = jQuery.fn.extend = function() {
 	return target;
 };
 
-jQuery.extend({
+jQuery.extend( {
+
 	// Unique for each copy of jQuery on the page
 	expando: "jQuery" + ( version + Math.random() ).replace( /\D/g, "" ),
 
@@ -253,11 +259,11 @@ jQuery.extend({
 	// Since version 1.3, DOM methods and functions like alert
 	// aren't supported. They return false on IE (#2968).
 	isFunction: function( obj ) {
-		return jQuery.type(obj) === "function";
+		return jQuery.type( obj ) === "function";
 	},
 
 	isArray: Array.isArray || function( obj ) {
-		return jQuery.type(obj) === "array";
+		return jQuery.type( obj ) === "array";
 	},
 
 	isWindow: function( obj ) {
@@ -266,11 +272,13 @@ jQuery.extend({
 	},
 
 	isNumeric: function( obj ) {
+
 		// parseFloat NaNs numeric-cast false positives (null|true|false|"")
 		// ...but misinterprets leading-number strings, particularly hex literals ("0x...")
 		// subtraction forces infinities to NaN
 		// adding 1 corrects loss of precision from parseFloat (#15100)
-		return !jQuery.isArray( obj ) && (obj - parseFloat( obj ) + 1) >= 0;
+		var realStringObj = obj && obj.toString();
+		return !jQuery.isArray( obj ) && ( realStringObj - parseFloat( realStringObj ) + 1 ) >= 0;
 	},
 
 	isEmptyObject: function( obj ) {
@@ -287,25 +295,27 @@ jQuery.extend({
 		// Must be an Object.
 		// Because of IE, we also have to check the presence of the constructor property.
 		// Make sure that DOM nodes and window objects don't pass through, as well
-		if ( !obj || jQuery.type(obj) !== "object" || obj.nodeType || jQuery.isWindow( obj ) ) {
+		if ( !obj || jQuery.type( obj ) !== "object" || obj.nodeType || jQuery.isWindow( obj ) ) {
 			return false;
 		}
 
 		try {
+
 			// Not own constructor property must be Object
 			if ( obj.constructor &&
-				!hasOwn.call(obj, "constructor") &&
-				!hasOwn.call(obj.constructor.prototype, "isPrototypeOf") ) {
+				!hasOwn.call( obj, "constructor" ) &&
+				!hasOwn.call( obj.constructor.prototype, "isPrototypeOf" ) ) {
 				return false;
 			}
 		} catch ( e ) {
+
 			// IE8,9 Will throw exceptions on certain host objects #9897
 			return false;
 		}
 
 		// Support: IE<9
 		// Handle iteration over inherited properties before own properties.
-		if ( support.ownLast ) {
+		if ( !support.ownFirst ) {
 			for ( key in obj ) {
 				return hasOwn.call( obj, key );
 			}
@@ -323,20 +333,20 @@ jQuery.extend({
 			return obj + "";
 		}
 		return typeof obj === "object" || typeof obj === "function" ?
-			class2type[ toString.call(obj) ] || "object" :
+			class2type[ toString.call( obj ) ] || "object" :
 			typeof obj;
 	},
 
-	// Evaluates a script in a global context
 	// Workarounds based on findings by Jim Driscoll
 	// http://weblogs.java.net/blog/driscoll/archive/2009/09/08/eval-javascript-global-context
 	globalEval: function( data ) {
 		if ( data && jQuery.trim( data ) ) {
+
 			// We use execScript on Internet Explorer
 			// We use an anonymous function so that context is window
 			// rather than jQuery in Firefox
 			( window.execScript || function( data ) {
-				window[ "eval" ].call( window, data );
+				window[ "eval" ].call( window, data ); // jscs:ignore requireDotNotation
 			} )( data );
 		}
 	},
@@ -351,49 +361,20 @@ jQuery.extend({
 		return elem.nodeName && elem.nodeName.toLowerCase() === name.toLowerCase();
 	},
 
-	// args is for internal usage only
-	each: function( obj, callback, args ) {
-		var value,
-			i = 0,
-			length = obj.length,
-			isArray = isArraylike( obj );
+	each: function( obj, callback ) {
+		var length, i = 0;
 
-		if ( args ) {
-			if ( isArray ) {
-				for ( ; i < length; i++ ) {
-					value = callback.apply( obj[ i ], args );
-
-					if ( value === false ) {
-						break;
-					}
-				}
-			} else {
-				for ( i in obj ) {
-					value = callback.apply( obj[ i ], args );
-
-					if ( value === false ) {
-						break;
-					}
+		if ( isArrayLike( obj ) ) {
+			length = obj.length;
+			for ( ; i < length; i++ ) {
+				if ( callback.call( obj[ i ], i, obj[ i ] ) === false ) {
+					break;
 				}
 			}
-
-		// A special, fast, case for the most common use of each
 		} else {
-			if ( isArray ) {
-				for ( ; i < length; i++ ) {
-					value = callback.call( obj[ i ], i, obj[ i ] );
-
-					if ( value === false ) {
-						break;
-					}
-				}
-			} else {
-				for ( i in obj ) {
-					value = callback.call( obj[ i ], i, obj[ i ] );
-
-					if ( value === false ) {
-						break;
-					}
+			for ( i in obj ) {
+				if ( callback.call( obj[ i ], i, obj[ i ] ) === false ) {
+					break;
 				}
 			}
 		}
@@ -413,7 +394,7 @@ jQuery.extend({
 		var ret = results || [];
 
 		if ( arr != null ) {
-			if ( isArraylike( Object(arr) ) ) {
+			if ( isArrayLike( Object( arr ) ) ) {
 				jQuery.merge( ret,
 					typeof arr === "string" ?
 					[ arr ] : arr
@@ -438,6 +419,7 @@ jQuery.extend({
 			i = i ? i < 0 ? Math.max( 0, len + i ) : i : 0;
 
 			for ( ; i < len; i++ ) {
+
 				// Skip accessing in sparse arrays
 				if ( i in arr && arr[ i ] === elem ) {
 					return i;
@@ -460,7 +442,7 @@ jQuery.extend({
 		// Support: IE<9
 		// Workaround casting of .length to NaN on otherwise arraylike objects (e.g., NodeLists)
 		if ( len !== len ) {
-			while ( second[j] !== undefined ) {
+			while ( second[ j ] !== undefined ) {
 				first[ i++ ] = second[ j++ ];
 			}
 		}
@@ -491,14 +473,13 @@ jQuery.extend({
 
 	// arg is for internal usage only
 	map: function( elems, callback, arg ) {
-		var value,
+		var length, value,
 			i = 0,
-			length = elems.length,
-			isArray = isArraylike( elems ),
 			ret = [];
 
 		// Go through the array, translating each of the items to their new values
-		if ( isArray ) {
+		if ( isArrayLike( elems ) ) {
+			length = elems.length;
 			for ( ; i < length; i++ ) {
 				value = callback( elems[ i ], i, arg );
 
@@ -561,23 +542,35 @@ jQuery.extend({
 	// jQuery.support is not used in Core but other projects attach their
 	// properties to it so it needs to exist.
 	support: support
-});
+} );
+
+// JSHint would error on this code due to the Symbol not being defined in ES5.
+// Defining this global in .jshintrc would create a danger of using the global
+// unguarded in another place, it seems safer to just disable JSHint for these
+// three lines.
+/* jshint ignore: start */
+if ( typeof Symbol === "function" ) {
+	jQuery.fn[ Symbol.iterator ] = deletedIds[ Symbol.iterator ];
+}
+/* jshint ignore: end */
 
 // Populate the class2type map
-jQuery.each("Boolean Number String Function Array Date RegExp Object Error".split(" "), function(i, name) {
+jQuery.each( "Boolean Number String Function Array Date RegExp Object Error Symbol".split( " " ),
+function( i, name ) {
 	class2type[ "[object " + name + "]" ] = name.toLowerCase();
-});
+} );
 
-function isArraylike( obj ) {
-	var length = obj.length,
+function isArrayLike( obj ) {
+
+	// Support: iOS 8.2 (not reproducible in simulator)
+	// `in` check used to prevent JIT error (gh-2145)
+	// hasOwn isn't used here due to false negatives
+	// regarding Nodelist length in IE
+	var length = !!obj && "length" in obj && obj.length,
 		type = jQuery.type( obj );
 
 	if ( type === "function" || jQuery.isWindow( obj ) ) {
 		return false;
-	}
-
-	if ( obj.nodeType === 1 && length ) {
-		return true;
 	}
 
 	return type === "array" || length === 0 ||
@@ -585,14 +578,14 @@ function isArraylike( obj ) {
 }
 var Sizzle =
 /*!
- * Sizzle CSS Selector Engine v2.2.0-pre
+ * Sizzle CSS Selector Engine v2.2.1
  * http://sizzlejs.com/
  *
- * Copyright 2008, 2014 jQuery Foundation, Inc. and other contributors
+ * Copyright jQuery Foundation and other contributors
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2014-12-16
+ * Date: 2015-10-17
  */
 (function( window ) {
 
@@ -660,25 +653,21 @@ var i,
 
 	// Regular expressions
 
-	// Whitespace characters http://www.w3.org/TR/css3-selectors/#whitespace
+	// http://www.w3.org/TR/css3-selectors/#whitespace
 	whitespace = "[\\x20\\t\\r\\n\\f]",
-	// http://www.w3.org/TR/css3-syntax/#characters
-	characterEncoding = "(?:\\\\.|[\\w-]|[^\\x00-\\xa0])+",
 
-	// Loosely modeled on CSS identifier characters
-	// An unquoted value should be a CSS identifier http://www.w3.org/TR/css3-selectors/#attribute-selectors
-	// Proper syntax: http://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
-	identifier = characterEncoding.replace( "w", "w#" ),
+	// http://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
+	identifier = "(?:\\\\.|[\\w-]|[^\\x00-\\xa0])+",
 
 	// Attribute selectors: http://www.w3.org/TR/selectors/#attribute-selectors
-	attributes = "\\[" + whitespace + "*(" + characterEncoding + ")(?:" + whitespace +
+	attributes = "\\[" + whitespace + "*(" + identifier + ")(?:" + whitespace +
 		// Operator (capture 2)
 		"*([*^$|!~]?=)" + whitespace +
 		// "Attribute values must be CSS identifiers [capture 5] or strings [capture 3 or capture 4]"
 		"*(?:'((?:\\\\.|[^\\\\'])*)'|\"((?:\\\\.|[^\\\\\"])*)\"|(" + identifier + "))|)" + whitespace +
 		"*\\]",
 
-	pseudos = ":(" + characterEncoding + ")(?:\\((" +
+	pseudos = ":(" + identifier + ")(?:\\((" +
 		// To reduce the number of selectors needing tokenize in the preFilter, prefer arguments:
 		// 1. quoted (capture 3; capture 4 or capture 5)
 		"('((?:\\\\.|[^\\\\'])*)'|\"((?:\\\\.|[^\\\\\"])*)\")|" +
@@ -701,9 +690,9 @@ var i,
 	ridentifier = new RegExp( "^" + identifier + "$" ),
 
 	matchExpr = {
-		"ID": new RegExp( "^#(" + characterEncoding + ")" ),
-		"CLASS": new RegExp( "^\\.(" + characterEncoding + ")" ),
-		"TAG": new RegExp( "^(" + characterEncoding.replace( "w", "w*" ) + ")" ),
+		"ID": new RegExp( "^#(" + identifier + ")" ),
+		"CLASS": new RegExp( "^\\.(" + identifier + ")" ),
+		"TAG": new RegExp( "^(" + identifier + "|[*])" ),
 		"ATTR": new RegExp( "^" + attributes ),
 		"PSEUDO": new RegExp( "^" + pseudos ),
 		"CHILD": new RegExp( "^:(only|first|last|nth|nth-last)-(child|of-type)(?:\\(" + whitespace +
@@ -781,103 +770,129 @@ try {
 }
 
 function Sizzle( selector, context, results, seed ) {
-	var match, elem, m, nodeType,
-		// QSA vars
-		i, groups, old, nid, newContext, newSelector;
+	var m, i, elem, nid, nidselect, match, groups, newSelector,
+		newContext = context && context.ownerDocument,
 
-	if ( ( context ? context.ownerDocument || context : preferredDoc ) !== document ) {
-		setDocument( context );
-	}
+		// nodeType defaults to 9, since context defaults to document
+		nodeType = context ? context.nodeType : 9;
 
-	context = context || document;
 	results = results || [];
-	nodeType = context.nodeType;
 
+	// Return early from calls with invalid selector or context
 	if ( typeof selector !== "string" || !selector ||
 		nodeType !== 1 && nodeType !== 9 && nodeType !== 11 ) {
 
 		return results;
 	}
 
-	if ( !seed && documentIsHTML ) {
+	// Try to shortcut find operations (as opposed to filters) in HTML documents
+	if ( !seed ) {
 
-		// Try to shortcut find operations when possible (e.g., not under DocumentFragment)
-		if ( nodeType !== 11 && (match = rquickExpr.exec( selector )) ) {
-			// Speed-up: Sizzle("#ID")
-			if ( (m = match[1]) ) {
-				if ( nodeType === 9 ) {
-					elem = context.getElementById( m );
-					// Check parentNode to catch when Blackberry 4.6 returns
-					// nodes that are no longer in the document (jQuery #6963)
-					if ( elem && elem.parentNode ) {
-						// Handle the case where IE, Opera, and Webkit return items
-						// by name instead of ID
-						if ( elem.id === m ) {
+		if ( ( context ? context.ownerDocument || context : preferredDoc ) !== document ) {
+			setDocument( context );
+		}
+		context = context || document;
+
+		if ( documentIsHTML ) {
+
+			// If the selector is sufficiently simple, try using a "get*By*" DOM method
+			// (excepting DocumentFragment context, where the methods don't exist)
+			if ( nodeType !== 11 && (match = rquickExpr.exec( selector )) ) {
+
+				// ID selector
+				if ( (m = match[1]) ) {
+
+					// Document context
+					if ( nodeType === 9 ) {
+						if ( (elem = context.getElementById( m )) ) {
+
+							// Support: IE, Opera, Webkit
+							// TODO: identify versions
+							// getElementById can match elements by name instead of ID
+							if ( elem.id === m ) {
+								results.push( elem );
+								return results;
+							}
+						} else {
+							return results;
+						}
+
+					// Element context
+					} else {
+
+						// Support: IE, Opera, Webkit
+						// TODO: identify versions
+						// getElementById can match elements by name instead of ID
+						if ( newContext && (elem = newContext.getElementById( m )) &&
+							contains( context, elem ) &&
+							elem.id === m ) {
+
 							results.push( elem );
 							return results;
 						}
-					} else {
-						return results;
 					}
-				} else {
-					// Context is not a document
-					if ( context.ownerDocument && (elem = context.ownerDocument.getElementById( m )) &&
-						contains( context, elem ) && elem.id === m ) {
-						results.push( elem );
-						return results;
-					}
-				}
 
-			// Speed-up: Sizzle("TAG")
-			} else if ( match[2] ) {
-				push.apply( results, context.getElementsByTagName( selector ) );
-				return results;
-
-			// Speed-up: Sizzle(".CLASS")
-			} else if ( (m = match[3]) && support.getElementsByClassName ) {
-				push.apply( results, context.getElementsByClassName( m ) );
-				return results;
-			}
-		}
-
-		// QSA path
-		if ( support.qsa && (!rbuggyQSA || !rbuggyQSA.test( selector )) ) {
-			nid = old = expando;
-			newContext = context;
-			newSelector = nodeType !== 1 && selector;
-
-			// qSA works strangely on Element-rooted queries
-			// We can work around this by specifying an extra ID on the root
-			// and working up from there (Thanks to Andrew Dupont for the technique)
-			// IE 8 doesn't work on object elements
-			if ( nodeType === 1 && context.nodeName.toLowerCase() !== "object" ) {
-				groups = tokenize( selector );
-
-				if ( (old = context.getAttribute("id")) ) {
-					nid = old.replace( rescape, "\\$&" );
-				} else {
-					context.setAttribute( "id", nid );
-				}
-				nid = "[id='" + nid + "'] ";
-
-				i = groups.length;
-				while ( i-- ) {
-					groups[i] = nid + toSelector( groups[i] );
-				}
-				newContext = rsibling.test( selector ) && testContext( context.parentNode ) || context;
-				newSelector = groups.join(",");
-			}
-
-			if ( newSelector ) {
-				try {
-					push.apply( results,
-						newContext.querySelectorAll( newSelector )
-					);
+				// Type selector
+				} else if ( match[2] ) {
+					push.apply( results, context.getElementsByTagName( selector ) );
 					return results;
-				} catch(qsaError) {
-				} finally {
-					if ( !old ) {
-						context.removeAttribute("id");
+
+				// Class selector
+				} else if ( (m = match[3]) && support.getElementsByClassName &&
+					context.getElementsByClassName ) {
+
+					push.apply( results, context.getElementsByClassName( m ) );
+					return results;
+				}
+			}
+
+			// Take advantage of querySelectorAll
+			if ( support.qsa &&
+				!compilerCache[ selector + " " ] &&
+				(!rbuggyQSA || !rbuggyQSA.test( selector )) ) {
+
+				if ( nodeType !== 1 ) {
+					newContext = context;
+					newSelector = selector;
+
+				// qSA looks outside Element context, which is not what we want
+				// Thanks to Andrew Dupont for this workaround technique
+				// Support: IE <=8
+				// Exclude object elements
+				} else if ( context.nodeName.toLowerCase() !== "object" ) {
+
+					// Capture the context ID, setting it first if necessary
+					if ( (nid = context.getAttribute( "id" )) ) {
+						nid = nid.replace( rescape, "\\$&" );
+					} else {
+						context.setAttribute( "id", (nid = expando) );
+					}
+
+					// Prefix every selector in the list
+					groups = tokenize( selector );
+					i = groups.length;
+					nidselect = ridentifier.test( nid ) ? "#" + nid : "[id='" + nid + "']";
+					while ( i-- ) {
+						groups[i] = nidselect + " " + toSelector( groups[i] );
+					}
+					newSelector = groups.join( "," );
+
+					// Expand context for sibling selectors
+					newContext = rsibling.test( selector ) && testContext( context.parentNode ) ||
+						context;
+				}
+
+				if ( newSelector ) {
+					try {
+						push.apply( results,
+							newContext.querySelectorAll( newSelector )
+						);
+						return results;
+					} catch ( qsaError ) {
+					} finally {
+						if ( nid === expando ) {
+							context.removeAttribute( "id" );
+						}
 					}
 				}
 			}
@@ -890,7 +905,7 @@ function Sizzle( selector, context, results, seed ) {
 
 /**
  * Create key-value caches of limited size
- * @returns {Function(string, Object)} Returns the Object data after storing it on itself with
+ * @returns {function(string, object)} Returns the Object data after storing it on itself with
  *	property name the (space-suffixed) string and (if the cache is larger than Expr.cacheLength)
  *	deleting the oldest entry
  */
@@ -945,7 +960,7 @@ function assert( fn ) {
  */
 function addHandle( attrs, handler ) {
 	var arr = attrs.split("|"),
-		i = attrs.length;
+		i = arr.length;
 
 	while ( i-- ) {
 		Expr.attrHandle[ arr[i] ] = handler;
@@ -1058,32 +1073,28 @@ setDocument = Sizzle.setDocument = function( node ) {
 	var hasCompare, parent,
 		doc = node ? node.ownerDocument || node : preferredDoc;
 
-	// If no document and documentElement is available, return
+	// Return early if doc is invalid or already selected
 	if ( doc === document || doc.nodeType !== 9 || !doc.documentElement ) {
 		return document;
 	}
 
-	// Set our document
+	// Update global variables
 	document = doc;
-	docElem = doc.documentElement;
-	parent = doc.defaultView;
+	docElem = document.documentElement;
+	documentIsHTML = !isXML( document );
 
-	// Support: IE>8
-	// If iframe document is assigned to "document" variable and if iframe has been reloaded,
-	// IE will throw "permission denied" error when accessing "document" variable, see jQuery #13936
-	// IE6-8 do not support the defaultView property so parent will be undefined
-	if ( parent && parent !== parent.top ) {
-		// IE11 does not have attachEvent, so all must suffer
+	// Support: IE 9-11, Edge
+	// Accessing iframe documents after unload throws "permission denied" errors (jQuery #13936)
+	if ( (parent = document.defaultView) && parent.top !== parent ) {
+		// Support: IE 11
 		if ( parent.addEventListener ) {
 			parent.addEventListener( "unload", unloadHandler, false );
+
+		// Support: IE 9 - 10 only
 		} else if ( parent.attachEvent ) {
 			parent.attachEvent( "onunload", unloadHandler );
 		}
 	}
-
-	/* Support tests
-	---------------------------------------------------------------------- */
-	documentIsHTML = !isXML( doc );
 
 	/* Attributes
 	---------------------------------------------------------------------- */
@@ -1101,12 +1112,12 @@ setDocument = Sizzle.setDocument = function( node ) {
 
 	// Check if getElementsByTagName("*") returns only elements
 	support.getElementsByTagName = assert(function( div ) {
-		div.appendChild( doc.createComment("") );
+		div.appendChild( document.createComment("") );
 		return !div.getElementsByTagName("*").length;
 	});
 
 	// Support: IE<9
-	support.getElementsByClassName = rnative.test( doc.getElementsByClassName );
+	support.getElementsByClassName = rnative.test( document.getElementsByClassName );
 
 	// Support: IE<10
 	// Check if getElementById returns elements by name
@@ -1114,7 +1125,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 	// so use a roundabout getElementsByName test
 	support.getById = assert(function( div ) {
 		docElem.appendChild( div ).id = expando;
-		return !doc.getElementsByName || !doc.getElementsByName( expando ).length;
+		return !document.getElementsByName || !document.getElementsByName( expando ).length;
 	});
 
 	// ID find and filter
@@ -1122,9 +1133,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 		Expr.find["ID"] = function( id, context ) {
 			if ( typeof context.getElementById !== "undefined" && documentIsHTML ) {
 				var m = context.getElementById( id );
-				// Check parentNode to catch when Blackberry 4.6 returns
-				// nodes that are no longer in the document #6963
-				return m && m.parentNode ? [ m ] : [];
+				return m ? [ m ] : [];
 			}
 		};
 		Expr.filter["ID"] = function( id ) {
@@ -1141,7 +1150,8 @@ setDocument = Sizzle.setDocument = function( node ) {
 		Expr.filter["ID"] =  function( id ) {
 			var attrId = id.replace( runescape, funescape );
 			return function( elem ) {
-				var node = typeof elem.getAttributeNode !== "undefined" && elem.getAttributeNode("id");
+				var node = typeof elem.getAttributeNode !== "undefined" &&
+					elem.getAttributeNode("id");
 				return node && node.value === attrId;
 			};
 		};
@@ -1181,7 +1191,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 
 	// Class
 	Expr.find["CLASS"] = support.getElementsByClassName && function( className, context ) {
-		if ( documentIsHTML ) {
+		if ( typeof context.getElementsByClassName !== "undefined" && documentIsHTML ) {
 			return context.getElementsByClassName( className );
 		}
 	};
@@ -1201,7 +1211,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 	// See http://bugs.jquery.com/ticket/13378
 	rbuggyQSA = [];
 
-	if ( (support.qsa = rnative.test( doc.querySelectorAll )) ) {
+	if ( (support.qsa = rnative.test( document.querySelectorAll )) ) {
 		// Build QSA regex
 		// Regex strategy adopted from Diego Perini
 		assert(function( div ) {
@@ -1211,7 +1221,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 			// since its presence should be enough
 			// http://bugs.jquery.com/ticket/12359
 			docElem.appendChild( div ).innerHTML = "<a id='" + expando + "'></a>" +
-				"<select id='" + expando + "-\f]' msallowcapture=''>" +
+				"<select id='" + expando + "-\r\\' msallowcapture=''>" +
 				"<option selected=''></option></select>";
 
 			// Support: IE8, Opera 11-12.16
@@ -1228,7 +1238,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 				rbuggyQSA.push( "\\[" + whitespace + "*(?:value|" + booleans + ")" );
 			}
 
-			// Support: Chrome<29, Android<4.2+, Safari<7.0+, iOS<7.0+, PhantomJS<1.9.7+
+			// Support: Chrome<29, Android<4.4, Safari<7.0+, iOS<7.0+, PhantomJS<1.9.8+
 			if ( !div.querySelectorAll( "[id~=" + expando + "-]" ).length ) {
 				rbuggyQSA.push("~=");
 			}
@@ -1251,7 +1261,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 		assert(function( div ) {
 			// Support: Windows 8 Native Apps
 			// The type and name attributes are restricted during .innerHTML assignment
-			var input = doc.createElement("input");
+			var input = document.createElement("input");
 			input.setAttribute( "type", "hidden" );
 			div.appendChild( input ).setAttribute( "name", "D" );
 
@@ -1299,7 +1309,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 	hasCompare = rnative.test( docElem.compareDocumentPosition );
 
 	// Element contains another
-	// Purposefully does not implement inclusive descendent
+	// Purposefully self-exclusive
 	// As in, an element does not contain itself
 	contains = hasCompare || rnative.test( docElem.contains ) ?
 		function( a, b ) {
@@ -1353,10 +1363,10 @@ setDocument = Sizzle.setDocument = function( node ) {
 			(!support.sortDetached && b.compareDocumentPosition( a ) === compare) ) {
 
 			// Choose the first element that is related to our preferred document
-			if ( a === doc || a.ownerDocument === preferredDoc && contains(preferredDoc, a) ) {
+			if ( a === document || a.ownerDocument === preferredDoc && contains(preferredDoc, a) ) {
 				return -1;
 			}
-			if ( b === doc || b.ownerDocument === preferredDoc && contains(preferredDoc, b) ) {
+			if ( b === document || b.ownerDocument === preferredDoc && contains(preferredDoc, b) ) {
 				return 1;
 			}
 
@@ -1384,8 +1394,8 @@ setDocument = Sizzle.setDocument = function( node ) {
 
 		// Parentless nodes are either documents or disconnected
 		if ( !aup || !bup ) {
-			return a === doc ? -1 :
-				b === doc ? 1 :
+			return a === document ? -1 :
+				b === document ? 1 :
 				aup ? -1 :
 				bup ? 1 :
 				sortInput ?
@@ -1422,7 +1432,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 			0;
 	};
 
-	return doc;
+	return document;
 };
 
 Sizzle.matches = function( expr, elements ) {
@@ -1439,6 +1449,7 @@ Sizzle.matchesSelector = function( elem, expr ) {
 	expr = expr.replace( rattributeQuotes, "='$1']" );
 
 	if ( support.matchesSelector && documentIsHTML &&
+		!compilerCache[ expr + " " ] &&
 		( !rbuggyMatches || !rbuggyMatches.test( expr ) ) &&
 		( !rbuggyQSA     || !rbuggyQSA.test( expr ) ) ) {
 
@@ -1712,11 +1723,12 @@ Expr = Sizzle.selectors = {
 				} :
 
 				function( elem, context, xml ) {
-					var cache, outerCache, node, diff, nodeIndex, start,
+					var cache, uniqueCache, outerCache, node, nodeIndex, start,
 						dir = simple !== forward ? "nextSibling" : "previousSibling",
 						parent = elem.parentNode,
 						name = ofType && elem.nodeName.toLowerCase(),
-						useCache = !xml && !ofType;
+						useCache = !xml && !ofType,
+						diff = false;
 
 					if ( parent ) {
 
@@ -1725,7 +1737,10 @@ Expr = Sizzle.selectors = {
 							while ( dir ) {
 								node = elem;
 								while ( (node = node[ dir ]) ) {
-									if ( ofType ? node.nodeName.toLowerCase() === name : node.nodeType === 1 ) {
+									if ( ofType ?
+										node.nodeName.toLowerCase() === name :
+										node.nodeType === 1 ) {
+
 										return false;
 									}
 								}
@@ -1739,11 +1754,21 @@ Expr = Sizzle.selectors = {
 
 						// non-xml :nth-child(...) stores cache data on `parent`
 						if ( forward && useCache ) {
+
 							// Seek `elem` from a previously-cached index
-							outerCache = parent[ expando ] || (parent[ expando ] = {});
-							cache = outerCache[ type ] || [];
-							nodeIndex = cache[0] === dirruns && cache[1];
-							diff = cache[0] === dirruns && cache[2];
+
+							// ...in a gzip-friendly way
+							node = parent;
+							outerCache = node[ expando ] || (node[ expando ] = {});
+
+							// Support: IE <9 only
+							// Defend against cloned attroperties (jQuery gh-1709)
+							uniqueCache = outerCache[ node.uniqueID ] ||
+								(outerCache[ node.uniqueID ] = {});
+
+							cache = uniqueCache[ type ] || [];
+							nodeIndex = cache[ 0 ] === dirruns && cache[ 1 ];
+							diff = nodeIndex && cache[ 2 ];
 							node = nodeIndex && parent.childNodes[ nodeIndex ];
 
 							while ( (node = ++nodeIndex && node && node[ dir ] ||
@@ -1753,29 +1778,55 @@ Expr = Sizzle.selectors = {
 
 								// When found, cache indexes on `parent` and break
 								if ( node.nodeType === 1 && ++diff && node === elem ) {
-									outerCache[ type ] = [ dirruns, nodeIndex, diff ];
+									uniqueCache[ type ] = [ dirruns, nodeIndex, diff ];
 									break;
 								}
 							}
 
-						// Use previously-cached element index if available
-						} else if ( useCache && (cache = (elem[ expando ] || (elem[ expando ] = {}))[ type ]) && cache[0] === dirruns ) {
-							diff = cache[1];
-
-						// xml :nth-child(...) or :nth-last-child(...) or :nth(-last)?-of-type(...)
 						} else {
-							// Use the same loop as above to seek `elem` from the start
-							while ( (node = ++nodeIndex && node && node[ dir ] ||
-								(diff = nodeIndex = 0) || start.pop()) ) {
+							// Use previously-cached element index if available
+							if ( useCache ) {
+								// ...in a gzip-friendly way
+								node = elem;
+								outerCache = node[ expando ] || (node[ expando ] = {});
 
-								if ( ( ofType ? node.nodeName.toLowerCase() === name : node.nodeType === 1 ) && ++diff ) {
-									// Cache the index of each encountered element
-									if ( useCache ) {
-										(node[ expando ] || (node[ expando ] = {}))[ type ] = [ dirruns, diff ];
-									}
+								// Support: IE <9 only
+								// Defend against cloned attroperties (jQuery gh-1709)
+								uniqueCache = outerCache[ node.uniqueID ] ||
+									(outerCache[ node.uniqueID ] = {});
 
-									if ( node === elem ) {
-										break;
+								cache = uniqueCache[ type ] || [];
+								nodeIndex = cache[ 0 ] === dirruns && cache[ 1 ];
+								diff = nodeIndex;
+							}
+
+							// xml :nth-child(...)
+							// or :nth-last-child(...) or :nth(-last)?-of-type(...)
+							if ( diff === false ) {
+								// Use the same loop as above to seek `elem` from the start
+								while ( (node = ++nodeIndex && node && node[ dir ] ||
+									(diff = nodeIndex = 0) || start.pop()) ) {
+
+									if ( ( ofType ?
+										node.nodeName.toLowerCase() === name :
+										node.nodeType === 1 ) &&
+										++diff ) {
+
+										// Cache the index of each encountered element
+										if ( useCache ) {
+											outerCache = node[ expando ] || (node[ expando ] = {});
+
+											// Support: IE <9 only
+											// Defend against cloned attroperties (jQuery gh-1709)
+											uniqueCache = outerCache[ node.uniqueID ] ||
+												(outerCache[ node.uniqueID ] = {});
+
+											uniqueCache[ type ] = [ dirruns, diff ];
+										}
+
+										if ( node === elem ) {
+											break;
+										}
 									}
 								}
 							}
@@ -2137,10 +2188,10 @@ function addCombinator( matcher, combinator, base ) {
 
 		// Check against all ancestor/preceding elements
 		function( elem, context, xml ) {
-			var oldCache, outerCache,
+			var oldCache, uniqueCache, outerCache,
 				newCache = [ dirruns, doneName ];
 
-			// We can't set arbitrary data on XML nodes, so they don't benefit from dir caching
+			// We can't set arbitrary data on XML nodes, so they don't benefit from combinator caching
 			if ( xml ) {
 				while ( (elem = elem[ dir ]) ) {
 					if ( elem.nodeType === 1 || checkNonElements ) {
@@ -2153,14 +2204,19 @@ function addCombinator( matcher, combinator, base ) {
 				while ( (elem = elem[ dir ]) ) {
 					if ( elem.nodeType === 1 || checkNonElements ) {
 						outerCache = elem[ expando ] || (elem[ expando ] = {});
-						if ( (oldCache = outerCache[ dir ]) &&
+
+						// Support: IE <9 only
+						// Defend against cloned attroperties (jQuery gh-1709)
+						uniqueCache = outerCache[ elem.uniqueID ] || (outerCache[ elem.uniqueID ] = {});
+
+						if ( (oldCache = uniqueCache[ dir ]) &&
 							oldCache[ 0 ] === dirruns && oldCache[ 1 ] === doneName ) {
 
 							// Assign to newCache so results back-propagate to previous elements
 							return (newCache[ 2 ] = oldCache[ 2 ]);
 						} else {
 							// Reuse newcache so results back-propagate to previous elements
-							outerCache[ dir ] = newCache;
+							uniqueCache[ dir ] = newCache;
 
 							// A match means we're done; a fail means we have to keep checking
 							if ( (newCache[ 2 ] = matcher( elem, context, xml )) ) {
@@ -2385,18 +2441,21 @@ function matcherFromGroupMatchers( elementMatchers, setMatchers ) {
 				len = elems.length;
 
 			if ( outermost ) {
-				outermostContext = context !== document && context;
+				outermostContext = context === document || context || outermost;
 			}
 
 			// Add elements passing elementMatchers directly to results
-			// Keep `i` a string if there are no elements so `matchedCount` will be "00" below
 			// Support: IE<9, Safari
 			// Tolerate NodeList properties (IE: "length"; Safari: <number>) matching elements by id
 			for ( ; i !== len && (elem = elems[i]) != null; i++ ) {
 				if ( byElement && elem ) {
 					j = 0;
+					if ( !context && elem.ownerDocument !== document ) {
+						setDocument( elem );
+						xml = !documentIsHTML;
+					}
 					while ( (matcher = elementMatchers[j++]) ) {
-						if ( matcher( elem, context, xml ) ) {
+						if ( matcher( elem, context || document, xml) ) {
 							results.push( elem );
 							break;
 						}
@@ -2420,8 +2479,17 @@ function matcherFromGroupMatchers( elementMatchers, setMatchers ) {
 				}
 			}
 
-			// Apply set filters to unmatched elements
+			// `i` is now the count of elements visited above, and adding it to `matchedCount`
+			// makes the latter nonnegative.
 			matchedCount += i;
+
+			// Apply set filters to unmatched elements
+			// NOTE: This can be skipped if there are no unmatched elements (i.e., `matchedCount`
+			// equals `i`), unless we didn't visit _any_ elements in the above loop because we have
+			// no element matchers and no seed.
+			// Incrementing an initially-string "0" `i` allows `i` to remain a string only in that
+			// case, which will result in a "00" `matchedCount` that differs from `i` but is also
+			// numerically zero.
 			if ( bySet && i !== matchedCount ) {
 				j = 0;
 				while ( (matcher = setMatchers[j++]) ) {
@@ -2513,10 +2581,11 @@ select = Sizzle.select = function( selector, context, results, seed ) {
 
 	results = results || [];
 
-	// Try to minimize operations if there is no seed and only one group
+	// Try to minimize operations if there is only one selector in the list and no seed
+	// (the latter of which guarantees us context)
 	if ( match.length === 1 ) {
 
-		// Take a shortcut and set the context if the root selector is an ID
+		// Reduce context if the leading compound selector is an ID
 		tokens = match[0] = match[0].slice( 0 );
 		if ( tokens.length > 2 && (token = tokens[0]).type === "ID" &&
 				support.getById && context.nodeType === 9 && documentIsHTML &&
@@ -2571,7 +2640,7 @@ select = Sizzle.select = function( selector, context, results, seed ) {
 		context,
 		!documentIsHTML,
 		results,
-		rsibling.test( selector ) && testContext( context.parentNode ) || context
+		!context || rsibling.test( selector ) && testContext( context.parentNode ) || context
 	);
 	return results;
 };
@@ -2647,17 +2716,46 @@ return Sizzle;
 
 jQuery.find = Sizzle;
 jQuery.expr = Sizzle.selectors;
-jQuery.expr[":"] = jQuery.expr.pseudos;
-jQuery.unique = Sizzle.uniqueSort;
+jQuery.expr[ ":" ] = jQuery.expr.pseudos;
+jQuery.uniqueSort = jQuery.unique = Sizzle.uniqueSort;
 jQuery.text = Sizzle.getText;
 jQuery.isXMLDoc = Sizzle.isXML;
 jQuery.contains = Sizzle.contains;
 
 
 
+var dir = function( elem, dir, until ) {
+	var matched = [],
+		truncate = until !== undefined;
+
+	while ( ( elem = elem[ dir ] ) && elem.nodeType !== 9 ) {
+		if ( elem.nodeType === 1 ) {
+			if ( truncate && jQuery( elem ).is( until ) ) {
+				break;
+			}
+			matched.push( elem );
+		}
+	}
+	return matched;
+};
+
+
+var siblings = function( n, elem ) {
+	var matched = [];
+
+	for ( ; n; n = n.nextSibling ) {
+		if ( n.nodeType === 1 && n !== elem ) {
+			matched.push( n );
+		}
+	}
+
+	return matched;
+};
+
+
 var rneedsContext = jQuery.expr.match.needsContext;
 
-var rsingleTag = (/^<(\w+)\s*\/?>(?:<\/\1>|)$/);
+var rsingleTag = ( /^<([\w-]+)\s*\/?>(?:<\/\1>|)$/ );
 
 
 
@@ -2669,14 +2767,14 @@ function winnow( elements, qualifier, not ) {
 		return jQuery.grep( elements, function( elem, i ) {
 			/* jshint -W018 */
 			return !!qualifier.call( elem, i, elem ) !== not;
-		});
+		} );
 
 	}
 
 	if ( qualifier.nodeType ) {
 		return jQuery.grep( elements, function( elem ) {
 			return ( elem === qualifier ) !== not;
-		});
+		} );
 
 	}
 
@@ -2689,8 +2787,8 @@ function winnow( elements, qualifier, not ) {
 	}
 
 	return jQuery.grep( elements, function( elem ) {
-		return ( jQuery.inArray( elem, qualifier ) >= 0 ) !== not;
-	});
+		return ( jQuery.inArray( elem, qualifier ) > -1 ) !== not;
+	} );
 }
 
 jQuery.filter = function( expr, elems, not ) {
@@ -2704,10 +2802,10 @@ jQuery.filter = function( expr, elems, not ) {
 		jQuery.find.matchesSelector( elem, expr ) ? [ elem ] : [] :
 		jQuery.find.matches( expr, jQuery.grep( elems, function( elem ) {
 			return elem.nodeType === 1;
-		}));
+		} ) );
 };
 
-jQuery.fn.extend({
+jQuery.fn.extend( {
 	find: function( selector ) {
 		var i,
 			ret = [],
@@ -2715,13 +2813,13 @@ jQuery.fn.extend({
 			len = self.length;
 
 		if ( typeof selector !== "string" ) {
-			return this.pushStack( jQuery( selector ).filter(function() {
+			return this.pushStack( jQuery( selector ).filter( function() {
 				for ( i = 0; i < len; i++ ) {
 					if ( jQuery.contains( self[ i ], this ) ) {
 						return true;
 					}
 				}
-			}) );
+			} ) );
 		}
 
 		for ( i = 0; i < len; i++ ) {
@@ -2734,10 +2832,10 @@ jQuery.fn.extend({
 		return ret;
 	},
 	filter: function( selector ) {
-		return this.pushStack( winnow(this, selector || [], false) );
+		return this.pushStack( winnow( this, selector || [], false ) );
 	},
 	not: function( selector ) {
-		return this.pushStack( winnow(this, selector || [], true) );
+		return this.pushStack( winnow( this, selector || [], true ) );
 	},
 	is: function( selector ) {
 		return !!winnow(
@@ -2751,7 +2849,7 @@ jQuery.fn.extend({
 			false
 		).length;
 	}
-});
+} );
 
 
 // Initialize a jQuery object
@@ -2760,15 +2858,12 @@ jQuery.fn.extend({
 // A central reference to the root jQuery(document)
 var rootjQuery,
 
-	// Use the correct document accordingly with window argument (sandbox)
-	document = window.document,
-
 	// A simple way to check for HTML strings
 	// Prioritize #id over <tag> to avoid XSS via location.hash (#9521)
 	// Strict HTML recognition (#11290: must start with <)
 	rquickExpr = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/,
 
-	init = jQuery.fn.init = function( selector, context ) {
+	init = jQuery.fn.init = function( selector, context, root ) {
 		var match, elem;
 
 		// HANDLE: $(""), $(null), $(undefined), $(false)
@@ -2776,9 +2871,16 @@ var rootjQuery,
 			return this;
 		}
 
+		// init accepts an alternate rootjQuery
+		// so migrate can support jQuery.sub (gh-2101)
+		root = root || rootjQuery;
+
 		// Handle HTML strings
 		if ( typeof selector === "string" ) {
-			if ( selector.charAt(0) === "<" && selector.charAt( selector.length - 1 ) === ">" && selector.length >= 3 ) {
+			if ( selector.charAt( 0 ) === "<" &&
+				selector.charAt( selector.length - 1 ) === ">" &&
+				selector.length >= 3 ) {
+
 				// Assume that strings that start and end with <> are HTML and skip the regex check
 				match = [ null, selector, null ];
 
@@ -2787,23 +2889,24 @@ var rootjQuery,
 			}
 
 			// Match html or make sure no context is specified for #id
-			if ( match && (match[1] || !context) ) {
+			if ( match && ( match[ 1 ] || !context ) ) {
 
 				// HANDLE: $(html) -> $(array)
-				if ( match[1] ) {
-					context = context instanceof jQuery ? context[0] : context;
+				if ( match[ 1 ] ) {
+					context = context instanceof jQuery ? context[ 0 ] : context;
 
 					// scripts is true for back-compat
 					// Intentionally let the error be thrown if parseHTML is not present
 					jQuery.merge( this, jQuery.parseHTML(
-						match[1],
+						match[ 1 ],
 						context && context.nodeType ? context.ownerDocument || context : document,
 						true
 					) );
 
 					// HANDLE: $(html, props)
-					if ( rsingleTag.test( match[1] ) && jQuery.isPlainObject( context ) ) {
+					if ( rsingleTag.test( match[ 1 ] ) && jQuery.isPlainObject( context ) ) {
 						for ( match in context ) {
+
 							// Properties of context are called as methods if possible
 							if ( jQuery.isFunction( this[ match ] ) ) {
 								this[ match ]( context[ match ] );
@@ -2819,20 +2922,21 @@ var rootjQuery,
 
 				// HANDLE: $(#id)
 				} else {
-					elem = document.getElementById( match[2] );
+					elem = document.getElementById( match[ 2 ] );
 
 					// Check parentNode to catch when Blackberry 4.6 returns
 					// nodes that are no longer in the document #6963
 					if ( elem && elem.parentNode ) {
+
 						// Handle the case where IE and Opera return items
 						// by name instead of ID
-						if ( elem.id !== match[2] ) {
+						if ( elem.id !== match[ 2 ] ) {
 							return rootjQuery.find( selector );
 						}
 
 						// Otherwise, we inject the element directly into the jQuery object
 						this.length = 1;
-						this[0] = elem;
+						this[ 0 ] = elem;
 					}
 
 					this.context = document;
@@ -2842,7 +2946,7 @@ var rootjQuery,
 
 			// HANDLE: $(expr, $(...))
 			} else if ( !context || context.jquery ) {
-				return ( context || rootjQuery ).find( selector );
+				return ( context || root ).find( selector );
 
 			// HANDLE: $(expr, context)
 			// (which is just equivalent to: $(context).find(expr)
@@ -2852,15 +2956,16 @@ var rootjQuery,
 
 		// HANDLE: $(DOMElement)
 		} else if ( selector.nodeType ) {
-			this.context = this[0] = selector;
+			this.context = this[ 0 ] = selector;
 			this.length = 1;
 			return this;
 
 		// HANDLE: $(function)
 		// Shortcut for document ready
 		} else if ( jQuery.isFunction( selector ) ) {
-			return typeof rootjQuery.ready !== "undefined" ?
-				rootjQuery.ready( selector ) :
+			return typeof root.ready !== "undefined" ?
+				root.ready( selector ) :
+
 				// Execute immediately if ready is not present
 				selector( jQuery );
 		}
@@ -2881,6 +2986,7 @@ rootjQuery = jQuery( document );
 
 
 var rparentsprev = /^(?:parents|prev(?:Until|All))/,
+
 	// methods guaranteed to produce a unique set when starting from a unique set
 	guaranteedUnique = {
 		children: true,
@@ -2889,46 +2995,19 @@ var rparentsprev = /^(?:parents|prev(?:Until|All))/,
 		prev: true
 	};
 
-jQuery.extend({
-	dir: function( elem, dir, until ) {
-		var matched = [],
-			cur = elem[ dir ];
-
-		while ( cur && cur.nodeType !== 9 && (until === undefined || cur.nodeType !== 1 || !jQuery( cur ).is( until )) ) {
-			if ( cur.nodeType === 1 ) {
-				matched.push( cur );
-			}
-			cur = cur[dir];
-		}
-		return matched;
-	},
-
-	sibling: function( n, elem ) {
-		var r = [];
-
-		for ( ; n; n = n.nextSibling ) {
-			if ( n.nodeType === 1 && n !== elem ) {
-				r.push( n );
-			}
-		}
-
-		return r;
-	}
-});
-
-jQuery.fn.extend({
+jQuery.fn.extend( {
 	has: function( target ) {
 		var i,
 			targets = jQuery( target, this ),
 			len = targets.length;
 
-		return this.filter(function() {
+		return this.filter( function() {
 			for ( i = 0; i < len; i++ ) {
-				if ( jQuery.contains( this, targets[i] ) ) {
+				if ( jQuery.contains( this, targets[ i ] ) ) {
 					return true;
 				}
 			}
-		});
+		} );
 	},
 
 	closest: function( selectors, context ) {
@@ -2941,14 +3020,15 @@ jQuery.fn.extend({
 				0;
 
 		for ( ; i < l; i++ ) {
-			for ( cur = this[i]; cur && cur !== context; cur = cur.parentNode ) {
+			for ( cur = this[ i ]; cur && cur !== context; cur = cur.parentNode ) {
+
 				// Always skip document fragments
-				if ( cur.nodeType < 11 && (pos ?
-					pos.index(cur) > -1 :
+				if ( cur.nodeType < 11 && ( pos ?
+					pos.index( cur ) > -1 :
 
 					// Don't pass non-elements to Sizzle
 					cur.nodeType === 1 &&
-						jQuery.find.matchesSelector(cur, selectors)) ) {
+						jQuery.find.matchesSelector( cur, selectors ) ) ) {
 
 					matched.push( cur );
 					break;
@@ -2956,7 +3036,7 @@ jQuery.fn.extend({
 			}
 		}
 
-		return this.pushStack( matched.length > 1 ? jQuery.unique( matched ) : matched );
+		return this.pushStack( matched.length > 1 ? jQuery.uniqueSort( matched ) : matched );
 	},
 
 	// Determine the position of an element within
@@ -2965,23 +3045,24 @@ jQuery.fn.extend({
 
 		// No argument, return index in parent
 		if ( !elem ) {
-			return ( this[0] && this[0].parentNode ) ? this.first().prevAll().length : -1;
+			return ( this[ 0 ] && this[ 0 ].parentNode ) ? this.first().prevAll().length : -1;
 		}
 
 		// index in selector
 		if ( typeof elem === "string" ) {
-			return jQuery.inArray( this[0], jQuery( elem ) );
+			return jQuery.inArray( this[ 0 ], jQuery( elem ) );
 		}
 
 		// Locate the position of the desired element
 		return jQuery.inArray(
+
 			// If it receives a jQuery object, the first element is used
-			elem.jquery ? elem[0] : elem, this );
+			elem.jquery ? elem[ 0 ] : elem, this );
 	},
 
 	add: function( selector, context ) {
 		return this.pushStack(
-			jQuery.unique(
+			jQuery.uniqueSort(
 				jQuery.merge( this.get(), jQuery( selector, context ) )
 			)
 		);
@@ -2989,10 +3070,10 @@ jQuery.fn.extend({
 
 	addBack: function( selector ) {
 		return this.add( selector == null ?
-			this.prevObject : this.prevObject.filter(selector)
+			this.prevObject : this.prevObject.filter( selector )
 		);
 	}
-});
+} );
 
 function sibling( cur, dir ) {
 	do {
@@ -3002,16 +3083,16 @@ function sibling( cur, dir ) {
 	return cur;
 }
 
-jQuery.each({
+jQuery.each( {
 	parent: function( elem ) {
 		var parent = elem.parentNode;
 		return parent && parent.nodeType !== 11 ? parent : null;
 	},
 	parents: function( elem ) {
-		return jQuery.dir( elem, "parentNode" );
+		return dir( elem, "parentNode" );
 	},
 	parentsUntil: function( elem, i, until ) {
-		return jQuery.dir( elem, "parentNode", until );
+		return dir( elem, "parentNode", until );
 	},
 	next: function( elem ) {
 		return sibling( elem, "nextSibling" );
@@ -3020,22 +3101,22 @@ jQuery.each({
 		return sibling( elem, "previousSibling" );
 	},
 	nextAll: function( elem ) {
-		return jQuery.dir( elem, "nextSibling" );
+		return dir( elem, "nextSibling" );
 	},
 	prevAll: function( elem ) {
-		return jQuery.dir( elem, "previousSibling" );
+		return dir( elem, "previousSibling" );
 	},
 	nextUntil: function( elem, i, until ) {
-		return jQuery.dir( elem, "nextSibling", until );
+		return dir( elem, "nextSibling", until );
 	},
 	prevUntil: function( elem, i, until ) {
-		return jQuery.dir( elem, "previousSibling", until );
+		return dir( elem, "previousSibling", until );
 	},
 	siblings: function( elem ) {
-		return jQuery.sibling( ( elem.parentNode || {} ).firstChild, elem );
+		return siblings( ( elem.parentNode || {} ).firstChild, elem );
 	},
 	children: function( elem ) {
-		return jQuery.sibling( elem.firstChild );
+		return siblings( elem.firstChild );
 	},
 	contents: function( elem ) {
 		return jQuery.nodeName( elem, "iframe" ) ?
@@ -3055,9 +3136,10 @@ jQuery.each({
 		}
 
 		if ( this.length > 1 ) {
+
 			// Remove duplicates
 			if ( !guaranteedUnique[ name ] ) {
-				ret = jQuery.unique( ret );
+				ret = jQuery.uniqueSort( ret );
 			}
 
 			// Reverse order for parents* and prev-derivatives
@@ -3068,20 +3150,17 @@ jQuery.each({
 
 		return this.pushStack( ret );
 	};
-});
-var rnotwhite = (/\S+/g);
+} );
+var rnotwhite = ( /\S+/g );
 
 
 
-// String to Object options format cache
-var optionsCache = {};
-
-// Convert String-formatted options into Object-formatted ones and store in cache
+// Convert String-formatted options into Object-formatted ones
 function createOptions( options ) {
-	var object = optionsCache[ options ] = {};
+	var object = {};
 	jQuery.each( options.match( rnotwhite ) || [], function( _, flag ) {
 		object[ flag ] = true;
-	});
+	} );
 	return object;
 }
 
@@ -3112,156 +3191,186 @@ jQuery.Callbacks = function( options ) {
 	// Convert options from String-formatted to Object-formatted if needed
 	// (we check in cache first)
 	options = typeof options === "string" ?
-		( optionsCache[ options ] || createOptions( options ) ) :
+		createOptions( options ) :
 		jQuery.extend( {}, options );
 
 	var // Flag to know if list is currently firing
 		firing,
-		// Last fire value (for non-forgettable lists)
+
+		// Last fire value for non-forgettable lists
 		memory,
+
 		// Flag to know if list was already fired
 		fired,
-		// End of the loop when firing
-		firingLength,
-		// Index of currently firing callback (modified by remove if needed)
-		firingIndex,
-		// First callback to fire (used internally by add and fireWith)
-		firingStart,
+
+		// Flag to prevent firing
+		locked,
+
 		// Actual callback list
 		list = [],
-		// Stack of fire calls for repeatable lists
-		stack = !options.once && [],
+
+		// Queue of execution data for repeatable lists
+		queue = [],
+
+		// Index of currently firing callback (modified by add/remove as needed)
+		firingIndex = -1,
+
 		// Fire callbacks
-		fire = function( data ) {
-			memory = options.memory && data;
-			fired = true;
-			firingIndex = firingStart || 0;
-			firingStart = 0;
-			firingLength = list.length;
-			firing = true;
-			for ( ; list && firingIndex < firingLength; firingIndex++ ) {
-				if ( list[ firingIndex ].apply( data[ 0 ], data[ 1 ] ) === false && options.stopOnFalse ) {
-					memory = false; // To prevent further calls using add
-					break;
+		fire = function() {
+
+			// Enforce single-firing
+			locked = options.once;
+
+			// Execute callbacks for all pending executions,
+			// respecting firingIndex overrides and runtime changes
+			fired = firing = true;
+			for ( ; queue.length; firingIndex = -1 ) {
+				memory = queue.shift();
+				while ( ++firingIndex < list.length ) {
+
+					// Run callback and check for early termination
+					if ( list[ firingIndex ].apply( memory[ 0 ], memory[ 1 ] ) === false &&
+						options.stopOnFalse ) {
+
+						// Jump to end and forget the data so .add doesn't re-fire
+						firingIndex = list.length;
+						memory = false;
+					}
 				}
 			}
+
+			// Forget the data if we're done with it
+			if ( !options.memory ) {
+				memory = false;
+			}
+
 			firing = false;
-			if ( list ) {
-				if ( stack ) {
-					if ( stack.length ) {
-						fire( stack.shift() );
-					}
-				} else if ( memory ) {
+
+			// Clean up if we're done firing for good
+			if ( locked ) {
+
+				// Keep an empty list if we have data for future add calls
+				if ( memory ) {
 					list = [];
+
+				// Otherwise, this object is spent
 				} else {
-					self.disable();
+					list = "";
 				}
 			}
 		},
+
 		// Actual Callbacks object
 		self = {
+
 			// Add a callback or a collection of callbacks to the list
 			add: function() {
 				if ( list ) {
-					// First, we save the current length
-					var start = list.length;
-					(function add( args ) {
+
+					// If we have memory from a past run, we should fire after adding
+					if ( memory && !firing ) {
+						firingIndex = list.length - 1;
+						queue.push( memory );
+					}
+
+					( function add( args ) {
 						jQuery.each( args, function( _, arg ) {
-							var type = jQuery.type( arg );
-							if ( type === "function" ) {
+							if ( jQuery.isFunction( arg ) ) {
 								if ( !options.unique || !self.has( arg ) ) {
 									list.push( arg );
 								}
-							} else if ( arg && arg.length && type !== "string" ) {
+							} else if ( arg && arg.length && jQuery.type( arg ) !== "string" ) {
+
 								// Inspect recursively
 								add( arg );
 							}
-						});
-					})( arguments );
-					// Do we need to add the callbacks to the
-					// current firing batch?
-					if ( firing ) {
-						firingLength = list.length;
-					// With memory, if we're not firing then
-					// we should call right away
-					} else if ( memory ) {
-						firingStart = start;
-						fire( memory );
+						} );
+					} )( arguments );
+
+					if ( memory && !firing ) {
+						fire();
 					}
 				}
 				return this;
 			},
+
 			// Remove a callback from the list
 			remove: function() {
-				if ( list ) {
-					jQuery.each( arguments, function( _, arg ) {
-						var index;
-						while ( ( index = jQuery.inArray( arg, list, index ) ) > -1 ) {
-							list.splice( index, 1 );
-							// Handle firing indexes
-							if ( firing ) {
-								if ( index <= firingLength ) {
-									firingLength--;
-								}
-								if ( index <= firingIndex ) {
-									firingIndex--;
-								}
-							}
+				jQuery.each( arguments, function( _, arg ) {
+					var index;
+					while ( ( index = jQuery.inArray( arg, list, index ) ) > -1 ) {
+						list.splice( index, 1 );
+
+						// Handle firing indexes
+						if ( index <= firingIndex ) {
+							firingIndex--;
 						}
-					});
-				}
+					}
+				} );
 				return this;
 			},
+
 			// Check if a given callback is in the list.
 			// If no argument is given, return whether or not list has callbacks attached.
 			has: function( fn ) {
-				return fn ? jQuery.inArray( fn, list ) > -1 : !!( list && list.length );
+				return fn ?
+					jQuery.inArray( fn, list ) > -1 :
+					list.length > 0;
 			},
+
 			// Remove all callbacks from the list
 			empty: function() {
-				list = [];
-				firingLength = 0;
+				if ( list ) {
+					list = [];
+				}
 				return this;
 			},
-			// Have the list do nothing anymore
+
+			// Disable .fire and .add
+			// Abort any current/pending executions
+			// Clear all callbacks and values
 			disable: function() {
-				list = stack = memory = undefined;
+				locked = queue = [];
+				list = memory = "";
 				return this;
 			},
-			// Is it disabled?
 			disabled: function() {
 				return !list;
 			},
-			// Lock the list in its current state
+
+			// Disable .fire
+			// Also disable .add unless we have memory (since it would have no effect)
+			// Abort any pending executions
 			lock: function() {
-				stack = undefined;
+				locked = true;
 				if ( !memory ) {
 					self.disable();
 				}
 				return this;
 			},
-			// Is it locked?
 			locked: function() {
-				return !stack;
+				return !!locked;
 			},
+
 			// Call all callbacks with the given context and arguments
 			fireWith: function( context, args ) {
-				if ( list && ( !fired || stack ) ) {
+				if ( !locked ) {
 					args = args || [];
 					args = [ context, args.slice ? args.slice() : args ];
-					if ( firing ) {
-						stack.push( args );
-					} else {
-						fire( args );
+					queue.push( args );
+					if ( !firing ) {
+						fire();
 					}
 				}
 				return this;
 			},
+
 			// Call all the callbacks with the given arguments
 			fire: function() {
 				self.fireWith( this, arguments );
 				return this;
 			},
+
 			// To know if the callbacks have already been called at least once
 			fired: function() {
 				return !!fired;
@@ -3272,14 +3381,15 @@ jQuery.Callbacks = function( options ) {
 };
 
 
-jQuery.extend({
+jQuery.extend( {
 
 	Deferred: function( func ) {
 		var tuples = [
+
 				// action, add listener, listener list, final state
-				[ "resolve", "done", jQuery.Callbacks("once memory"), "resolved" ],
-				[ "reject", "fail", jQuery.Callbacks("once memory"), "rejected" ],
-				[ "notify", "progress", jQuery.Callbacks("memory") ]
+				[ "resolve", "done", jQuery.Callbacks( "once memory" ), "resolved" ],
+				[ "reject", "fail", jQuery.Callbacks( "once memory" ), "rejected" ],
+				[ "notify", "progress", jQuery.Callbacks( "memory" ) ]
 			],
 			state = "pending",
 			promise = {
@@ -3292,25 +3402,30 @@ jQuery.extend({
 				},
 				then: function( /* fnDone, fnFail, fnProgress */ ) {
 					var fns = arguments;
-					return jQuery.Deferred(function( newDefer ) {
+					return jQuery.Deferred( function( newDefer ) {
 						jQuery.each( tuples, function( i, tuple ) {
 							var fn = jQuery.isFunction( fns[ i ] ) && fns[ i ];
+
 							// deferred[ done | fail | progress ] for forwarding actions to newDefer
-							deferred[ tuple[1] ](function() {
+							deferred[ tuple[ 1 ] ]( function() {
 								var returned = fn && fn.apply( this, arguments );
 								if ( returned && jQuery.isFunction( returned.promise ) ) {
 									returned.promise()
+										.progress( newDefer.notify )
 										.done( newDefer.resolve )
-										.fail( newDefer.reject )
-										.progress( newDefer.notify );
+										.fail( newDefer.reject );
 								} else {
-									newDefer[ tuple[ 0 ] + "With" ]( this === promise ? newDefer.promise() : this, fn ? [ returned ] : arguments );
+									newDefer[ tuple[ 0 ] + "With" ](
+										this === promise ? newDefer.promise() : this,
+										fn ? [ returned ] : arguments
+									);
 								}
-							});
-						});
+							} );
+						} );
 						fns = null;
-					}).promise();
+					} ).promise();
 				},
+
 				// Get a promise for this deferred
 				// If obj is provided, the promise aspect is added to the object
 				promise: function( obj ) {
@@ -3328,11 +3443,12 @@ jQuery.extend({
 				stateString = tuple[ 3 ];
 
 			// promise[ done | fail | progress ] = list.add
-			promise[ tuple[1] ] = list.add;
+			promise[ tuple[ 1 ] ] = list.add;
 
 			// Handle state
 			if ( stateString ) {
-				list.add(function() {
+				list.add( function() {
+
 					// state = [ resolved | rejected ]
 					state = stateString;
 
@@ -3341,12 +3457,12 @@ jQuery.extend({
 			}
 
 			// deferred[ resolve | reject | notify ]
-			deferred[ tuple[0] ] = function() {
-				deferred[ tuple[0] + "With" ]( this === deferred ? promise : this, arguments );
+			deferred[ tuple[ 0 ] ] = function() {
+				deferred[ tuple[ 0 ] + "With" ]( this === deferred ? promise : this, arguments );
 				return this;
 			};
-			deferred[ tuple[0] + "With" ] = list.fireWith;
-		});
+			deferred[ tuple[ 0 ] + "With" ] = list.fireWith;
+		} );
 
 		// Make the deferred a promise
 		promise.promise( deferred );
@@ -3367,9 +3483,11 @@ jQuery.extend({
 			length = resolveValues.length,
 
 			// the count of uncompleted subordinates
-			remaining = length !== 1 || ( subordinate && jQuery.isFunction( subordinate.promise ) ) ? length : 0,
+			remaining = length !== 1 ||
+				( subordinate && jQuery.isFunction( subordinate.promise ) ) ? length : 0,
 
-			// the master Deferred. If resolveValues consist of only a single Deferred, just use that.
+			// the master Deferred.
+			// If resolveValues consist of only a single Deferred, just use that.
 			deferred = remaining === 1 ? subordinate : jQuery.Deferred(),
 
 			// Update function for both resolve and progress values
@@ -3380,7 +3498,7 @@ jQuery.extend({
 					if ( values === progressValues ) {
 						deferred.notifyWith( contexts, values );
 
-					} else if ( !(--remaining) ) {
+					} else if ( !( --remaining ) ) {
 						deferred.resolveWith( contexts, values );
 					}
 				};
@@ -3396,9 +3514,9 @@ jQuery.extend({
 			for ( ; i < length; i++ ) {
 				if ( resolveValues[ i ] && jQuery.isFunction( resolveValues[ i ].promise ) ) {
 					resolveValues[ i ].promise()
+						.progress( updateFunc( i, progressContexts, progressValues ) )
 						.done( updateFunc( i, resolveContexts, resolveValues ) )
-						.fail( deferred.reject )
-						.progress( updateFunc( i, progressContexts, progressValues ) );
+						.fail( deferred.reject );
 				} else {
 					--remaining;
 				}
@@ -3412,20 +3530,22 @@ jQuery.extend({
 
 		return deferred.promise();
 	}
-});
+} );
 
 
 // The deferred used on DOM ready
 var readyList;
 
 jQuery.fn.ready = function( fn ) {
+
 	// Add the callback
 	jQuery.ready.promise().done( fn );
 
 	return this;
 };
 
-jQuery.extend({
+jQuery.extend( {
+
 	// Is the DOM ready to be used? Set to true once it occurs.
 	isReady: false,
 
@@ -3450,11 +3570,6 @@ jQuery.extend({
 			return;
 		}
 
-		// Make sure body exists, at least, in case IE gets a little overzealous (ticket #5443).
-		if ( !document.body ) {
-			return setTimeout( jQuery.ready );
-		}
-
 		// Remember that the DOM is ready
 		jQuery.isReady = true;
 
@@ -3472,15 +3587,15 @@ jQuery.extend({
 			jQuery( document ).off( "ready" );
 		}
 	}
-});
+} );
 
 /**
  * Clean-up method for dom ready events
  */
 function detach() {
 	if ( document.addEventListener ) {
-		document.removeEventListener( "DOMContentLoaded", completed, false );
-		window.removeEventListener( "load", completed, false );
+		document.removeEventListener( "DOMContentLoaded", completed );
+		window.removeEventListener( "load", completed );
 
 	} else {
 		document.detachEvent( "onreadystatechange", completed );
@@ -3492,8 +3607,12 @@ function detach() {
  * The ready event handler and self cleanup method
  */
 function completed() {
+
 	// readyState === "complete" is good enough for us to call the dom ready in oldIE
-	if ( document.addEventListener || event.type === "load" || document.readyState === "complete" ) {
+	if ( document.addEventListener ||
+		window.event.type === "load" ||
+		document.readyState === "complete" ) {
+
 		detach();
 		jQuery.ready();
 	}
@@ -3504,23 +3623,28 @@ jQuery.ready.promise = function( obj ) {
 
 		readyList = jQuery.Deferred();
 
-		// Catch cases where $(document).ready() is called after the browser event has already occurred.
-		// we once tried to use readyState "interactive" here, but it caused issues like the one
-		// discovered by ChrisS here: http://bugs.jquery.com/ticket/12282#comment:15
-		if ( document.readyState === "complete" ) {
+		// Catch cases where $(document).ready() is called
+		// after the browser event has already occurred.
+		// Support: IE6-10
+		// Older IE sometimes signals "interactive" too soon
+		if ( document.readyState === "complete" ||
+			( document.readyState !== "loading" && !document.documentElement.doScroll ) ) {
+
 			// Handle it asynchronously to allow scripts the opportunity to delay ready
-			setTimeout( jQuery.ready );
+			window.setTimeout( jQuery.ready );
 
 		// Standards-based browsers support DOMContentLoaded
 		} else if ( document.addEventListener ) {
+
 			// Use the handy event callback
-			document.addEventListener( "DOMContentLoaded", completed, false );
+			document.addEventListener( "DOMContentLoaded", completed );
 
 			// A fallback to window.onload, that will always work
-			window.addEventListener( "load", completed, false );
+			window.addEventListener( "load", completed );
 
 		// If IE event model is used
 		} else {
+
 			// Ensure firing before onload, maybe late but safe also for iframes
 			document.attachEvent( "onreadystatechange", completed );
 
@@ -3533,18 +3657,19 @@ jQuery.ready.promise = function( obj ) {
 
 			try {
 				top = window.frameElement == null && document.documentElement;
-			} catch(e) {}
+			} catch ( e ) {}
 
 			if ( top && top.doScroll ) {
-				(function doScrollCheck() {
+				( function doScrollCheck() {
 					if ( !jQuery.isReady ) {
 
 						try {
+
 							// Use the trick by Diego Perini
 							// http://javascript.nwbox.com/IEContentLoaded/
-							top.doScroll("left");
-						} catch(e) {
-							return setTimeout( doScrollCheck, 50 );
+							top.doScroll( "left" );
+						} catch ( e ) {
+							return window.setTimeout( doScrollCheck, 50 );
 						}
 
 						// detach all dom ready events
@@ -3553,15 +3678,16 @@ jQuery.ready.promise = function( obj ) {
 						// and execute any waiting functions
 						jQuery.ready();
 					}
-				})();
+				} )();
 			}
 		}
 	}
 	return readyList.promise( obj );
 };
 
+// Kick off the DOM ready check even if the user does not
+jQuery.ready.promise();
 
-var strundefined = typeof undefined;
 
 
 
@@ -3571,19 +3697,21 @@ var i;
 for ( i in jQuery( support ) ) {
 	break;
 }
-support.ownLast = i !== "0";
+support.ownFirst = i === "0";
 
 // Note: most support tests are defined in their respective modules.
 // false until the test is run
 support.inlineBlockNeedsLayout = false;
 
 // Execute ASAP in case we need to set body.style.zoom
-jQuery(function() {
+jQuery( function() {
+
 	// Minified: var a,b,c,d
 	var val, div, body, container;
 
 	body = document.getElementsByTagName( "body" )[ 0 ];
 	if ( !body || !body.style ) {
+
 		// Return for frameset docs that don't have a body
 		return;
 	}
@@ -3594,7 +3722,8 @@ jQuery(function() {
 	container.style.cssText = "position:absolute;border:0;width:0;height:0;top:0;left:-9999px";
 	body.appendChild( container ).appendChild( div );
 
-	if ( typeof div.style.zoom !== strundefined ) {
+	if ( typeof div.style.zoom !== "undefined" ) {
+
 		// Support: IE<8
 		// Check if natively block-level elements act like inline-block
 		// elements when setting their display to 'inline' and giving
@@ -3603,6 +3732,7 @@ jQuery(function() {
 
 		support.inlineBlockNeedsLayout = val = div.offsetWidth === 3;
 		if ( val ) {
+
 			// Prevent IE 6 from affecting layout for positioned elements #11048
 			// Prevent IE from shrinking the body in IE 7 mode #12869
 			// Support: IE<8
@@ -3611,35 +3741,25 @@ jQuery(function() {
 	}
 
 	body.removeChild( container );
-});
+} );
 
 
-
-
-(function() {
+( function() {
 	var div = document.createElement( "div" );
 
-	// Execute the test only if not already executed in another module.
-	if (support.deleteExpando == null) {
-		// Support: IE<9
-		support.deleteExpando = true;
-		try {
-			delete div.test;
-		} catch( e ) {
-			support.deleteExpando = false;
-		}
+	// Support: IE<9
+	support.deleteExpando = true;
+	try {
+		delete div.test;
+	} catch ( e ) {
+		support.deleteExpando = false;
 	}
 
 	// Null elements to avoid leaks in IE.
 	div = null;
-})();
-
-
-/**
- * Determines whether an object can have data
- */
-jQuery.acceptData = function( elem ) {
-	var noData = jQuery.noData[ (elem.nodeName + " ").toLowerCase() ],
+} )();
+var acceptData = function( elem ) {
+	var noData = jQuery.noData[ ( elem.nodeName + " " ).toLowerCase() ],
 		nodeType = +elem.nodeType || 1;
 
 	// Do not set data on non-element DOM nodes because it will not be cleared (#8335).
@@ -3647,14 +3767,17 @@ jQuery.acceptData = function( elem ) {
 		false :
 
 		// Nodes accept data unless otherwise specified; rejection can be conditional
-		!noData || noData !== true && elem.getAttribute("classid") === noData;
+		!noData || noData !== true && elem.getAttribute( "classid" ) === noData;
 };
+
+
 
 
 var rbrace = /^(?:\{[\w\W]*\}|\[[\w\W]*\])$/,
 	rmultiDash = /([A-Z])/g;
 
 function dataAttr( elem, key, data ) {
+
 	// If nothing was found internally, try to fetch any
 	// data from the HTML5 data-* attribute
 	if ( data === undefined && elem.nodeType === 1 ) {
@@ -3668,11 +3791,12 @@ function dataAttr( elem, key, data ) {
 				data = data === "true" ? true :
 					data === "false" ? false :
 					data === "null" ? null :
+
 					// Only convert to a number if it doesn't change the string
 					+data + "" === data ? +data :
 					rbrace.test( data ) ? jQuery.parseJSON( data ) :
 					data;
-			} catch( e ) {}
+			} catch ( e ) {}
 
 			// Make sure we set the data so it isn't changed later
 			jQuery.data( elem, key, data );
@@ -3691,7 +3815,7 @@ function isEmptyDataObject( obj ) {
 	for ( name in obj ) {
 
 		// if the public data object is empty, the private is still empty
-		if ( name === "data" && jQuery.isEmptyObject( obj[name] ) ) {
+		if ( name === "data" && jQuery.isEmptyObject( obj[ name ] ) ) {
 			continue;
 		}
 		if ( name !== "toJSON" ) {
@@ -3703,7 +3827,7 @@ function isEmptyDataObject( obj ) {
 }
 
 function internalData( elem, name, data, pvt /* Internal Use Only */ ) {
-	if ( !jQuery.acceptData( elem ) ) {
+	if ( !acceptData( elem ) ) {
 		return;
 	}
 
@@ -3724,11 +3848,13 @@ function internalData( elem, name, data, pvt /* Internal Use Only */ ) {
 
 	// Avoid doing any more work than we need to when trying to get data on an
 	// object that has no data at all
-	if ( (!id || !cache[id] || (!pvt && !cache[id].data)) && data === undefined && typeof name === "string" ) {
+	if ( ( !id || !cache[ id ] || ( !pvt && !cache[ id ].data ) ) &&
+		data === undefined && typeof name === "string" ) {
 		return;
 	}
 
 	if ( !id ) {
+
 		// Only DOM nodes need a new unique ID for each element since their data
 		// ends up in the global cache
 		if ( isNode ) {
@@ -3739,6 +3865,7 @@ function internalData( elem, name, data, pvt /* Internal Use Only */ ) {
 	}
 
 	if ( !cache[ id ] ) {
+
 		// Avoid exposing jQuery metadata on plain JS objects when the object
 		// is serialized using JSON.stringify
 		cache[ id ] = isNode ? {} : { toJSON: jQuery.noop };
@@ -3792,7 +3919,7 @@ function internalData( elem, name, data, pvt /* Internal Use Only */ ) {
 }
 
 function internalRemoveData( elem, name, pvt ) {
-	if ( !jQuery.acceptData( elem ) ) {
+	if ( !acceptData( elem ) ) {
 		return;
 	}
 
@@ -3828,10 +3955,11 @@ function internalRemoveData( elem, name, pvt ) {
 					if ( name in thisCache ) {
 						name = [ name ];
 					} else {
-						name = name.split(" ");
+						name = name.split( " " );
 					}
 				}
 			} else {
+
 				// If "name" is an array of keys...
 				// When data is initially created, via ("key", "val") signature,
 				// keys will be converted to camelCase.
@@ -3843,12 +3971,12 @@ function internalRemoveData( elem, name, pvt ) {
 
 			i = name.length;
 			while ( i-- ) {
-				delete thisCache[ name[i] ];
+				delete thisCache[ name[ i ] ];
 			}
 
 			// If there is no data left in the cache, we want to continue
 			// and let the cache object itself get destroyed
-			if ( pvt ? !isEmptyDataObject(thisCache) : !jQuery.isEmptyObject(thisCache) ) {
+			if ( pvt ? !isEmptyDataObject( thisCache ) : !jQuery.isEmptyObject( thisCache ) ) {
 				return;
 			}
 		}
@@ -3875,13 +4003,13 @@ function internalRemoveData( elem, name, pvt ) {
 		/* jshint eqeqeq: true */
 		delete cache[ id ];
 
-	// When all else fails, null
+	// When all else fails, undefined
 	} else {
-		cache[ id ] = null;
+		cache[ id ] = undefined;
 	}
 }
 
-jQuery.extend({
+jQuery.extend( {
 	cache: {},
 
 	// The following elements (space-suffixed to avoid Object.prototype collisions)
@@ -3889,12 +4017,13 @@ jQuery.extend({
 	noData: {
 		"applet ": true,
 		"embed ": true,
+
 		// ...but Flash objects (which have this classid) *can* handle expandos
 		"object ": "clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 	},
 
 	hasData: function( elem ) {
-		elem = elem.nodeType ? jQuery.cache[ elem[jQuery.expando] ] : elem[ jQuery.expando ];
+		elem = elem.nodeType ? jQuery.cache[ elem[ jQuery.expando ] ] : elem[ jQuery.expando ];
 		return !!elem && !isEmptyDataObject( elem );
 	},
 
@@ -3914,12 +4043,12 @@ jQuery.extend({
 	_removeData: function( elem, name ) {
 		return internalRemoveData( elem, name, true );
 	}
-});
+} );
 
-jQuery.fn.extend({
+jQuery.fn.extend( {
 	data: function( key, value ) {
 		var i, name, data,
-			elem = this[0],
+			elem = this[ 0 ],
 			attrs = elem && elem.attributes;
 
 		// Special expections of .data basically thwart jQuery.access,
@@ -3939,7 +4068,7 @@ jQuery.fn.extend({
 						if ( attrs[ i ] ) {
 							name = attrs[ i ].name;
 							if ( name.indexOf( "data-" ) === 0 ) {
-								name = jQuery.camelCase( name.slice(5) );
+								name = jQuery.camelCase( name.slice( 5 ) );
 								dataAttr( elem, name, data[ name ] );
 							}
 						}
@@ -3953,17 +4082,17 @@ jQuery.fn.extend({
 
 		// Sets multiple values
 		if ( typeof key === "object" ) {
-			return this.each(function() {
+			return this.each( function() {
 				jQuery.data( this, key );
-			});
+			} );
 		}
 
 		return arguments.length > 1 ?
 
 			// Sets one value
-			this.each(function() {
+			this.each( function() {
 				jQuery.data( this, key, value );
-			}) :
+			} ) :
 
 			// Gets one value
 			// Try to fetch any internally stored data first
@@ -3971,14 +4100,14 @@ jQuery.fn.extend({
 	},
 
 	removeData: function( key ) {
-		return this.each(function() {
+		return this.each( function() {
 			jQuery.removeData( this, key );
-		});
+		} );
 	}
-});
+} );
 
 
-jQuery.extend({
+jQuery.extend( {
 	queue: function( elem, type, data ) {
 		var queue;
 
@@ -3988,8 +4117,8 @@ jQuery.extend({
 
 			// Speed up dequeue by getting out quickly if this is just a lookup
 			if ( data ) {
-				if ( !queue || jQuery.isArray(data) ) {
-					queue = jQuery._data( elem, type, jQuery.makeArray(data) );
+				if ( !queue || jQuery.isArray( data ) ) {
+					queue = jQuery._data( elem, type, jQuery.makeArray( data ) );
 				} else {
 					queue.push( data );
 				}
@@ -4033,19 +4162,20 @@ jQuery.extend({
 		}
 	},
 
-	// not intended for public consumption - generates a queueHooks object, or returns the current one
+	// not intended for public consumption - generates a queueHooks object,
+	// or returns the current one
 	_queueHooks: function( elem, type ) {
 		var key = type + "queueHooks";
 		return jQuery._data( elem, key ) || jQuery._data( elem, key, {
-			empty: jQuery.Callbacks("once memory").add(function() {
+			empty: jQuery.Callbacks( "once memory" ).add( function() {
 				jQuery._removeData( elem, type + "queue" );
 				jQuery._removeData( elem, key );
-			})
-		});
+			} )
+		} );
 	}
-});
+} );
 
-jQuery.fn.extend({
+jQuery.fn.extend( {
 	queue: function( type, data ) {
 		var setter = 2;
 
@@ -4056,30 +4186,31 @@ jQuery.fn.extend({
 		}
 
 		if ( arguments.length < setter ) {
-			return jQuery.queue( this[0], type );
+			return jQuery.queue( this[ 0 ], type );
 		}
 
 		return data === undefined ?
 			this :
-			this.each(function() {
+			this.each( function() {
 				var queue = jQuery.queue( this, type, data );
 
 				// ensure a hooks for this queue
 				jQuery._queueHooks( this, type );
 
-				if ( type === "fx" && queue[0] !== "inprogress" ) {
+				if ( type === "fx" && queue[ 0 ] !== "inprogress" ) {
 					jQuery.dequeue( this, type );
 				}
-			});
+			} );
 	},
 	dequeue: function( type ) {
-		return this.each(function() {
+		return this.each( function() {
 			jQuery.dequeue( this, type );
-		});
+		} );
 	},
 	clearQueue: function( type ) {
 		return this.queue( type || "fx", [] );
 	},
+
 	// Get a promise resolved when queues of a certain type
 	// are emptied (fx is the type by default)
 	promise: function( type, obj ) {
@@ -4110,23 +4241,138 @@ jQuery.fn.extend({
 		resolve();
 		return defer.promise( obj );
 	}
-});
-var pnum = (/[+-]?(?:\d*\.|)\d+(?:[eE][+-]?\d+|)/).source;
+} );
+
+
+( function() {
+	var shrinkWrapBlocksVal;
+
+	support.shrinkWrapBlocks = function() {
+		if ( shrinkWrapBlocksVal != null ) {
+			return shrinkWrapBlocksVal;
+		}
+
+		// Will be changed later if needed.
+		shrinkWrapBlocksVal = false;
+
+		// Minified: var b,c,d
+		var div, body, container;
+
+		body = document.getElementsByTagName( "body" )[ 0 ];
+		if ( !body || !body.style ) {
+
+			// Test fired too early or in an unsupported environment, exit.
+			return;
+		}
+
+		// Setup
+		div = document.createElement( "div" );
+		container = document.createElement( "div" );
+		container.style.cssText = "position:absolute;border:0;width:0;height:0;top:0;left:-9999px";
+		body.appendChild( container ).appendChild( div );
+
+		// Support: IE6
+		// Check if elements with layout shrink-wrap their children
+		if ( typeof div.style.zoom !== "undefined" ) {
+
+			// Reset CSS: box-sizing; display; margin; border
+			div.style.cssText =
+
+				// Support: Firefox<29, Android 2.3
+				// Vendor-prefix box-sizing
+				"-webkit-box-sizing:content-box;-moz-box-sizing:content-box;" +
+				"box-sizing:content-box;display:block;margin:0;border:0;" +
+				"padding:1px;width:1px;zoom:1";
+			div.appendChild( document.createElement( "div" ) ).style.width = "5px";
+			shrinkWrapBlocksVal = div.offsetWidth !== 3;
+		}
+
+		body.removeChild( container );
+
+		return shrinkWrapBlocksVal;
+	};
+
+} )();
+var pnum = ( /[+-]?(?:\d*\.|)\d+(?:[eE][+-]?\d+|)/ ).source;
+
+var rcssNum = new RegExp( "^(?:([+-])=|)(" + pnum + ")([a-z%]*)$", "i" );
+
 
 var cssExpand = [ "Top", "Right", "Bottom", "Left" ];
 
 var isHidden = function( elem, el ) {
+
 		// isHidden might be called from jQuery#filter function;
 		// in that case, element will be second argument
 		elem = el || elem;
-		return jQuery.css( elem, "display" ) === "none" || !jQuery.contains( elem.ownerDocument, elem );
+		return jQuery.css( elem, "display" ) === "none" ||
+			!jQuery.contains( elem.ownerDocument, elem );
 	};
 
 
 
+function adjustCSS( elem, prop, valueParts, tween ) {
+	var adjusted,
+		scale = 1,
+		maxIterations = 20,
+		currentValue = tween ?
+			function() { return tween.cur(); } :
+			function() { return jQuery.css( elem, prop, "" ); },
+		initial = currentValue(),
+		unit = valueParts && valueParts[ 3 ] || ( jQuery.cssNumber[ prop ] ? "" : "px" ),
+
+		// Starting value computation is required for potential unit mismatches
+		initialInUnit = ( jQuery.cssNumber[ prop ] || unit !== "px" && +initial ) &&
+			rcssNum.exec( jQuery.css( elem, prop ) );
+
+	if ( initialInUnit && initialInUnit[ 3 ] !== unit ) {
+
+		// Trust units reported by jQuery.css
+		unit = unit || initialInUnit[ 3 ];
+
+		// Make sure we update the tween properties later on
+		valueParts = valueParts || [];
+
+		// Iteratively approximate from a nonzero starting point
+		initialInUnit = +initial || 1;
+
+		do {
+
+			// If previous iteration zeroed out, double until we get *something*.
+			// Use string for doubling so we don't accidentally see scale as unchanged below
+			scale = scale || ".5";
+
+			// Adjust and apply
+			initialInUnit = initialInUnit / scale;
+			jQuery.style( elem, prop, initialInUnit + unit );
+
+		// Update scale, tolerating zero or NaN from tween.cur()
+		// Break the loop if scale is unchanged or perfect, or if we've just had enough.
+		} while (
+			scale !== ( scale = currentValue() / initial ) && scale !== 1 && --maxIterations
+		);
+	}
+
+	if ( valueParts ) {
+		initialInUnit = +initialInUnit || +initial || 0;
+
+		// Apply relative offset (+=/-=) if specified
+		adjusted = valueParts[ 1 ] ?
+			initialInUnit + ( valueParts[ 1 ] + 1 ) * valueParts[ 2 ] :
+			+valueParts[ 2 ];
+		if ( tween ) {
+			tween.unit = unit;
+			tween.start = initialInUnit;
+			tween.end = adjusted;
+		}
+	}
+	return adjusted;
+}
+
+
 // Multifunctional method to get and set values of a collection
 // The value/s can optionally be executed if it's a function
-var access = jQuery.access = function( elems, fn, key, value, chainable, emptyGet, raw ) {
+var access = function( elems, fn, key, value, chainable, emptyGet, raw ) {
 	var i = 0,
 		length = elems.length,
 		bulk = key == null;
@@ -4135,7 +4381,7 @@ var access = jQuery.access = function( elems, fn, key, value, chainable, emptyGe
 	if ( jQuery.type( key ) === "object" ) {
 		chainable = true;
 		for ( i in key ) {
-			jQuery.access( elems, fn, i, key[i], true, emptyGet, raw );
+			access( elems, fn, i, key[ i ], true, emptyGet, raw );
 		}
 
 	// Sets one value
@@ -4147,6 +4393,7 @@ var access = jQuery.access = function( elems, fn, key, value, chainable, emptyGe
 		}
 
 		if ( bulk ) {
+
 			// Bulk operations run against the entire set
 			if ( raw ) {
 				fn.call( elems, value );
@@ -4163,7 +4410,11 @@ var access = jQuery.access = function( elems, fn, key, value, chainable, emptyGe
 
 		if ( fn ) {
 			for ( ; i < length; i++ ) {
-				fn( elems[i], key, raw ? value : value.call( elems[i], i, fn( elems[i], key ) ) );
+				fn(
+					elems[ i ],
+					key,
+					raw ? value : value.call( elems[ i ], i, fn( elems[ i ], key ) )
+				);
 			}
 		}
 	}
@@ -4174,17 +4425,41 @@ var access = jQuery.access = function( elems, fn, key, value, chainable, emptyGe
 		// Gets
 		bulk ?
 			fn.call( elems ) :
-			length ? fn( elems[0], key ) : emptyGet;
+			length ? fn( elems[ 0 ], key ) : emptyGet;
 };
-var rcheckableType = (/^(?:checkbox|radio)$/i);
+var rcheckableType = ( /^(?:checkbox|radio)$/i );
+
+var rtagName = ( /<([\w:-]+)/ );
+
+var rscriptType = ( /^$|\/(?:java|ecma)script/i );
+
+var rleadingWhitespace = ( /^\s+/ );
+
+var nodeNames = "abbr|article|aside|audio|bdi|canvas|data|datalist|" +
+		"details|dialog|figcaption|figure|footer|header|hgroup|main|" +
+		"mark|meter|nav|output|picture|progress|section|summary|template|time|video";
 
 
 
-(function() {
-	// Minified: var a,b,c
-	var input = document.createElement( "input" ),
-		div = document.createElement( "div" ),
-		fragment = document.createDocumentFragment();
+function createSafeFragment( document ) {
+	var list = nodeNames.split( "|" ),
+		safeFrag = document.createDocumentFragment();
+
+	if ( safeFrag.createElement ) {
+		while ( list.length ) {
+			safeFrag.createElement(
+				list.pop()
+			);
+		}
+	}
+	return safeFrag;
+}
+
+
+( function() {
+	var div = document.createElement( "div" ),
+		fragment = document.createDocumentFragment(),
+		input = document.createElement( "input" );
 
 	// Setup
 	div.innerHTML = "  <link/><table></table><a href='/a'>a</a><input type='checkbox'/>";
@@ -4219,62 +4494,267 @@ var rcheckableType = (/^(?:checkbox|radio)$/i);
 
 	// #11217 - WebKit loses check when the name is after the checked attribute
 	fragment.appendChild( div );
-	div.innerHTML = "<input type='radio' checked='checked' name='t'/>";
+
+	// Support: Windows Web Apps (WWA)
+	// `name` and `type` must use .setAttribute for WWA (#14901)
+	input = document.createElement( "input" );
+	input.setAttribute( "type", "radio" );
+	input.setAttribute( "checked", "checked" );
+	input.setAttribute( "name", "t" );
+
+	div.appendChild( input );
 
 	// Support: Safari 5.1, iOS 5.1, Android 4.x, Android 2.3
 	// old WebKit doesn't clone checked state correctly in fragments
 	support.checkClone = div.cloneNode( true ).cloneNode( true ).lastChild.checked;
 
 	// Support: IE<9
-	// Opera does not clone events (and typeof div.attachEvent === undefined).
-	// IE9-10 clones events bound via attachEvent, but they don't trigger with .click()
-	support.noCloneEvent = true;
-	if ( div.attachEvent ) {
-		div.attachEvent( "onclick", function() {
-			support.noCloneEvent = false;
-		});
+	// Cloned elements keep attachEvent handlers, we use addEventListener on IE9+
+	support.noCloneEvent = !!div.addEventListener;
 
-		div.cloneNode( true ).click();
-	}
+	// Support: IE<9
+	// Since attributes and properties are the same in IE,
+	// cleanData must set properties to undefined rather than use removeAttribute
+	div[ jQuery.expando ] = 1;
+	support.attributes = !div.getAttribute( jQuery.expando );
+} )();
 
-	// Execute the test only if not already executed in another module.
-	if (support.deleteExpando == null) {
-		// Support: IE<9
-		support.deleteExpando = true;
-		try {
-			delete div.test;
-		} catch( e ) {
-			support.deleteExpando = false;
+
+// We have to close these tags to support XHTML (#13200)
+var wrapMap = {
+	option: [ 1, "<select multiple='multiple'>", "</select>" ],
+	legend: [ 1, "<fieldset>", "</fieldset>" ],
+	area: [ 1, "<map>", "</map>" ],
+
+	// Support: IE8
+	param: [ 1, "<object>", "</object>" ],
+	thead: [ 1, "<table>", "</table>" ],
+	tr: [ 2, "<table><tbody>", "</tbody></table>" ],
+	col: [ 2, "<table><tbody></tbody><colgroup>", "</colgroup></table>" ],
+	td: [ 3, "<table><tbody><tr>", "</tr></tbody></table>" ],
+
+	// IE6-8 can't serialize link, script, style, or any html5 (NoScope) tags,
+	// unless wrapped in a div with non-breaking characters in front of it.
+	_default: support.htmlSerialize ? [ 0, "", "" ] : [ 1, "X<div>", "</div>" ]
+};
+
+// Support: IE8-IE9
+wrapMap.optgroup = wrapMap.option;
+
+wrapMap.tbody = wrapMap.tfoot = wrapMap.colgroup = wrapMap.caption = wrapMap.thead;
+wrapMap.th = wrapMap.td;
+
+
+function getAll( context, tag ) {
+	var elems, elem,
+		i = 0,
+		found = typeof context.getElementsByTagName !== "undefined" ?
+			context.getElementsByTagName( tag || "*" ) :
+			typeof context.querySelectorAll !== "undefined" ?
+				context.querySelectorAll( tag || "*" ) :
+				undefined;
+
+	if ( !found ) {
+		for ( found = [], elems = context.childNodes || context;
+			( elem = elems[ i ] ) != null;
+			i++
+		) {
+			if ( !tag || jQuery.nodeName( elem, tag ) ) {
+				found.push( elem );
+			} else {
+				jQuery.merge( found, getAll( elem, tag ) );
+			}
 		}
 	}
-})();
+
+	return tag === undefined || tag && jQuery.nodeName( context, tag ) ?
+		jQuery.merge( [ context ], found ) :
+		found;
+}
 
 
-(function() {
+// Mark scripts as having already been evaluated
+function setGlobalEval( elems, refElements ) {
+	var elem,
+		i = 0;
+	for ( ; ( elem = elems[ i ] ) != null; i++ ) {
+		jQuery._data(
+			elem,
+			"globalEval",
+			!refElements || jQuery._data( refElements[ i ], "globalEval" )
+		);
+	}
+}
+
+
+var rhtml = /<|&#?\w+;/,
+	rtbody = /<tbody/i;
+
+function fixDefaultChecked( elem ) {
+	if ( rcheckableType.test( elem.type ) ) {
+		elem.defaultChecked = elem.checked;
+	}
+}
+
+function buildFragment( elems, context, scripts, selection, ignored ) {
+	var j, elem, contains,
+		tmp, tag, tbody, wrap,
+		l = elems.length,
+
+		// Ensure a safe fragment
+		safe = createSafeFragment( context ),
+
+		nodes = [],
+		i = 0;
+
+	for ( ; i < l; i++ ) {
+		elem = elems[ i ];
+
+		if ( elem || elem === 0 ) {
+
+			// Add nodes directly
+			if ( jQuery.type( elem ) === "object" ) {
+				jQuery.merge( nodes, elem.nodeType ? [ elem ] : elem );
+
+			// Convert non-html into a text node
+			} else if ( !rhtml.test( elem ) ) {
+				nodes.push( context.createTextNode( elem ) );
+
+			// Convert html into DOM nodes
+			} else {
+				tmp = tmp || safe.appendChild( context.createElement( "div" ) );
+
+				// Deserialize a standard representation
+				tag = ( rtagName.exec( elem ) || [ "", "" ] )[ 1 ].toLowerCase();
+				wrap = wrapMap[ tag ] || wrapMap._default;
+
+				tmp.innerHTML = wrap[ 1 ] + jQuery.htmlPrefilter( elem ) + wrap[ 2 ];
+
+				// Descend through wrappers to the right content
+				j = wrap[ 0 ];
+				while ( j-- ) {
+					tmp = tmp.lastChild;
+				}
+
+				// Manually add leading whitespace removed by IE
+				if ( !support.leadingWhitespace && rleadingWhitespace.test( elem ) ) {
+					nodes.push( context.createTextNode( rleadingWhitespace.exec( elem )[ 0 ] ) );
+				}
+
+				// Remove IE's autoinserted <tbody> from table fragments
+				if ( !support.tbody ) {
+
+					// String was a <table>, *may* have spurious <tbody>
+					elem = tag === "table" && !rtbody.test( elem ) ?
+						tmp.firstChild :
+
+						// String was a bare <thead> or <tfoot>
+						wrap[ 1 ] === "<table>" && !rtbody.test( elem ) ?
+							tmp :
+							0;
+
+					j = elem && elem.childNodes.length;
+					while ( j-- ) {
+						if ( jQuery.nodeName( ( tbody = elem.childNodes[ j ] ), "tbody" ) &&
+							!tbody.childNodes.length ) {
+
+							elem.removeChild( tbody );
+						}
+					}
+				}
+
+				jQuery.merge( nodes, tmp.childNodes );
+
+				// Fix #12392 for WebKit and IE > 9
+				tmp.textContent = "";
+
+				// Fix #12392 for oldIE
+				while ( tmp.firstChild ) {
+					tmp.removeChild( tmp.firstChild );
+				}
+
+				// Remember the top-level container for proper cleanup
+				tmp = safe.lastChild;
+			}
+		}
+	}
+
+	// Fix #11356: Clear elements from fragment
+	if ( tmp ) {
+		safe.removeChild( tmp );
+	}
+
+	// Reset defaultChecked for any radios and checkboxes
+	// about to be appended to the DOM in IE 6/7 (#8060)
+	if ( !support.appendChecked ) {
+		jQuery.grep( getAll( nodes, "input" ), fixDefaultChecked );
+	}
+
+	i = 0;
+	while ( ( elem = nodes[ i++ ] ) ) {
+
+		// Skip elements already in the context collection (trac-4087)
+		if ( selection && jQuery.inArray( elem, selection ) > -1 ) {
+			if ( ignored ) {
+				ignored.push( elem );
+			}
+
+			continue;
+		}
+
+		contains = jQuery.contains( elem.ownerDocument, elem );
+
+		// Append to fragment
+		tmp = getAll( safe.appendChild( elem ), "script" );
+
+		// Preserve script evaluation history
+		if ( contains ) {
+			setGlobalEval( tmp );
+		}
+
+		// Capture executables
+		if ( scripts ) {
+			j = 0;
+			while ( ( elem = tmp[ j++ ] ) ) {
+				if ( rscriptType.test( elem.type || "" ) ) {
+					scripts.push( elem );
+				}
+			}
+		}
+	}
+
+	tmp = null;
+
+	return safe;
+}
+
+
+( function() {
 	var i, eventName,
 		div = document.createElement( "div" );
 
-	// Support: IE<9 (lack submit/change bubble), Firefox 23+ (lack focusin event)
-	for ( i in { submit: true, change: true, focusin: true }) {
+	// Support: IE<9 (lack submit/change bubble), Firefox (lack focus(in | out) events)
+	for ( i in { submit: true, change: true, focusin: true } ) {
 		eventName = "on" + i;
 
-		if ( !(support[ i + "Bubbles" ] = eventName in window) ) {
+		if ( !( support[ i ] = eventName in window ) ) {
+
 			// Beware of CSP restrictions (https://developer.mozilla.org/en/Security/CSP)
 			div.setAttribute( eventName, "t" );
-			support[ i + "Bubbles" ] = div.attributes[ eventName ].expando === false;
+			support[ i ] = div.attributes[ eventName ].expando === false;
 		}
 	}
 
 	// Null elements to avoid leaks in IE.
 	div = null;
-})();
+} )();
 
 
 var rformElems = /^(?:input|select|textarea)$/i,
 	rkeyEvent = /^key/,
-	rmouseEvent = /^(?:mouse|pointer|contextmenu)|click/,
+	rmouseEvent = /^(?:mouse|pointer|contextmenu|drag|drop)|click/,
 	rfocusMorph = /^(?:focusinfocus|focusoutblur)$/,
-	rtypenamespace = /^([^.]*)(?:\.(.+)|)$/;
+	rtypenamespace = /^([^.]*)(?:\.(.+)|)/;
 
 function returnTrue() {
 	return true;
@@ -4284,10 +4764,73 @@ function returnFalse() {
 	return false;
 }
 
+// Support: IE9
+// See #13393 for more info
 function safeActiveElement() {
 	try {
 		return document.activeElement;
 	} catch ( err ) { }
+}
+
+function on( elem, types, selector, data, fn, one ) {
+	var origFn, type;
+
+	// Types can be a map of types/handlers
+	if ( typeof types === "object" ) {
+
+		// ( types-Object, selector, data )
+		if ( typeof selector !== "string" ) {
+
+			// ( types-Object, data )
+			data = data || selector;
+			selector = undefined;
+		}
+		for ( type in types ) {
+			on( elem, type, selector, data, types[ type ], one );
+		}
+		return elem;
+	}
+
+	if ( data == null && fn == null ) {
+
+		// ( types, fn )
+		fn = selector;
+		data = selector = undefined;
+	} else if ( fn == null ) {
+		if ( typeof selector === "string" ) {
+
+			// ( types, selector, fn )
+			fn = data;
+			data = undefined;
+		} else {
+
+			// ( types, data, fn )
+			fn = data;
+			data = selector;
+			selector = undefined;
+		}
+	}
+	if ( fn === false ) {
+		fn = returnFalse;
+	} else if ( !fn ) {
+		return elem;
+	}
+
+	if ( one === 1 ) {
+		origFn = fn;
+		fn = function( event ) {
+
+			// Can use an empty set, since event contains the info
+			jQuery().off( event );
+			return origFn.apply( this, arguments );
+		};
+
+		// Use same guid so caller can remove using origFn
+		fn.guid = origFn.guid || ( origFn.guid = jQuery.guid++ );
+	}
+	return elem.each( function() {
+		jQuery.event.add( this, types, fn, data, selector );
+	} );
 }
 
 /*
@@ -4322,18 +4865,22 @@ jQuery.event = {
 		}
 
 		// Init the element's event structure and main handler, if this is the first
-		if ( !(events = elemData.events) ) {
+		if ( !( events = elemData.events ) ) {
 			events = elemData.events = {};
 		}
-		if ( !(eventHandle = elemData.handle) ) {
+		if ( !( eventHandle = elemData.handle ) ) {
 			eventHandle = elemData.handle = function( e ) {
+
 				// Discard the second event of a jQuery.event.trigger() and
 				// when an event is called after a page has unloaded
-				return typeof jQuery !== strundefined && (!e || jQuery.event.triggered !== e.type) ?
+				return typeof jQuery !== "undefined" &&
+					( !e || jQuery.event.triggered !== e.type ) ?
 					jQuery.event.dispatch.apply( eventHandle.elem, arguments ) :
 					undefined;
 			};
-			// Add elem as a property of the handle fn to prevent a memory leak with IE non-native events
+
+			// Add elem as a property of the handle fn to prevent a memory leak
+			// with IE non-native events
 			eventHandle.elem = elem;
 		}
 
@@ -4341,9 +4888,9 @@ jQuery.event = {
 		types = ( types || "" ).match( rnotwhite ) || [ "" ];
 		t = types.length;
 		while ( t-- ) {
-			tmp = rtypenamespace.exec( types[t] ) || [];
-			type = origType = tmp[1];
-			namespaces = ( tmp[2] || "" ).split( "." ).sort();
+			tmp = rtypenamespace.exec( types[ t ] ) || [];
+			type = origType = tmp[ 1 ];
+			namespaces = ( tmp[ 2 ] || "" ).split( "." ).sort();
 
 			// There *must* be a type, no attaching namespace-only handlers
 			if ( !type ) {
@@ -4360,7 +4907,7 @@ jQuery.event = {
 			special = jQuery.event.special[ type ] || {};
 
 			// handleObj is passed to all event handlers
-			handleObj = jQuery.extend({
+			handleObj = jQuery.extend( {
 				type: type,
 				origType: origType,
 				data: data,
@@ -4368,16 +4915,18 @@ jQuery.event = {
 				guid: handler.guid,
 				selector: selector,
 				needsContext: selector && jQuery.expr.match.needsContext.test( selector ),
-				namespace: namespaces.join(".")
+				namespace: namespaces.join( "." )
 			}, handleObjIn );
 
 			// Init the event handler queue if we're the first
-			if ( !(handlers = events[ type ]) ) {
+			if ( !( handlers = events[ type ] ) ) {
 				handlers = events[ type ] = [];
 				handlers.delegateCount = 0;
 
 				// Only use addEventListener/attachEvent if the special events handler returns false
-				if ( !special.setup || special.setup.call( elem, data, namespaces, eventHandle ) === false ) {
+				if ( !special.setup ||
+					special.setup.call( elem, data, namespaces, eventHandle ) === false ) {
+
 					// Bind the global event handler to the element
 					if ( elem.addEventListener ) {
 						elem.addEventListener( type, eventHandle, false );
@@ -4419,7 +4968,7 @@ jQuery.event = {
 			namespaces, origType,
 			elemData = jQuery.hasData( elem ) && jQuery._data( elem );
 
-		if ( !elemData || !(events = elemData.events) ) {
+		if ( !elemData || !( events = elemData.events ) ) {
 			return;
 		}
 
@@ -4427,9 +4976,9 @@ jQuery.event = {
 		types = ( types || "" ).match( rnotwhite ) || [ "" ];
 		t = types.length;
 		while ( t-- ) {
-			tmp = rtypenamespace.exec( types[t] ) || [];
-			type = origType = tmp[1];
-			namespaces = ( tmp[2] || "" ).split( "." ).sort();
+			tmp = rtypenamespace.exec( types[ t ] ) || [];
+			type = origType = tmp[ 1 ];
+			namespaces = ( tmp[ 2 ] || "" ).split( "." ).sort();
 
 			// Unbind all events (on this namespace, if provided) for the element
 			if ( !type ) {
@@ -4442,7 +4991,8 @@ jQuery.event = {
 			special = jQuery.event.special[ type ] || {};
 			type = ( selector ? special.delegateType : special.bindType ) || type;
 			handlers = events[ type ] || [];
-			tmp = tmp[2] && new RegExp( "(^|\\.)" + namespaces.join("\\.(?:.*\\.|)") + "(\\.|$)" );
+			tmp = tmp[ 2 ] &&
+				new RegExp( "(^|\\.)" + namespaces.join( "\\.(?:.*\\.|)" ) + "(\\.|$)" );
 
 			// Remove matching events
 			origCount = j = handlers.length;
@@ -4452,7 +5002,8 @@ jQuery.event = {
 				if ( ( mappedTypes || origType === handleObj.origType ) &&
 					( !handler || handler.guid === handleObj.guid ) &&
 					( !tmp || tmp.test( handleObj.namespace ) ) &&
-					( !selector || selector === handleObj.selector || selector === "**" && handleObj.selector ) ) {
+					( !selector || selector === handleObj.selector ||
+						selector === "**" && handleObj.selector ) ) {
 					handlers.splice( j, 1 );
 
 					if ( handleObj.selector ) {
@@ -4467,7 +5018,9 @@ jQuery.event = {
 			// Remove generic event handler if we removed something and no more handlers exist
 			// (avoids potential for endless recursion during removal of special event handlers)
 			if ( origCount && !handlers.length ) {
-				if ( !special.teardown || special.teardown.call( elem, namespaces, elemData.handle ) === false ) {
+				if ( !special.teardown ||
+					special.teardown.call( elem, namespaces, elemData.handle ) === false ) {
+
 					jQuery.removeEvent( elem, type, elemData.handle );
 				}
 
@@ -4490,7 +5043,7 @@ jQuery.event = {
 			bubbleType, special, tmp, i,
 			eventPath = [ elem || document ],
 			type = hasOwn.call( event, "type" ) ? event.type : event,
-			namespaces = hasOwn.call( event, "namespace" ) ? event.namespace.split(".") : [];
+			namespaces = hasOwn.call( event, "namespace" ) ? event.namespace.split( "." ) : [];
 
 		cur = tmp = elem = elem || document;
 
@@ -4504,13 +5057,14 @@ jQuery.event = {
 			return;
 		}
 
-		if ( type.indexOf(".") >= 0 ) {
+		if ( type.indexOf( "." ) > -1 ) {
+
 			// Namespaced trigger; create a regexp to match event type in handle()
-			namespaces = type.split(".");
+			namespaces = type.split( "." );
 			type = namespaces.shift();
 			namespaces.sort();
 		}
-		ontype = type.indexOf(":") < 0 && "on" + type;
+		ontype = type.indexOf( ":" ) < 0 && "on" + type;
 
 		// Caller can pass in a jQuery.Event object, Object, or just an event type string
 		event = event[ jQuery.expando ] ?
@@ -4519,9 +5073,9 @@ jQuery.event = {
 
 		// Trigger bitmask: & 1 for native handlers; & 2 for jQuery (always true)
 		event.isTrigger = onlyHandlers ? 2 : 3;
-		event.namespace = namespaces.join(".");
-		event.namespace_re = event.namespace ?
-			new RegExp( "(^|\\.)" + namespaces.join("\\.(?:.*\\.|)") + "(\\.|$)" ) :
+		event.namespace = namespaces.join( "." );
+		event.rnamespace = event.namespace ?
+			new RegExp( "(^|\\.)" + namespaces.join( "\\.(?:.*\\.|)" ) + "(\\.|$)" ) :
 			null;
 
 		// Clean up the event in case it is being reused
@@ -4555,28 +5109,30 @@ jQuery.event = {
 			}
 
 			// Only add window if we got to document (e.g., not plain obj or detached DOM)
-			if ( tmp === (elem.ownerDocument || document) ) {
+			if ( tmp === ( elem.ownerDocument || document ) ) {
 				eventPath.push( tmp.defaultView || tmp.parentWindow || window );
 			}
 		}
 
 		// Fire handlers on the event path
 		i = 0;
-		while ( (cur = eventPath[i++]) && !event.isPropagationStopped() ) {
+		while ( ( cur = eventPath[ i++ ] ) && !event.isPropagationStopped() ) {
 
 			event.type = i > 1 ?
 				bubbleType :
 				special.bindType || type;
 
 			// jQuery handler
-			handle = ( jQuery._data( cur, "events" ) || {} )[ event.type ] && jQuery._data( cur, "handle" );
+			handle = ( jQuery._data( cur, "events" ) || {} )[ event.type ] &&
+				jQuery._data( cur, "handle" );
+
 			if ( handle ) {
 				handle.apply( cur, data );
 			}
 
 			// Native handler
 			handle = ontype && cur[ ontype ];
-			if ( handle && handle.apply && jQuery.acceptData( cur ) ) {
+			if ( handle && handle.apply && acceptData( cur ) ) {
 				event.result = handle.apply( cur, data );
 				if ( event.result === false ) {
 					event.preventDefault();
@@ -4588,8 +5144,11 @@ jQuery.event = {
 		// If nobody prevented the default action, do it now
 		if ( !onlyHandlers && !event.isDefaultPrevented() ) {
 
-			if ( (!special._default || special._default.apply( eventPath.pop(), data ) === false) &&
-				jQuery.acceptData( elem ) ) {
+			if (
+				( !special._default ||
+				 special._default.apply( eventPath.pop(), data ) === false
+				) && acceptData( elem )
+			) {
 
 				// Call a native DOM method on the target with the same name name as the event.
 				// Can't use an .isFunction() check here because IE6/7 fails that test.
@@ -4608,6 +5167,7 @@ jQuery.event = {
 					try {
 						elem[ type ]();
 					} catch ( e ) {
+
 						// IE<9 dies on focus/blur to hidden element (#1486,#12518)
 						// only reproducible on winXP IE8 native, not IE9 in IE8 mode
 					}
@@ -4628,14 +5188,14 @@ jQuery.event = {
 		// Make a writable jQuery.Event from the native event object
 		event = jQuery.event.fix( event );
 
-		var i, ret, handleObj, matched, j,
+		var i, j, ret, matched, handleObj,
 			handlerQueue = [],
 			args = slice.call( arguments ),
 			handlers = ( jQuery._data( this, "events" ) || {} )[ event.type ] || [],
 			special = jQuery.event.special[ event.type ] || {};
 
 		// Use the fix-ed jQuery.Event rather than the (read-only) native event
-		args[0] = event;
+		args[ 0 ] = event;
 		event.delegateTarget = this;
 
 		// Call the preDispatch hook for the mapped type, and let it bail if desired
@@ -4648,24 +5208,25 @@ jQuery.event = {
 
 		// Run delegates first; they may want to stop propagation beneath us
 		i = 0;
-		while ( (matched = handlerQueue[ i++ ]) && !event.isPropagationStopped() ) {
+		while ( ( matched = handlerQueue[ i++ ] ) && !event.isPropagationStopped() ) {
 			event.currentTarget = matched.elem;
 
 			j = 0;
-			while ( (handleObj = matched.handlers[ j++ ]) && !event.isImmediatePropagationStopped() ) {
+			while ( ( handleObj = matched.handlers[ j++ ] ) &&
+				!event.isImmediatePropagationStopped() ) {
 
-				// Triggered event must either 1) have no namespace, or
-				// 2) have namespace(s) a subset or equal to those in the bound event (both can have no namespace).
-				if ( !event.namespace_re || event.namespace_re.test( handleObj.namespace ) ) {
+				// Triggered event must either 1) have no namespace, or 2) have namespace(s)
+				// a subset or equal to those in the bound event (both can have no namespace).
+				if ( !event.rnamespace || event.rnamespace.test( handleObj.namespace ) ) {
 
 					event.handleObj = handleObj;
 					event.data = handleObj.data;
 
-					ret = ( (jQuery.event.special[ handleObj.origType ] || {}).handle || handleObj.handler )
-							.apply( matched.elem, args );
+					ret = ( ( jQuery.event.special[ handleObj.origType ] || {} ).handle ||
+						handleObj.handler ).apply( matched.elem, args );
 
 					if ( ret !== undefined ) {
-						if ( (event.result = ret) === false ) {
+						if ( ( event.result = ret ) === false ) {
 							event.preventDefault();
 							event.stopPropagation();
 						}
@@ -4683,15 +5244,19 @@ jQuery.event = {
 	},
 
 	handlers: function( event, handlers ) {
-		var sel, handleObj, matches, i,
+		var i, matches, sel, handleObj,
 			handlerQueue = [],
 			delegateCount = handlers.delegateCount,
 			cur = event.target;
 
+		// Support (at least): Chrome, IE9
 		// Find delegate handlers
 		// Black-hole SVG <use> instance trees (#13180)
-		// Avoid non-left-click bubbling in Firefox (#3861)
-		if ( delegateCount && cur.nodeType && (!event.button || event.type !== "click") ) {
+		//
+		// Support: Firefox<=42+
+		// Avoid non-left-click in FF but don't block IE radio events (#3861, gh-2343)
+		if ( delegateCount && cur.nodeType &&
+			( event.type !== "click" || isNaN( event.button ) || event.button < 1 ) ) {
 
 			/* jshint eqeqeq: false */
 			for ( ; cur != this; cur = cur.parentNode || this ) {
@@ -4699,7 +5264,7 @@ jQuery.event = {
 
 				// Don't check non-elements (#13208)
 				// Don't process clicks on disabled elements (#6911, #8165, #11382, #11764)
-				if ( cur.nodeType === 1 && (cur.disabled !== true || event.type !== "click") ) {
+				if ( cur.nodeType === 1 && ( cur.disabled !== true || event.type !== "click" ) ) {
 					matches = [];
 					for ( i = 0; i < delegateCount; i++ ) {
 						handleObj = handlers[ i ];
@@ -4709,7 +5274,7 @@ jQuery.event = {
 
 						if ( matches[ sel ] === undefined ) {
 							matches[ sel ] = handleObj.needsContext ?
-								jQuery( sel, this ).index( cur ) >= 0 :
+								jQuery( sel, this ).index( cur ) > -1 :
 								jQuery.find( sel, this, null, [ cur ] ).length;
 						}
 						if ( matches[ sel ] ) {
@@ -4717,7 +5282,7 @@ jQuery.event = {
 						}
 					}
 					if ( matches.length ) {
-						handlerQueue.push({ elem: cur, handlers: matches });
+						handlerQueue.push( { elem: cur, handlers: matches } );
 					}
 				}
 			}
@@ -4725,7 +5290,7 @@ jQuery.event = {
 
 		// Add the remaining (directly-bound) handlers
 		if ( delegateCount < handlers.length ) {
-			handlerQueue.push({ elem: this, handlers: handlers.slice( delegateCount ) });
+			handlerQueue.push( { elem: this, handlers: handlers.slice( delegateCount ) } );
 		}
 
 		return handlerQueue;
@@ -4764,7 +5329,7 @@ jQuery.event = {
 			event.target = originalEvent.srcElement || document;
 		}
 
-		// Support: Chrome 23+, Safari?
+		// Support: Safari 6-8+
 		// Target should not be a text node (#504, #13143)
 		if ( event.target.nodeType === 3 ) {
 			event.target = event.target.parentNode;
@@ -4778,12 +5343,13 @@ jQuery.event = {
 	},
 
 	// Includes some event props shared by KeyEvent and MouseEvent
-	props: "altKey bubbles cancelable ctrlKey currentTarget eventPhase metaKey relatedTarget shiftKey target timeStamp view which".split(" "),
+	props: ( "altKey bubbles cancelable ctrlKey currentTarget detail eventPhase " +
+		"metaKey relatedTarget shiftKey target timeStamp view which" ).split( " " ),
 
 	fixHooks: {},
 
 	keyHooks: {
-		props: "char charCode key keyCode".split(" "),
+		props: "char charCode key keyCode".split( " " ),
 		filter: function( event, original ) {
 
 			// Add which for key events
@@ -4796,7 +5362,8 @@ jQuery.event = {
 	},
 
 	mouseHooks: {
-		props: "button buttons clientX clientY fromElement offsetX offsetY pageX pageY screenX screenY toElement".split(" "),
+		props: ( "button buttons clientX clientY fromElement offsetX offsetY " +
+			"pageX pageY screenX screenY toElement" ).split( " " ),
 		filter: function( event, original ) {
 			var body, eventDoc, doc,
 				button = original.button,
@@ -4808,13 +5375,19 @@ jQuery.event = {
 				doc = eventDoc.documentElement;
 				body = eventDoc.body;
 
-				event.pageX = original.clientX + ( doc && doc.scrollLeft || body && body.scrollLeft || 0 ) - ( doc && doc.clientLeft || body && body.clientLeft || 0 );
-				event.pageY = original.clientY + ( doc && doc.scrollTop  || body && body.scrollTop  || 0 ) - ( doc && doc.clientTop  || body && body.clientTop  || 0 );
+				event.pageX = original.clientX +
+					( doc && doc.scrollLeft || body && body.scrollLeft || 0 ) -
+					( doc && doc.clientLeft || body && body.clientLeft || 0 );
+				event.pageY = original.clientY +
+					( doc && doc.scrollTop  || body && body.scrollTop  || 0 ) -
+					( doc && doc.clientTop  || body && body.clientTop  || 0 );
 			}
 
 			// Add relatedTarget, if necessary
 			if ( !event.relatedTarget && fromElement ) {
-				event.relatedTarget = fromElement === event.target ? original.toElement : fromElement;
+				event.relatedTarget = fromElement === event.target ?
+					original.toElement :
+					fromElement;
 			}
 
 			// Add which for click: 1 === left; 2 === middle; 3 === right
@@ -4829,10 +5402,12 @@ jQuery.event = {
 
 	special: {
 		load: {
+
 			// Prevent triggered image.load events from bubbling to window.load
 			noBubble: true
 		},
 		focus: {
+
 			// Fire native event if possible so blur/focus sequence is correct
 			trigger: function() {
 				if ( this !== safeActiveElement() && this.focus ) {
@@ -4840,6 +5415,7 @@ jQuery.event = {
 						this.focus();
 						return false;
 					} catch ( e ) {
+
 						// Support: IE<9
 						// If we error on focus to hidden element (#1486, #12518),
 						// let .trigger() run the handlers
@@ -4858,6 +5434,7 @@ jQuery.event = {
 			delegateType: "focusout"
 		},
 		click: {
+
 			// For checkbox, fire native event so checked state will be right
 			trigger: function() {
 				if ( jQuery.nodeName( this, "input" ) && this.type === "checkbox" && this.click ) {
@@ -4884,24 +5461,28 @@ jQuery.event = {
 		}
 	},
 
-	simulate: function( type, elem, event, bubble ) {
-		// Piggyback on a donor event to simulate a different one.
-		// Fake originalEvent to avoid donor's stopPropagation, but if the
-		// simulated event prevents default then we do the same on the donor.
+	// Piggyback on a donor event to simulate a different one
+	simulate: function( type, elem, event ) {
 		var e = jQuery.extend(
 			new jQuery.Event(),
 			event,
 			{
 				type: type,
-				isSimulated: true,
-				originalEvent: {}
+				isSimulated: true
+
+				// Previously, `originalEvent: {}` was set here, so stopPropagation call
+				// would not be triggered on donor event, since in our own
+				// jQuery.event.stopPropagation function we had a check for existence of
+				// originalEvent.stopPropagation method, so, consequently it would be a noop.
+				//
+				// Guard for simulated events was moved to jQuery.event.stopPropagation function
+				// since `originalEvent` should point to the original event for the
+				// constancy with other events and for more focused logic
 			}
 		);
-		if ( bubble ) {
-			jQuery.event.trigger( e, null, elem );
-		} else {
-			jQuery.event.dispatch.call( elem, e );
-		}
+
+		jQuery.event.trigger( e, null, elem );
+
 		if ( e.isDefaultPrevented() ) {
 			event.preventDefault();
 		}
@@ -4910,8 +5491,10 @@ jQuery.event = {
 
 jQuery.removeEvent = document.removeEventListener ?
 	function( elem, type, handle ) {
+
+		// This "if" is needed for plain objects
 		if ( elem.removeEventListener ) {
-			elem.removeEventListener( type, handle, false );
+			elem.removeEventListener( type, handle );
 		}
 	} :
 	function( elem, type, handle ) {
@@ -4920,8 +5503,9 @@ jQuery.removeEvent = document.removeEventListener ?
 		if ( elem.detachEvent ) {
 
 			// #8545, #7054, preventing memory leaks for custom events in IE6-8
-			// detachEvent needed property on element, by name of that event, to properly expose it to GC
-			if ( typeof elem[ name ] === strundefined ) {
+			// detachEvent needed property on element, by name of that event,
+			// to properly expose it to GC
+			if ( typeof elem[ name ] === "undefined" ) {
 				elem[ name ] = null;
 			}
 
@@ -4930,8 +5514,9 @@ jQuery.removeEvent = document.removeEventListener ?
 	};
 
 jQuery.Event = function( src, props ) {
+
 	// Allow instantiation without the 'new' keyword
-	if ( !(this instanceof jQuery.Event) ) {
+	if ( !( this instanceof jQuery.Event ) ) {
 		return new jQuery.Event( src, props );
 	}
 
@@ -4944,6 +5529,7 @@ jQuery.Event = function( src, props ) {
 		// by a handler lower down the tree; reflect the correct value.
 		this.isDefaultPrevented = src.defaultPrevented ||
 				src.defaultPrevented === undefined &&
+
 				// Support: IE < 9, Android < 4.0
 				src.returnValue === false ?
 			returnTrue :
@@ -4969,6 +5555,7 @@ jQuery.Event = function( src, props ) {
 // jQuery.Event is based on DOM3 Events as specified by the ECMAScript Language Binding
 // http://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html
 jQuery.Event.prototype = {
+	constructor: jQuery.Event,
 	isDefaultPrevented: returnFalse,
 	isPropagationStopped: returnFalse,
 	isImmediatePropagationStopped: returnFalse,
@@ -4995,9 +5582,11 @@ jQuery.Event.prototype = {
 		var e = this.originalEvent;
 
 		this.isPropagationStopped = returnTrue;
-		if ( !e ) {
+
+		if ( !e || this.isSimulated ) {
 			return;
 		}
+
 		// If stopPropagation exists, run it on the original event
 		if ( e.stopPropagation ) {
 			e.stopPropagation();
@@ -5021,7 +5610,14 @@ jQuery.Event.prototype = {
 };
 
 // Create mouseenter/leave events using mouseover/out and event-time checks
-jQuery.each({
+// so that event delegation works in jQuery.
+// Do the same for pointerenter/pointerleave and pointerover/pointerout
+//
+// Support: Safari 7 only
+// Safari sends mouseenter too often; see:
+// https://code.google.com/p/chromium/issues/detail?id=470258
+// for the description of the bug (it existed in older Chrome versions as well).
+jQuery.each( {
 	mouseenter: "mouseover",
 	mouseleave: "mouseout",
 	pointerenter: "pointerover",
@@ -5037,9 +5633,9 @@ jQuery.each({
 				related = event.relatedTarget,
 				handleObj = event.handleObj;
 
-			// For mousenter/leave call the handler if related is outside the target.
+			// For mouseenter/leave call the handler if related is outside the target.
 			// NB: No relatedTarget if the mouse left/entered the browser window
-			if ( !related || (related !== target && !jQuery.contains( target, related )) ) {
+			if ( !related || ( related !== target && !jQuery.contains( target, related ) ) ) {
 				event.type = handleObj.origType;
 				ret = handleObj.handler.apply( this, arguments );
 				event.type = fix;
@@ -5047,13 +5643,14 @@ jQuery.each({
 			return ret;
 		}
 	};
-});
+} );
 
 // IE submit delegation
-if ( !support.submitBubbles ) {
+if ( !support.submit ) {
 
 	jQuery.event.special.submit = {
 		setup: function() {
+
 			// Only need this for delegated form submit events
 			if ( jQuery.nodeName( this, "form" ) ) {
 				return false;
@@ -5061,30 +5658,42 @@ if ( !support.submitBubbles ) {
 
 			// Lazy-add a submit handler when a descendant form may potentially be submitted
 			jQuery.event.add( this, "click._submit keypress._submit", function( e ) {
+
 				// Node name check avoids a VML-related crash in IE (#9807)
 				var elem = e.target,
-					form = jQuery.nodeName( elem, "input" ) || jQuery.nodeName( elem, "button" ) ? elem.form : undefined;
-				if ( form && !jQuery._data( form, "submitBubbles" ) ) {
+					form = jQuery.nodeName( elem, "input" ) || jQuery.nodeName( elem, "button" ) ?
+
+						// Support: IE <=8
+						// We use jQuery.prop instead of elem.form
+						// to allow fixing the IE8 delegated submit issue (gh-2332)
+						// by 3rd party polyfills/workarounds.
+						jQuery.prop( elem, "form" ) :
+						undefined;
+
+				if ( form && !jQuery._data( form, "submit" ) ) {
 					jQuery.event.add( form, "submit._submit", function( event ) {
-						event._submit_bubble = true;
-					});
-					jQuery._data( form, "submitBubbles", true );
+						event._submitBubble = true;
+					} );
+					jQuery._data( form, "submit", true );
 				}
-			});
+			} );
+
 			// return undefined since we don't need an event listener
 		},
 
 		postDispatch: function( event ) {
+
 			// If form was submitted by the user, bubble the event up the tree
-			if ( event._submit_bubble ) {
-				delete event._submit_bubble;
+			if ( event._submitBubble ) {
+				delete event._submitBubble;
 				if ( this.parentNode && !event.isTrigger ) {
-					jQuery.event.simulate( "submit", this.parentNode, event, true );
+					jQuery.event.simulate( "submit", this.parentNode, event );
 				}
 			}
 		},
 
 		teardown: function() {
+
 			// Only need this for delegated form submit events
 			if ( jQuery.nodeName( this, "form" ) ) {
 				return false;
@@ -5097,52 +5706,57 @@ if ( !support.submitBubbles ) {
 }
 
 // IE change delegation and checkbox/radio fix
-if ( !support.changeBubbles ) {
+if ( !support.change ) {
 
 	jQuery.event.special.change = {
 
 		setup: function() {
 
 			if ( rformElems.test( this.nodeName ) ) {
+
 				// IE doesn't fire change on a check/radio until blur; trigger it on click
 				// after a propertychange. Eat the blur-change in special.change.handle.
 				// This still fires onchange a second time for check/radio after blur.
 				if ( this.type === "checkbox" || this.type === "radio" ) {
 					jQuery.event.add( this, "propertychange._change", function( event ) {
 						if ( event.originalEvent.propertyName === "checked" ) {
-							this._just_changed = true;
+							this._justChanged = true;
 						}
-					});
+					} );
 					jQuery.event.add( this, "click._change", function( event ) {
-						if ( this._just_changed && !event.isTrigger ) {
-							this._just_changed = false;
+						if ( this._justChanged && !event.isTrigger ) {
+							this._justChanged = false;
 						}
+
 						// Allow triggered, simulated change events (#11500)
-						jQuery.event.simulate( "change", this, event, true );
-					});
+						jQuery.event.simulate( "change", this, event );
+					} );
 				}
 				return false;
 			}
+
 			// Delegated event; lazy-add a change handler on descendant inputs
 			jQuery.event.add( this, "beforeactivate._change", function( e ) {
 				var elem = e.target;
 
-				if ( rformElems.test( elem.nodeName ) && !jQuery._data( elem, "changeBubbles" ) ) {
+				if ( rformElems.test( elem.nodeName ) && !jQuery._data( elem, "change" ) ) {
 					jQuery.event.add( elem, "change._change", function( event ) {
 						if ( this.parentNode && !event.isSimulated && !event.isTrigger ) {
-							jQuery.event.simulate( "change", this.parentNode, event, true );
+							jQuery.event.simulate( "change", this.parentNode, event );
 						}
-					});
-					jQuery._data( elem, "changeBubbles", true );
+					} );
+					jQuery._data( elem, "change", true );
 				}
-			});
+			} );
 		},
 
 		handle: function( event ) {
 			var elem = event.target;
 
 			// Swallow native change events from checkbox/radio, we already triggered them above
-			if ( this !== elem || event.isSimulated || event.isTrigger || (elem.type !== "radio" && elem.type !== "checkbox") ) {
+			if ( this !== elem || event.isSimulated || event.isTrigger ||
+				( elem.type !== "radio" && elem.type !== "checkbox" ) ) {
+
 				return event.handleObj.handler.apply( this, arguments );
 			}
 		},
@@ -5155,14 +5769,21 @@ if ( !support.changeBubbles ) {
 	};
 }
 
-// Create "bubbling" focus and blur events
-if ( !support.focusinBubbles ) {
-	jQuery.each({ focus: "focusin", blur: "focusout" }, function( orig, fix ) {
+// Support: Firefox
+// Firefox doesn't have focus(in | out) events
+// Related ticket - https://bugzilla.mozilla.org/show_bug.cgi?id=687787
+//
+// Support: Chrome, Safari
+// focus(in | out) events fire after focus & blur events,
+// which is spec violation - http://www.w3.org/TR/DOM-Level-3-Events/#events-focusevent-event-order
+// Related ticket - https://code.google.com/p/chromium/issues/detail?id=449857
+if ( !support.focusin ) {
+	jQuery.each( { focus: "focusin", blur: "focusout" }, function( orig, fix ) {
 
 		// Attach a single capturing handler on the document while someone wants focusin/focusout
 		var handler = function( event ) {
-				jQuery.event.simulate( fix, event.target, jQuery.event.fix( event ), true );
-			};
+			jQuery.event.simulate( fix, event.target, jQuery.event.fix( event ) );
+		};
 
 		jQuery.event.special[ fix ] = {
 			setup: function() {
@@ -5186,80 +5807,34 @@ if ( !support.focusinBubbles ) {
 				}
 			}
 		};
-	});
+	} );
 }
 
-jQuery.fn.extend({
+jQuery.fn.extend( {
 
-	on: function( types, selector, data, fn, /*INTERNAL*/ one ) {
-		var type, origFn;
-
-		// Types can be a map of types/handlers
-		if ( typeof types === "object" ) {
-			// ( types-Object, selector, data )
-			if ( typeof selector !== "string" ) {
-				// ( types-Object, data )
-				data = data || selector;
-				selector = undefined;
-			}
-			for ( type in types ) {
-				this.on( type, selector, data, types[ type ], one );
-			}
-			return this;
-		}
-
-		if ( data == null && fn == null ) {
-			// ( types, fn )
-			fn = selector;
-			data = selector = undefined;
-		} else if ( fn == null ) {
-			if ( typeof selector === "string" ) {
-				// ( types, selector, fn )
-				fn = data;
-				data = undefined;
-			} else {
-				// ( types, data, fn )
-				fn = data;
-				data = selector;
-				selector = undefined;
-			}
-		}
-		if ( fn === false ) {
-			fn = returnFalse;
-		} else if ( !fn ) {
-			return this;
-		}
-
-		if ( one === 1 ) {
-			origFn = fn;
-			fn = function( event ) {
-				// Can use an empty set, since event contains the info
-				jQuery().off( event );
-				return origFn.apply( this, arguments );
-			};
-			// Use same guid so caller can remove using origFn
-			fn.guid = origFn.guid || ( origFn.guid = jQuery.guid++ );
-		}
-		return this.each( function() {
-			jQuery.event.add( this, types, fn, data, selector );
-		});
+	on: function( types, selector, data, fn ) {
+		return on( this, types, selector, data, fn );
 	},
 	one: function( types, selector, data, fn ) {
-		return this.on( types, selector, data, fn, 1 );
+		return on( this, types, selector, data, fn, 1 );
 	},
 	off: function( types, selector, fn ) {
 		var handleObj, type;
 		if ( types && types.preventDefault && types.handleObj ) {
+
 			// ( event )  dispatched jQuery.Event
 			handleObj = types.handleObj;
 			jQuery( types.delegateTarget ).off(
-				handleObj.namespace ? handleObj.origType + "." + handleObj.namespace : handleObj.origType,
+				handleObj.namespace ?
+					handleObj.origType + "." + handleObj.namespace :
+					handleObj.origType,
 				handleObj.selector,
 				handleObj.handler
 			);
 			return this;
 		}
 		if ( typeof types === "object" ) {
+
 			// ( types-object [, selector] )
 			for ( type in types ) {
 				this.off( type, selector, types[ type ] );
@@ -5267,6 +5842,7 @@ jQuery.fn.extend({
 			return this;
 		}
 		if ( selector === false || typeof selector === "function" ) {
+
 			// ( types [, fn] )
 			fn = selector;
 			selector = undefined;
@@ -5274,105 +5850,40 @@ jQuery.fn.extend({
 		if ( fn === false ) {
 			fn = returnFalse;
 		}
-		return this.each(function() {
+		return this.each( function() {
 			jQuery.event.remove( this, types, fn, selector );
-		});
+		} );
 	},
 
 	trigger: function( type, data ) {
-		return this.each(function() {
+		return this.each( function() {
 			jQuery.event.trigger( type, data, this );
-		});
+		} );
 	},
 	triggerHandler: function( type, data ) {
-		var elem = this[0];
+		var elem = this[ 0 ];
 		if ( elem ) {
 			return jQuery.event.trigger( type, data, elem, true );
 		}
 	}
-});
+} );
 
 
-function createSafeFragment( document ) {
-	var list = nodeNames.split( "|" ),
-		safeFrag = document.createDocumentFragment();
+var rinlinejQuery = / jQuery\d+="(?:null|\d+)"/g,
+	rnoshimcache = new RegExp( "<(?:" + nodeNames + ")[\\s/>]", "i" ),
+	rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:-]+)[^>]*)\/>/gi,
 
-	if ( safeFrag.createElement ) {
-		while ( list.length ) {
-			safeFrag.createElement(
-				list.pop()
-			);
-		}
-	}
-	return safeFrag;
-}
+	// Support: IE 10-11, Edge 10240+
+	// In IE/Edge using regex groups here causes severe slowdowns.
+	// See https://connect.microsoft.com/IE/feedback/details/1736512/
+	rnoInnerhtml = /<script|<style|<link/i,
 
-var nodeNames = "abbr|article|aside|audio|bdi|canvas|data|datalist|details|figcaption|figure|footer|" +
-		"header|hgroup|mark|meter|nav|output|progress|section|summary|time|video",
-	rinlinejQuery = / jQuery\d+="(?:null|\d+)"/g,
-	rnoshimcache = new RegExp("<(?:" + nodeNames + ")[\\s/>]", "i"),
-	rleadingWhitespace = /^\s+/,
-	rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)[^>]*)\/>/gi,
-	rtagName = /<([\w:]+)/,
-	rtbody = /<tbody/i,
-	rhtml = /<|&#?\w+;/,
-	rnoInnerhtml = /<(?:script|style|link)/i,
 	// checked="checked" or checked
 	rchecked = /checked\s*(?:[^=]|=\s*.checked.)/i,
-	rscriptType = /^$|\/(?:java|ecma)script/i,
 	rscriptTypeMasked = /^true\/(.*)/,
 	rcleanScript = /^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g,
-
-	// We have to close these tags to support XHTML (#13200)
-	wrapMap = {
-		option: [ 1, "<select multiple='multiple'>", "</select>" ],
-		legend: [ 1, "<fieldset>", "</fieldset>" ],
-		area: [ 1, "<map>", "</map>" ],
-		param: [ 1, "<object>", "</object>" ],
-		thead: [ 1, "<table>", "</table>" ],
-		tr: [ 2, "<table><tbody>", "</tbody></table>" ],
-		col: [ 2, "<table><tbody></tbody><colgroup>", "</colgroup></table>" ],
-		td: [ 3, "<table><tbody><tr>", "</tr></tbody></table>" ],
-
-		// IE6-8 can't serialize link, script, style, or any html5 (NoScope) tags,
-		// unless wrapped in a div with non-breaking characters in front of it.
-		_default: support.htmlSerialize ? [ 0, "", "" ] : [ 1, "X<div>", "</div>"  ]
-	},
 	safeFragment = createSafeFragment( document ),
-	fragmentDiv = safeFragment.appendChild( document.createElement("div") );
-
-wrapMap.optgroup = wrapMap.option;
-wrapMap.tbody = wrapMap.tfoot = wrapMap.colgroup = wrapMap.caption = wrapMap.thead;
-wrapMap.th = wrapMap.td;
-
-function getAll( context, tag ) {
-	var elems, elem,
-		i = 0,
-		found = typeof context.getElementsByTagName !== strundefined ? context.getElementsByTagName( tag || "*" ) :
-			typeof context.querySelectorAll !== strundefined ? context.querySelectorAll( tag || "*" ) :
-			undefined;
-
-	if ( !found ) {
-		for ( found = [], elems = context.childNodes || context; (elem = elems[i]) != null; i++ ) {
-			if ( !tag || jQuery.nodeName( elem, tag ) ) {
-				found.push( elem );
-			} else {
-				jQuery.merge( found, getAll( elem, tag ) );
-			}
-		}
-	}
-
-	return tag === undefined || tag && jQuery.nodeName( context, tag ) ?
-		jQuery.merge( [ context ], found ) :
-		found;
-}
-
-// Used in buildFragment, fixes the defaultChecked property
-function fixDefaultChecked( elem ) {
-	if ( rcheckableType.test( elem.type ) ) {
-		elem.defaultChecked = elem.checked;
-	}
-}
+	fragmentDiv = safeFragment.appendChild( document.createElement( "div" ) );
 
 // Support: IE<8
 // Manipulating tables requires a tbody
@@ -5380,37 +5891,27 @@ function manipulationTarget( elem, content ) {
 	return jQuery.nodeName( elem, "table" ) &&
 		jQuery.nodeName( content.nodeType !== 11 ? content : content.firstChild, "tr" ) ?
 
-		elem.getElementsByTagName("tbody")[0] ||
-			elem.appendChild( elem.ownerDocument.createElement("tbody") ) :
+		elem.getElementsByTagName( "tbody" )[ 0 ] ||
+			elem.appendChild( elem.ownerDocument.createElement( "tbody" ) ) :
 		elem;
 }
 
 // Replace/restore the type attribute of script elements for safe DOM manipulation
 function disableScript( elem ) {
-	elem.type = (jQuery.find.attr( elem, "type" ) !== null) + "/" + elem.type;
+	elem.type = ( jQuery.find.attr( elem, "type" ) !== null ) + "/" + elem.type;
 	return elem;
 }
 function restoreScript( elem ) {
 	var match = rscriptTypeMasked.exec( elem.type );
 	if ( match ) {
-		elem.type = match[1];
+		elem.type = match[ 1 ];
 	} else {
-		elem.removeAttribute("type");
+		elem.removeAttribute( "type" );
 	}
 	return elem;
 }
 
-// Mark scripts as having already been evaluated
-function setGlobalEval( elems, refElements ) {
-	var elem,
-		i = 0;
-	for ( ; (elem = elems[i]) != null; i++ ) {
-		jQuery._data( elem, "globalEval", !refElements || jQuery._data( refElements[i], "globalEval" ) );
-	}
-}
-
 function cloneCopyEvent( src, dest ) {
-
 	if ( dest.nodeType !== 1 || !jQuery.hasData( src ) ) {
 		return;
 	}
@@ -5475,11 +5976,12 @@ function fixCloneNodeIssues( src, dest ) {
 		// element in IE9, the outerHTML strategy above is not sufficient.
 		// If the src has innerHTML and the destination does not,
 		// copy the src.innerHTML into the dest.innerHTML. #10324
-		if ( support.html5Clone && ( src.innerHTML && !jQuery.trim(dest.innerHTML) ) ) {
+		if ( support.html5Clone && ( src.innerHTML && !jQuery.trim( dest.innerHTML ) ) ) {
 			dest.innerHTML = src.innerHTML;
 		}
 
 	} else if ( nodeName === "input" && rcheckableType.test( src.type ) ) {
+
 		// IE6-8 fails to persist the checked state of a cloned checkbox
 		// or radio button. Worse, IE6-7 fail to give the cloned element
 		// a checked appearance if the defaultChecked value isn't also set
@@ -5504,12 +6006,137 @@ function fixCloneNodeIssues( src, dest ) {
 	}
 }
 
-jQuery.extend({
+function domManip( collection, args, callback, ignored ) {
+
+	// Flatten any nested arrays
+	args = concat.apply( [], args );
+
+	var first, node, hasScripts,
+		scripts, doc, fragment,
+		i = 0,
+		l = collection.length,
+		iNoClone = l - 1,
+		value = args[ 0 ],
+		isFunction = jQuery.isFunction( value );
+
+	// We can't cloneNode fragments that contain checked, in WebKit
+	if ( isFunction ||
+			( l > 1 && typeof value === "string" &&
+				!support.checkClone && rchecked.test( value ) ) ) {
+		return collection.each( function( index ) {
+			var self = collection.eq( index );
+			if ( isFunction ) {
+				args[ 0 ] = value.call( this, index, self.html() );
+			}
+			domManip( self, args, callback, ignored );
+		} );
+	}
+
+	if ( l ) {
+		fragment = buildFragment( args, collection[ 0 ].ownerDocument, false, collection, ignored );
+		first = fragment.firstChild;
+
+		if ( fragment.childNodes.length === 1 ) {
+			fragment = first;
+		}
+
+		// Require either new content or an interest in ignored elements to invoke the callback
+		if ( first || ignored ) {
+			scripts = jQuery.map( getAll( fragment, "script" ), disableScript );
+			hasScripts = scripts.length;
+
+			// Use the original fragment for the last item
+			// instead of the first because it can end up
+			// being emptied incorrectly in certain situations (#8070).
+			for ( ; i < l; i++ ) {
+				node = fragment;
+
+				if ( i !== iNoClone ) {
+					node = jQuery.clone( node, true, true );
+
+					// Keep references to cloned scripts for later restoration
+					if ( hasScripts ) {
+
+						// Support: Android<4.1, PhantomJS<2
+						// push.apply(_, arraylike) throws on ancient WebKit
+						jQuery.merge( scripts, getAll( node, "script" ) );
+					}
+				}
+
+				callback.call( collection[ i ], node, i );
+			}
+
+			if ( hasScripts ) {
+				doc = scripts[ scripts.length - 1 ].ownerDocument;
+
+				// Reenable scripts
+				jQuery.map( scripts, restoreScript );
+
+				// Evaluate executable scripts on first document insertion
+				for ( i = 0; i < hasScripts; i++ ) {
+					node = scripts[ i ];
+					if ( rscriptType.test( node.type || "" ) &&
+						!jQuery._data( node, "globalEval" ) &&
+						jQuery.contains( doc, node ) ) {
+
+						if ( node.src ) {
+
+							// Optional AJAX dependency, but won't run scripts if not present
+							if ( jQuery._evalUrl ) {
+								jQuery._evalUrl( node.src );
+							}
+						} else {
+							jQuery.globalEval(
+								( node.text || node.textContent || node.innerHTML || "" )
+									.replace( rcleanScript, "" )
+							);
+						}
+					}
+				}
+			}
+
+			// Fix #11809: Avoid leaking memory
+			fragment = first = null;
+		}
+	}
+
+	return collection;
+}
+
+function remove( elem, selector, keepData ) {
+	var node,
+		elems = selector ? jQuery.filter( selector, elem ) : elem,
+		i = 0;
+
+	for ( ; ( node = elems[ i ] ) != null; i++ ) {
+
+		if ( !keepData && node.nodeType === 1 ) {
+			jQuery.cleanData( getAll( node ) );
+		}
+
+		if ( node.parentNode ) {
+			if ( keepData && jQuery.contains( node.ownerDocument, node ) ) {
+				setGlobalEval( getAll( node, "script" ) );
+			}
+			node.parentNode.removeChild( node );
+		}
+	}
+
+	return elem;
+}
+
+jQuery.extend( {
+	htmlPrefilter: function( html ) {
+		return html.replace( rxhtmlTag, "<$1></$2>" );
+	},
+
 	clone: function( elem, dataAndEvents, deepDataAndEvents ) {
 		var destElements, node, clone, i, srcElements,
 			inPage = jQuery.contains( elem.ownerDocument, elem );
 
-		if ( support.html5Clone || jQuery.isXMLDoc(elem) || !rnoshimcache.test( "<" + elem.nodeName + ">" ) ) {
+		if ( support.html5Clone || jQuery.isXMLDoc( elem ) ||
+			!rnoshimcache.test( "<" + elem.nodeName + ">" ) ) {
+
 			clone = elem.cloneNode( true );
 
 		// IE<=8 does not properly clone detached, unknown element nodes
@@ -5518,18 +6145,19 @@ jQuery.extend({
 			fragmentDiv.removeChild( clone = fragmentDiv.firstChild );
 		}
 
-		if ( (!support.noCloneEvent || !support.noCloneChecked) &&
-				(elem.nodeType === 1 || elem.nodeType === 11) && !jQuery.isXMLDoc(elem) ) {
+		if ( ( !support.noCloneEvent || !support.noCloneChecked ) &&
+				( elem.nodeType === 1 || elem.nodeType === 11 ) && !jQuery.isXMLDoc( elem ) ) {
 
 			// We eschew Sizzle here for performance reasons: http://jsperf.com/getall-vs-sizzle/2
 			destElements = getAll( clone );
 			srcElements = getAll( elem );
 
 			// Fix all IE cloning issues
-			for ( i = 0; (node = srcElements[i]) != null; ++i ) {
+			for ( i = 0; ( node = srcElements[ i ] ) != null; ++i ) {
+
 				// Ensure that the destination node is not null; Fixes #9587
-				if ( destElements[i] ) {
-					fixCloneNodeIssues( node, destElements[i] );
+				if ( destElements[ i ] ) {
+					fixCloneNodeIssues( node, destElements[ i ] );
 				}
 			}
 		}
@@ -5540,8 +6168,8 @@ jQuery.extend({
 				srcElements = srcElements || getAll( elem );
 				destElements = destElements || getAll( clone );
 
-				for ( i = 0; (node = srcElements[i]) != null; i++ ) {
-					cloneCopyEvent( node, destElements[i] );
+				for ( i = 0; ( node = srcElements[ i ] ) != null; i++ ) {
+					cloneCopyEvent( node, destElements[ i ] );
 				}
 			} else {
 				cloneCopyEvent( elem, clone );
@@ -5560,143 +6188,16 @@ jQuery.extend({
 		return clone;
 	},
 
-	buildFragment: function( elems, context, scripts, selection ) {
-		var j, elem, contains,
-			tmp, tag, tbody, wrap,
-			l = elems.length,
-
-			// Ensure a safe fragment
-			safe = createSafeFragment( context ),
-
-			nodes = [],
-			i = 0;
-
-		for ( ; i < l; i++ ) {
-			elem = elems[ i ];
-
-			if ( elem || elem === 0 ) {
-
-				// Add nodes directly
-				if ( jQuery.type( elem ) === "object" ) {
-					jQuery.merge( nodes, elem.nodeType ? [ elem ] : elem );
-
-				// Convert non-html into a text node
-				} else if ( !rhtml.test( elem ) ) {
-					nodes.push( context.createTextNode( elem ) );
-
-				// Convert html into DOM nodes
-				} else {
-					tmp = tmp || safe.appendChild( context.createElement("div") );
-
-					// Deserialize a standard representation
-					tag = (rtagName.exec( elem ) || [ "", "" ])[ 1 ].toLowerCase();
-					wrap = wrapMap[ tag ] || wrapMap._default;
-
-					tmp.innerHTML = wrap[1] + elem.replace( rxhtmlTag, "<$1></$2>" ) + wrap[2];
-
-					// Descend through wrappers to the right content
-					j = wrap[0];
-					while ( j-- ) {
-						tmp = tmp.lastChild;
-					}
-
-					// Manually add leading whitespace removed by IE
-					if ( !support.leadingWhitespace && rleadingWhitespace.test( elem ) ) {
-						nodes.push( context.createTextNode( rleadingWhitespace.exec( elem )[0] ) );
-					}
-
-					// Remove IE's autoinserted <tbody> from table fragments
-					if ( !support.tbody ) {
-
-						// String was a <table>, *may* have spurious <tbody>
-						elem = tag === "table" && !rtbody.test( elem ) ?
-							tmp.firstChild :
-
-							// String was a bare <thead> or <tfoot>
-							wrap[1] === "<table>" && !rtbody.test( elem ) ?
-								tmp :
-								0;
-
-						j = elem && elem.childNodes.length;
-						while ( j-- ) {
-							if ( jQuery.nodeName( (tbody = elem.childNodes[j]), "tbody" ) && !tbody.childNodes.length ) {
-								elem.removeChild( tbody );
-							}
-						}
-					}
-
-					jQuery.merge( nodes, tmp.childNodes );
-
-					// Fix #12392 for WebKit and IE > 9
-					tmp.textContent = "";
-
-					// Fix #12392 for oldIE
-					while ( tmp.firstChild ) {
-						tmp.removeChild( tmp.firstChild );
-					}
-
-					// Remember the top-level container for proper cleanup
-					tmp = safe.lastChild;
-				}
-			}
-		}
-
-		// Fix #11356: Clear elements from fragment
-		if ( tmp ) {
-			safe.removeChild( tmp );
-		}
-
-		// Reset defaultChecked for any radios and checkboxes
-		// about to be appended to the DOM in IE 6/7 (#8060)
-		if ( !support.appendChecked ) {
-			jQuery.grep( getAll( nodes, "input" ), fixDefaultChecked );
-		}
-
-		i = 0;
-		while ( (elem = nodes[ i++ ]) ) {
-
-			// #4087 - If origin and destination elements are the same, and this is
-			// that element, do not do anything
-			if ( selection && jQuery.inArray( elem, selection ) !== -1 ) {
-				continue;
-			}
-
-			contains = jQuery.contains( elem.ownerDocument, elem );
-
-			// Append to fragment
-			tmp = getAll( safe.appendChild( elem ), "script" );
-
-			// Preserve script evaluation history
-			if ( contains ) {
-				setGlobalEval( tmp );
-			}
-
-			// Capture executables
-			if ( scripts ) {
-				j = 0;
-				while ( (elem = tmp[ j++ ]) ) {
-					if ( rscriptType.test( elem.type || "" ) ) {
-						scripts.push( elem );
-					}
-				}
-			}
-		}
-
-		tmp = null;
-
-		return safe;
-	},
-
-	cleanData: function( elems, /* internal */ acceptData ) {
+	cleanData: function( elems, /* internal */ forceAcceptData ) {
 		var elem, type, id, data,
 			i = 0,
 			internalKey = jQuery.expando,
 			cache = jQuery.cache,
-			deleteExpando = support.deleteExpando,
+			attributes = support.attributes,
 			special = jQuery.event.special;
 
-		for ( ; (elem = elems[i]) != null; i++ ) {
-			if ( acceptData || jQuery.acceptData( elem ) ) {
+		for ( ; ( elem = elems[ i ] ) != null; i++ ) {
+			if ( forceAcceptData || acceptData( elem ) ) {
 
 				id = elem[ internalKey ];
 				data = id && cache[ id ];
@@ -5719,17 +6220,18 @@ jQuery.extend({
 
 						delete cache[ id ];
 
-						// IE does not allow us to delete expando properties from nodes,
-						// nor does it have a removeAttribute function on Document nodes;
-						// we must handle all of these cases
-						if ( deleteExpando ) {
-							delete elem[ internalKey ];
-
-						} else if ( typeof elem.removeAttribute !== strundefined ) {
+						// Support: IE<9
+						// IE does not allow us to delete expando properties from nodes
+						// IE creates expando attributes along with the property
+						// IE does not have a removeAttribute function on Document nodes
+						if ( !attributes && typeof elem.removeAttribute !== "undefined" ) {
 							elem.removeAttribute( internalKey );
 
+						// Webkit & Blink performance suffers when deleting properties
+						// from DOM nodes, so set to undefined instead
+						// https://code.google.com/p/chromium/issues/detail?id=378607
 						} else {
-							elem[ internalKey ] = null;
+							elem[ internalKey ] = undefined;
 						}
 
 						deletedIds.push( id );
@@ -5738,78 +6240,71 @@ jQuery.extend({
 			}
 		}
 	}
-});
+} );
 
-jQuery.fn.extend({
+jQuery.fn.extend( {
+
+	// Keep domManip exposed until 3.0 (gh-2225)
+	domManip: domManip,
+
+	detach: function( selector ) {
+		return remove( this, selector, true );
+	},
+
+	remove: function( selector ) {
+		return remove( this, selector );
+	},
+
 	text: function( value ) {
 		return access( this, function( value ) {
 			return value === undefined ?
 				jQuery.text( this ) :
-				this.empty().append( ( this[0] && this[0].ownerDocument || document ).createTextNode( value ) );
+				this.empty().append(
+					( this[ 0 ] && this[ 0 ].ownerDocument || document ).createTextNode( value )
+				);
 		}, null, value, arguments.length );
 	},
 
 	append: function() {
-		return this.domManip( arguments, function( elem ) {
+		return domManip( this, arguments, function( elem ) {
 			if ( this.nodeType === 1 || this.nodeType === 11 || this.nodeType === 9 ) {
 				var target = manipulationTarget( this, elem );
 				target.appendChild( elem );
 			}
-		});
+		} );
 	},
 
 	prepend: function() {
-		return this.domManip( arguments, function( elem ) {
+		return domManip( this, arguments, function( elem ) {
 			if ( this.nodeType === 1 || this.nodeType === 11 || this.nodeType === 9 ) {
 				var target = manipulationTarget( this, elem );
 				target.insertBefore( elem, target.firstChild );
 			}
-		});
+		} );
 	},
 
 	before: function() {
-		return this.domManip( arguments, function( elem ) {
+		return domManip( this, arguments, function( elem ) {
 			if ( this.parentNode ) {
 				this.parentNode.insertBefore( elem, this );
 			}
-		});
+		} );
 	},
 
 	after: function() {
-		return this.domManip( arguments, function( elem ) {
+		return domManip( this, arguments, function( elem ) {
 			if ( this.parentNode ) {
 				this.parentNode.insertBefore( elem, this.nextSibling );
 			}
-		});
-	},
-
-	remove: function( selector, keepData /* Internal Use Only */ ) {
-		var elem,
-			elems = selector ? jQuery.filter( selector, this ) : this,
-			i = 0;
-
-		for ( ; (elem = elems[i]) != null; i++ ) {
-
-			if ( !keepData && elem.nodeType === 1 ) {
-				jQuery.cleanData( getAll( elem ) );
-			}
-
-			if ( elem.parentNode ) {
-				if ( keepData && jQuery.contains( elem.ownerDocument, elem ) ) {
-					setGlobalEval( getAll( elem, "script" ) );
-				}
-				elem.parentNode.removeChild( elem );
-			}
-		}
-
-		return this;
+		} );
 	},
 
 	empty: function() {
 		var elem,
 			i = 0;
 
-		for ( ; (elem = this[i]) != null; i++ ) {
+		for ( ; ( elem = this[ i ] ) != null; i++ ) {
+
 			// Remove element nodes and prevent memory leaks
 			if ( elem.nodeType === 1 ) {
 				jQuery.cleanData( getAll( elem, false ) );
@@ -5834,9 +6329,9 @@ jQuery.fn.extend({
 		dataAndEvents = dataAndEvents == null ? false : dataAndEvents;
 		deepDataAndEvents = deepDataAndEvents == null ? dataAndEvents : deepDataAndEvents;
 
-		return this.map(function() {
+		return this.map( function() {
 			return jQuery.clone( this, dataAndEvents, deepDataAndEvents );
-		});
+		} );
 	},
 
 	html: function( value ) {
@@ -5855,14 +6350,15 @@ jQuery.fn.extend({
 			if ( typeof value === "string" && !rnoInnerhtml.test( value ) &&
 				( support.htmlSerialize || !rnoshimcache.test( value )  ) &&
 				( support.leadingWhitespace || !rleadingWhitespace.test( value ) ) &&
-				!wrapMap[ (rtagName.exec( value ) || [ "", "" ])[ 1 ].toLowerCase() ] ) {
+				!wrapMap[ ( rtagName.exec( value ) || [ "", "" ] )[ 1 ].toLowerCase() ] ) {
 
-				value = value.replace( rxhtmlTag, "<$1></$2>" );
+				value = jQuery.htmlPrefilter( value );
 
 				try {
-					for (; i < l; i++ ) {
+					for ( ; i < l; i++ ) {
+
 						// Remove element nodes and prevent memory leaks
-						elem = this[i] || {};
+						elem = this[ i ] || {};
 						if ( elem.nodeType === 1 ) {
 							jQuery.cleanData( getAll( elem, false ) );
 							elem.innerHTML = value;
@@ -5872,7 +6368,7 @@ jQuery.fn.extend({
 					elem = 0;
 
 				// If using innerHTML throws an exception, use the fallback method
-				} catch(e) {}
+				} catch ( e ) {}
 			}
 
 			if ( elem ) {
@@ -5882,117 +6378,25 @@ jQuery.fn.extend({
 	},
 
 	replaceWith: function() {
-		var arg = arguments[ 0 ];
+		var ignored = [];
 
-		// Make the changes, replacing each context element with the new content
-		this.domManip( arguments, function( elem ) {
-			arg = this.parentNode;
+		// Make the changes, replacing each non-ignored context element with the new content
+		return domManip( this, arguments, function( elem ) {
+			var parent = this.parentNode;
 
-			jQuery.cleanData( getAll( this ) );
-
-			if ( arg ) {
-				arg.replaceChild( elem, this );
-			}
-		});
-
-		// Force removal if there was no new content (e.g., from empty arguments)
-		return arg && (arg.length || arg.nodeType) ? this : this.remove();
-	},
-
-	detach: function( selector ) {
-		return this.remove( selector, true );
-	},
-
-	domManip: function( args, callback ) {
-
-		// Flatten any nested arrays
-		args = concat.apply( [], args );
-
-		var first, node, hasScripts,
-			scripts, doc, fragment,
-			i = 0,
-			l = this.length,
-			set = this,
-			iNoClone = l - 1,
-			value = args[0],
-			isFunction = jQuery.isFunction( value );
-
-		// We can't cloneNode fragments that contain checked, in WebKit
-		if ( isFunction ||
-				( l > 1 && typeof value === "string" &&
-					!support.checkClone && rchecked.test( value ) ) ) {
-			return this.each(function( index ) {
-				var self = set.eq( index );
-				if ( isFunction ) {
-					args[0] = value.call( this, index, self.html() );
+			if ( jQuery.inArray( this, ignored ) < 0 ) {
+				jQuery.cleanData( getAll( this ) );
+				if ( parent ) {
+					parent.replaceChild( elem, this );
 				}
-				self.domManip( args, callback );
-			});
-		}
-
-		if ( l ) {
-			fragment = jQuery.buildFragment( args, this[ 0 ].ownerDocument, false, this );
-			first = fragment.firstChild;
-
-			if ( fragment.childNodes.length === 1 ) {
-				fragment = first;
 			}
 
-			if ( first ) {
-				scripts = jQuery.map( getAll( fragment, "script" ), disableScript );
-				hasScripts = scripts.length;
-
-				// Use the original fragment for the last item instead of the first because it can end up
-				// being emptied incorrectly in certain situations (#8070).
-				for ( ; i < l; i++ ) {
-					node = fragment;
-
-					if ( i !== iNoClone ) {
-						node = jQuery.clone( node, true, true );
-
-						// Keep references to cloned scripts for later restoration
-						if ( hasScripts ) {
-							jQuery.merge( scripts, getAll( node, "script" ) );
-						}
-					}
-
-					callback.call( this[i], node, i );
-				}
-
-				if ( hasScripts ) {
-					doc = scripts[ scripts.length - 1 ].ownerDocument;
-
-					// Reenable scripts
-					jQuery.map( scripts, restoreScript );
-
-					// Evaluate executable scripts on first document insertion
-					for ( i = 0; i < hasScripts; i++ ) {
-						node = scripts[ i ];
-						if ( rscriptType.test( node.type || "" ) &&
-							!jQuery._data( node, "globalEval" ) && jQuery.contains( doc, node ) ) {
-
-							if ( node.src ) {
-								// Optional AJAX dependency, but won't run scripts if not present
-								if ( jQuery._evalUrl ) {
-									jQuery._evalUrl( node.src );
-								}
-							} else {
-								jQuery.globalEval( ( node.text || node.textContent || node.innerHTML || "" ).replace( rcleanScript, "" ) );
-							}
-						}
-					}
-				}
-
-				// Fix #11809: Avoid leaking memory
-				fragment = first = null;
-			}
-		}
-
-		return this;
+		// Force callback invocation
+		}, ignored );
 	}
-});
+} );
 
-jQuery.each({
+jQuery.each( {
 	appendTo: "append",
 	prependTo: "prepend",
 	insertBefore: "before",
@@ -6007,8 +6411,8 @@ jQuery.each({
 			last = insert.length - 1;
 
 		for ( ; i <= last; i++ ) {
-			elems = i === last ? this : this.clone(true);
-			jQuery( insert[i] )[ original ]( elems );
+			elems = i === last ? this : this.clone( true );
+			jQuery( insert[ i ] )[ original ]( elems );
 
 			// Modern browsers can apply jQuery collections as arrays, but oldIE needs a .get()
 			push.apply( ret, elems.get() );
@@ -6016,28 +6420,29 @@ jQuery.each({
 
 		return this.pushStack( ret );
 	};
-});
+} );
 
 
 var iframe,
-	elemdisplay = {};
+	elemdisplay = {
+
+		// Support: Firefox
+		// We have to pre-define these values for FF (#10227)
+		HTML: "block",
+		BODY: "block"
+	};
 
 /**
  * Retrieve the actual display of a element
  * @param {String} name nodeName of the element
  * @param {Object} doc Document object
  */
+
 // Called only from within defaultDisplay
 function actualDisplay( name, doc ) {
-	var style,
-		elem = jQuery( doc.createElement( name ) ).appendTo( doc.body ),
+	var elem = jQuery( doc.createElement( name ) ).appendTo( doc.body ),
 
-		// getDefaultComputedStyle might be reliably used only on attached element
-		display = window.getDefaultComputedStyle && ( style = window.getDefaultComputedStyle( elem[ 0 ] ) ) ?
-
-			// Use of this method is a temporary fix (more like optmization) until something better comes along,
-			// since it was removed from specification and supported only in FF
-			style.display : jQuery.css( elem[ 0 ], "display" );
+		display = jQuery.css( elem[ 0 ], "display" );
 
 	// We don't have any data stored on the element,
 	// so use "detach" method as fast way to get rid of the element
@@ -6061,7 +6466,8 @@ function defaultDisplay( nodeName ) {
 		if ( display === "none" || !display ) {
 
 			// Use the already-created iframe if possible
-			iframe = (iframe || jQuery( "<iframe frameborder='0' width='0' height='0'/>" )).appendTo( doc.documentElement );
+			iframe = ( iframe || jQuery( "<iframe frameborder='0' width='0' height='0'/>" ) )
+				.appendTo( doc.documentElement );
 
 			// Always write a new HTML skeleton so Webkit and Firefox don't choke on reuse
 			doc = ( iframe[ 0 ].contentWindow || iframe[ 0 ].contentDocument ).document;
@@ -6080,58 +6486,208 @@ function defaultDisplay( nodeName ) {
 
 	return display;
 }
-
-
-(function() {
-	var shrinkWrapBlocksVal;
-
-	support.shrinkWrapBlocks = function() {
-		if ( shrinkWrapBlocksVal != null ) {
-			return shrinkWrapBlocksVal;
-		}
-
-		// Will be changed later if needed.
-		shrinkWrapBlocksVal = false;
-
-		// Minified: var b,c,d
-		var div, body, container;
-
-		body = document.getElementsByTagName( "body" )[ 0 ];
-		if ( !body || !body.style ) {
-			// Test fired too early or in an unsupported environment, exit.
-			return;
-		}
-
-		// Setup
-		div = document.createElement( "div" );
-		container = document.createElement( "div" );
-		container.style.cssText = "position:absolute;border:0;width:0;height:0;top:0;left:-9999px";
-		body.appendChild( container ).appendChild( div );
-
-		// Support: IE6
-		// Check if elements with layout shrink-wrap their children
-		if ( typeof div.style.zoom !== strundefined ) {
-			// Reset CSS: box-sizing; display; margin; border
-			div.style.cssText =
-				// Support: Firefox<29, Android 2.3
-				// Vendor-prefix box-sizing
-				"-webkit-box-sizing:content-box;-moz-box-sizing:content-box;" +
-				"box-sizing:content-box;display:block;margin:0;border:0;" +
-				"padding:1px;width:1px;zoom:1";
-			div.appendChild( document.createElement( "div" ) ).style.width = "5px";
-			shrinkWrapBlocksVal = div.offsetWidth !== 3;
-		}
-
-		body.removeChild( container );
-
-		return shrinkWrapBlocksVal;
-	};
-
-})();
-var rmargin = (/^margin/);
+var rmargin = ( /^margin/ );
 
 var rnumnonpx = new RegExp( "^(" + pnum + ")(?!px)[a-z%]+$", "i" );
 
+var swap = function( elem, options, callback, args ) {
+	var ret, name,
+		old = {};
+
+	// Remember the old values, and insert the new ones
+	for ( name in options ) {
+		old[ name ] = elem.style[ name ];
+		elem.style[ name ] = options[ name ];
+	}
+
+	ret = callback.apply( elem, args || [] );
+
+	// Revert the old values
+	for ( name in options ) {
+		elem.style[ name ] = old[ name ];
+	}
+
+	return ret;
+};
+
+
+var documentElement = document.documentElement;
+
+
+
+( function() {
+	var pixelPositionVal, pixelMarginRightVal, boxSizingReliableVal,
+		reliableHiddenOffsetsVal, reliableMarginRightVal, reliableMarginLeftVal,
+		container = document.createElement( "div" ),
+		div = document.createElement( "div" );
+
+	// Finish early in limited (non-browser) environments
+	if ( !div.style ) {
+		return;
+	}
+
+	div.style.cssText = "float:left;opacity:.5";
+
+	// Support: IE<9
+	// Make sure that element opacity exists (as opposed to filter)
+	support.opacity = div.style.opacity === "0.5";
+
+	// Verify style float existence
+	// (IE uses styleFloat instead of cssFloat)
+	support.cssFloat = !!div.style.cssFloat;
+
+	div.style.backgroundClip = "content-box";
+	div.cloneNode( true ).style.backgroundClip = "";
+	support.clearCloneStyle = div.style.backgroundClip === "content-box";
+
+	container = document.createElement( "div" );
+	container.style.cssText = "border:0;width:8px;height:0;top:0;left:-9999px;" +
+		"padding:0;margin-top:1px;position:absolute";
+	div.innerHTML = "";
+	container.appendChild( div );
+
+	// Support: Firefox<29, Android 2.3
+	// Vendor-prefix box-sizing
+	support.boxSizing = div.style.boxSizing === "" || div.style.MozBoxSizing === "" ||
+		div.style.WebkitBoxSizing === "";
+
+	jQuery.extend( support, {
+		reliableHiddenOffsets: function() {
+			if ( pixelPositionVal == null ) {
+				computeStyleTests();
+			}
+			return reliableHiddenOffsetsVal;
+		},
+
+		boxSizingReliable: function() {
+
+			// We're checking for pixelPositionVal here instead of boxSizingReliableVal
+			// since that compresses better and they're computed together anyway.
+			if ( pixelPositionVal == null ) {
+				computeStyleTests();
+			}
+			return boxSizingReliableVal;
+		},
+
+		pixelMarginRight: function() {
+
+			// Support: Android 4.0-4.3
+			if ( pixelPositionVal == null ) {
+				computeStyleTests();
+			}
+			return pixelMarginRightVal;
+		},
+
+		pixelPosition: function() {
+			if ( pixelPositionVal == null ) {
+				computeStyleTests();
+			}
+			return pixelPositionVal;
+		},
+
+		reliableMarginRight: function() {
+
+			// Support: Android 2.3
+			if ( pixelPositionVal == null ) {
+				computeStyleTests();
+			}
+			return reliableMarginRightVal;
+		},
+
+		reliableMarginLeft: function() {
+
+			// Support: IE <=8 only, Android 4.0 - 4.3 only, Firefox <=3 - 37
+			if ( pixelPositionVal == null ) {
+				computeStyleTests();
+			}
+			return reliableMarginLeftVal;
+		}
+	} );
+
+	function computeStyleTests() {
+		var contents, divStyle,
+			documentElement = document.documentElement;
+
+		// Setup
+		documentElement.appendChild( container );
+
+		div.style.cssText =
+
+			// Support: Android 2.3
+			// Vendor-prefix box-sizing
+			"-webkit-box-sizing:border-box;box-sizing:border-box;" +
+			"position:relative;display:block;" +
+			"margin:auto;border:1px;padding:1px;" +
+			"top:1%;width:50%";
+
+		// Support: IE<9
+		// Assume reasonable values in the absence of getComputedStyle
+		pixelPositionVal = boxSizingReliableVal = reliableMarginLeftVal = false;
+		pixelMarginRightVal = reliableMarginRightVal = true;
+
+		// Check for getComputedStyle so that this code is not run in IE<9.
+		if ( window.getComputedStyle ) {
+			divStyle = window.getComputedStyle( div );
+			pixelPositionVal = ( divStyle || {} ).top !== "1%";
+			reliableMarginLeftVal = ( divStyle || {} ).marginLeft === "2px";
+			boxSizingReliableVal = ( divStyle || { width: "4px" } ).width === "4px";
+
+			// Support: Android 4.0 - 4.3 only
+			// Some styles come back with percentage values, even though they shouldn't
+			div.style.marginRight = "50%";
+			pixelMarginRightVal = ( divStyle || { marginRight: "4px" } ).marginRight === "4px";
+
+			// Support: Android 2.3 only
+			// Div with explicit width and no margin-right incorrectly
+			// gets computed margin-right based on width of container (#3333)
+			// WebKit Bug 13343 - getComputedStyle returns wrong value for margin-right
+			contents = div.appendChild( document.createElement( "div" ) );
+
+			// Reset CSS: box-sizing; display; margin; border; padding
+			contents.style.cssText = div.style.cssText =
+
+				// Support: Android 2.3
+				// Vendor-prefix box-sizing
+				"-webkit-box-sizing:content-box;-moz-box-sizing:content-box;" +
+				"box-sizing:content-box;display:block;margin:0;border:0;padding:0";
+			contents.style.marginRight = contents.style.width = "0";
+			div.style.width = "1px";
+
+			reliableMarginRightVal =
+				!parseFloat( ( window.getComputedStyle( contents ) || {} ).marginRight );
+
+			div.removeChild( contents );
+		}
+
+		// Support: IE6-8
+		// First check that getClientRects works as expected
+		// Check if table cells still have offsetWidth/Height when they are set
+		// to display:none and there are still other visible table cells in a
+		// table row; if so, offsetWidth/Height are not reliable for use when
+		// determining if an element has been hidden directly using
+		// display:none (it is still safe to use offsets if a parent element is
+		// hidden; don safety goggles and see bug #4512 for more information).
+		div.style.display = "none";
+		reliableHiddenOffsetsVal = div.getClientRects().length === 0;
+		if ( reliableHiddenOffsetsVal ) {
+			div.style.display = "";
+			div.innerHTML = "<table><tr><td></td><td>t</td></tr></table>";
+			div.childNodes[ 0 ].style.borderCollapse = "separate";
+			contents = div.getElementsByTagName( "td" );
+			contents[ 0 ].style.cssText = "margin:0;border:0;padding:0;display:none";
+			reliableHiddenOffsetsVal = contents[ 0 ].offsetHeight === 0;
+			if ( reliableHiddenOffsetsVal ) {
+				contents[ 0 ].style.display = "";
+				contents[ 1 ].style.display = "none";
+				reliableHiddenOffsetsVal = contents[ 0 ].offsetHeight === 0;
+			}
+		}
+
+		// Teardown
+		documentElement.removeChild( container );
+	}
+
+} )();
 
 
 var getStyles, curCSS,
@@ -6139,14 +6695,17 @@ var getStyles, curCSS,
 
 if ( window.getComputedStyle ) {
 	getStyles = function( elem ) {
+
 		// Support: IE<=11+, Firefox<=30+ (#15098, #14150)
 		// IE throws on elements created in popups
 		// FF meanwhile throws on frame elements through "defaultView.getComputedStyle"
-		if ( elem.ownerDocument.defaultView.opener ) {
-			return elem.ownerDocument.defaultView.getComputedStyle( elem, null );
+		var view = elem.ownerDocument.defaultView;
+
+		if ( !view || !view.opener ) {
+			view = window;
 		}
 
-		return window.getComputedStyle( elem, null );
+		return view.getComputedStyle( elem );
 	};
 
 	curCSS = function( elem, name, computed ) {
@@ -6158,17 +6717,23 @@ if ( window.getComputedStyle ) {
 		// getPropertyValue is only needed for .css('filter') in IE9, see #12537
 		ret = computed ? computed.getPropertyValue( name ) || computed[ name ] : undefined;
 
+		// Support: Opera 12.1x only
+		// Fall back to style even without computed
+		// computed is undefined for elems on document fragments
+		if ( ( ret === "" || ret === undefined ) && !jQuery.contains( elem.ownerDocument, elem ) ) {
+			ret = jQuery.style( elem, name );
+		}
+
 		if ( computed ) {
 
-			if ( ret === "" && !jQuery.contains( elem.ownerDocument, elem ) ) {
-				ret = jQuery.style( elem, name );
-			}
-
 			// A tribute to the "awesome hack by Dean Edwards"
-			// Chrome < 17 and Safari 5.0 uses "computed value" instead of "used value" for margin-right
-			// Safari 5.1.7 (at least) returns percentage for a larger set of values, but width seems to be reliably pixels
-			// this is against the CSSOM draft spec: http://dev.w3.org/csswg/cssom/#resolved-values
-			if ( rnumnonpx.test( ret ) && rmargin.test( name ) ) {
+			// Chrome < 17 and Safari 5.0 uses "computed value"
+			// instead of "used value" for margin-right
+			// Safari 5.1.7 (at least) returns percentage for a larger set of values,
+			// but width seems to be reliably pixels
+			// this is against the CSSOM draft spec:
+			// http://dev.w3.org/csswg/cssom/#resolved-values
+			if ( !support.pixelMarginRight() && rnumnonpx.test( ret ) && rmargin.test( name ) ) {
 
 				// Remember the original values
 				width = style.width;
@@ -6192,7 +6757,7 @@ if ( window.getComputedStyle ) {
 			ret :
 			ret + "";
 	};
-} else if ( document.documentElement.currentStyle ) {
+} else if ( documentElement.currentStyle ) {
 	getStyles = function( elem ) {
 		return elem.currentStyle;
 	};
@@ -6215,8 +6780,10 @@ if ( window.getComputedStyle ) {
 
 		// If we're not dealing with a regular pixel number
 		// but a number that has a weird ending, we need to convert it to pixels
-		// but not position css attributes, as those are proportional to the parent element instead
-		// and we can't measure the parent instead because it might trigger a "stacking dolls" problem
+		// but not position css attributes, as those are
+		// proportional to the parent element instead
+		// and we can't measure the parent instead because it
+		// might trigger a "stacking dolls" problem
 		if ( rnumnonpx.test( ret ) && !rposition.test( name ) ) {
 
 			// Remember the original values
@@ -6250,208 +6817,36 @@ if ( window.getComputedStyle ) {
 
 
 function addGetHookIf( conditionFn, hookFn ) {
+
 	// Define the hook, we'll check on the first run if it's really needed.
 	return {
 		get: function() {
-			var condition = conditionFn();
+			if ( conditionFn() ) {
 
-			if ( condition == null ) {
-				// The test was not ready at this point; screw the hook this time
-				// but check again when needed next time.
-				return;
-			}
-
-			if ( condition ) {
-				// Hook not needed (or it's not possible to use it due to missing dependency),
-				// remove it.
-				// Since there are no other hooks for marginRight, remove the whole object.
+				// Hook not needed (or it's not possible to use it due
+				// to missing dependency), remove it.
 				delete this.get;
 				return;
 			}
 
 			// Hook needed; redefine it so that the support test is not executed again.
-
-			return (this.get = hookFn).apply( this, arguments );
+			return ( this.get = hookFn ).apply( this, arguments );
 		}
 	};
 }
 
 
-(function() {
-	// Minified: var b,c,d,e,f,g, h,i
-	var div, style, a, pixelPositionVal, boxSizingReliableVal,
-		reliableHiddenOffsetsVal, reliableMarginRightVal;
-
-	// Setup
-	div = document.createElement( "div" );
-	div.innerHTML = "  <link/><table></table><a href='/a'>a</a><input type='checkbox'/>";
-	a = div.getElementsByTagName( "a" )[ 0 ];
-	style = a && a.style;
-
-	// Finish early in limited (non-browser) environments
-	if ( !style ) {
-		return;
-	}
-
-	style.cssText = "float:left;opacity:.5";
-
-	// Support: IE<9
-	// Make sure that element opacity exists (as opposed to filter)
-	support.opacity = style.opacity === "0.5";
-
-	// Verify style float existence
-	// (IE uses styleFloat instead of cssFloat)
-	support.cssFloat = !!style.cssFloat;
-
-	div.style.backgroundClip = "content-box";
-	div.cloneNode( true ).style.backgroundClip = "";
-	support.clearCloneStyle = div.style.backgroundClip === "content-box";
-
-	// Support: Firefox<29, Android 2.3
-	// Vendor-prefix box-sizing
-	support.boxSizing = style.boxSizing === "" || style.MozBoxSizing === "" ||
-		style.WebkitBoxSizing === "";
-
-	jQuery.extend(support, {
-		reliableHiddenOffsets: function() {
-			if ( reliableHiddenOffsetsVal == null ) {
-				computeStyleTests();
-			}
-			return reliableHiddenOffsetsVal;
-		},
-
-		boxSizingReliable: function() {
-			if ( boxSizingReliableVal == null ) {
-				computeStyleTests();
-			}
-			return boxSizingReliableVal;
-		},
-
-		pixelPosition: function() {
-			if ( pixelPositionVal == null ) {
-				computeStyleTests();
-			}
-			return pixelPositionVal;
-		},
-
-		// Support: Android 2.3
-		reliableMarginRight: function() {
-			if ( reliableMarginRightVal == null ) {
-				computeStyleTests();
-			}
-			return reliableMarginRightVal;
-		}
-	});
-
-	function computeStyleTests() {
-		// Minified: var b,c,d,j
-		var div, body, container, contents;
-
-		body = document.getElementsByTagName( "body" )[ 0 ];
-		if ( !body || !body.style ) {
-			// Test fired too early or in an unsupported environment, exit.
-			return;
-		}
-
-		// Setup
-		div = document.createElement( "div" );
-		container = document.createElement( "div" );
-		container.style.cssText = "position:absolute;border:0;width:0;height:0;top:0;left:-9999px";
-		body.appendChild( container ).appendChild( div );
-
-		div.style.cssText =
-			// Support: Firefox<29, Android 2.3
-			// Vendor-prefix box-sizing
-			"-webkit-box-sizing:border-box;-moz-box-sizing:border-box;" +
-			"box-sizing:border-box;display:block;margin-top:1%;top:1%;" +
-			"border:1px;padding:1px;width:4px;position:absolute";
-
-		// Support: IE<9
-		// Assume reasonable values in the absence of getComputedStyle
-		pixelPositionVal = boxSizingReliableVal = false;
-		reliableMarginRightVal = true;
-
-		// Check for getComputedStyle so that this code is not run in IE<9.
-		if ( window.getComputedStyle ) {
-			pixelPositionVal = ( window.getComputedStyle( div, null ) || {} ).top !== "1%";
-			boxSizingReliableVal =
-				( window.getComputedStyle( div, null ) || { width: "4px" } ).width === "4px";
-
-			// Support: Android 2.3
-			// Div with explicit width and no margin-right incorrectly
-			// gets computed margin-right based on width of container (#3333)
-			// WebKit Bug 13343 - getComputedStyle returns wrong value for margin-right
-			contents = div.appendChild( document.createElement( "div" ) );
-
-			// Reset CSS: box-sizing; display; margin; border; padding
-			contents.style.cssText = div.style.cssText =
-				// Support: Firefox<29, Android 2.3
-				// Vendor-prefix box-sizing
-				"-webkit-box-sizing:content-box;-moz-box-sizing:content-box;" +
-				"box-sizing:content-box;display:block;margin:0;border:0;padding:0";
-			contents.style.marginRight = contents.style.width = "0";
-			div.style.width = "1px";
-
-			reliableMarginRightVal =
-				!parseFloat( ( window.getComputedStyle( contents, null ) || {} ).marginRight );
-
-			div.removeChild( contents );
-		}
-
-		// Support: IE8
-		// Check if table cells still have offsetWidth/Height when they are set
-		// to display:none and there are still other visible table cells in a
-		// table row; if so, offsetWidth/Height are not reliable for use when
-		// determining if an element has been hidden directly using
-		// display:none (it is still safe to use offsets if a parent element is
-		// hidden; don safety goggles and see bug #4512 for more information).
-		div.innerHTML = "<table><tr><td></td><td>t</td></tr></table>";
-		contents = div.getElementsByTagName( "td" );
-		contents[ 0 ].style.cssText = "margin:0;border:0;padding:0;display:none";
-		reliableHiddenOffsetsVal = contents[ 0 ].offsetHeight === 0;
-		if ( reliableHiddenOffsetsVal ) {
-			contents[ 0 ].style.display = "";
-			contents[ 1 ].style.display = "none";
-			reliableHiddenOffsetsVal = contents[ 0 ].offsetHeight === 0;
-		}
-
-		body.removeChild( container );
-	}
-
-})();
-
-
-// A method for quickly swapping in/out CSS properties to get correct calculations.
-jQuery.swap = function( elem, options, callback, args ) {
-	var ret, name,
-		old = {};
-
-	// Remember the old values, and insert the new ones
-	for ( name in options ) {
-		old[ name ] = elem.style[ name ];
-		elem.style[ name ] = options[ name ];
-	}
-
-	ret = callback.apply( elem, args || [] );
-
-	// Revert the old values
-	for ( name in options ) {
-		elem.style[ name ] = old[ name ];
-	}
-
-	return ret;
-};
-
-
 var
-		ralpha = /alpha\([^)]*\)/i,
-	ropacity = /opacity\s*=\s*([^)]*)/,
 
-	// swappable if display is none or starts with table except "table", "table-cell", or "table-caption"
-	// see here for display values: https://developer.mozilla.org/en-US/docs/CSS/display
+		ralpha = /alpha\([^)]*\)/i,
+	ropacity = /opacity\s*=\s*([^)]*)/i,
+
+	// swappable if display is none or starts with table except
+	// "table", "table-cell", or "table-caption"
+	// see here for display values:
+	// https://developer.mozilla.org/en-US/docs/CSS/display
 	rdisplayswap = /^(none|table(?!-c[ea]).+)/,
 	rnumsplit = new RegExp( "^(" + pnum + ")(.*)$", "i" ),
-	rrelNum = new RegExp( "^([+-])=(" + pnum + ")", "i" ),
 
 	cssShow = { position: "absolute", visibility: "hidden", display: "block" },
 	cssNormalTransform = {
@@ -6459,30 +6854,28 @@ var
 		fontWeight: "400"
 	},
 
-	cssPrefixes = [ "Webkit", "O", "Moz", "ms" ];
+	cssPrefixes = [ "Webkit", "O", "Moz", "ms" ],
+	emptyStyle = document.createElement( "div" ).style;
 
 
 // return a css property mapped to a potentially vendor prefixed property
-function vendorPropName( style, name ) {
+function vendorPropName( name ) {
 
 	// shortcut for names that are not vendor prefixed
-	if ( name in style ) {
+	if ( name in emptyStyle ) {
 		return name;
 	}
 
 	// check for vendor prefixed names
-	var capName = name.charAt(0).toUpperCase() + name.slice(1),
-		origName = name,
+	var capName = name.charAt( 0 ).toUpperCase() + name.slice( 1 ),
 		i = cssPrefixes.length;
 
 	while ( i-- ) {
 		name = cssPrefixes[ i ] + capName;
-		if ( name in style ) {
+		if ( name in emptyStyle ) {
 			return name;
 		}
 	}
-
-	return origName;
 }
 
 function showHide( elements, show ) {
@@ -6500,6 +6893,7 @@ function showHide( elements, show ) {
 		values[ index ] = jQuery._data( elem, "olddisplay" );
 		display = elem.style.display;
 		if ( show ) {
+
 			// Reset the inline display of this element to learn if it is
 			// being hidden by cascaded rules or not
 			if ( !values[ index ] && display === "none" ) {
@@ -6510,13 +6904,18 @@ function showHide( elements, show ) {
 			// in a stylesheet to whatever the default browser style is
 			// for such an element
 			if ( elem.style.display === "" && isHidden( elem ) ) {
-				values[ index ] = jQuery._data( elem, "olddisplay", defaultDisplay(elem.nodeName) );
+				values[ index ] =
+					jQuery._data( elem, "olddisplay", defaultDisplay( elem.nodeName ) );
 			}
 		} else {
 			hidden = isHidden( elem );
 
 			if ( display && display !== "none" || !hidden ) {
-				jQuery._data( elem, "olddisplay", hidden ? display : jQuery.css( elem, "display" ) );
+				jQuery._data(
+					elem,
+					"olddisplay",
+					hidden ? display : jQuery.css( elem, "display" )
+				);
 			}
 		}
 	}
@@ -6539,6 +6938,7 @@ function showHide( elements, show ) {
 function setPositiveNumber( elem, value, subtract ) {
 	var matches = rnumsplit.exec( value );
 	return matches ?
+
 		// Guard against undefined "subtract", e.g., when used as in cssHooks
 		Math.max( 0, matches[ 1 ] - ( subtract || 0 ) ) + ( matches[ 2 ] || "px" ) :
 		value;
@@ -6546,20 +6946,24 @@ function setPositiveNumber( elem, value, subtract ) {
 
 function augmentWidthOrHeight( elem, name, extra, isBorderBox, styles ) {
 	var i = extra === ( isBorderBox ? "border" : "content" ) ?
+
 		// If we already have the right measurement, avoid augmentation
 		4 :
+
 		// Otherwise initialize for horizontal or vertical properties
 		name === "width" ? 1 : 0,
 
 		val = 0;
 
 	for ( ; i < 4; i += 2 ) {
+
 		// both box models exclude margin, so add it if we want it
 		if ( extra === "margin" ) {
 			val += jQuery.css( elem, extra + cssExpand[ i ], true, styles );
 		}
 
 		if ( isBorderBox ) {
+
 			// border-box includes padding, so remove it if we want content
 			if ( extra === "content" ) {
 				val -= jQuery.css( elem, "padding" + cssExpand[ i ], true, styles );
@@ -6570,6 +6974,7 @@ function augmentWidthOrHeight( elem, name, extra, isBorderBox, styles ) {
 				val -= jQuery.css( elem, "border" + cssExpand[ i ] + "Width", true, styles );
 			}
 		} else {
+
 			// at this point, extra isn't content, so add padding
 			val += jQuery.css( elem, "padding" + cssExpand[ i ], true, styles );
 
@@ -6589,12 +6994,14 @@ function getWidthOrHeight( elem, name, extra ) {
 	var valueIsBorderBox = true,
 		val = name === "width" ? elem.offsetWidth : elem.offsetHeight,
 		styles = getStyles( elem ),
-		isBorderBox = support.boxSizing && jQuery.css( elem, "boxSizing", false, styles ) === "border-box";
+		isBorderBox = support.boxSizing &&
+			jQuery.css( elem, "boxSizing", false, styles ) === "border-box";
 
 	// some non-html elements return undefined for offsetWidth, so check for null/undefined
 	// svg - https://bugzilla.mozilla.org/show_bug.cgi?id=649285
 	// MathML - https://bugzilla.mozilla.org/show_bug.cgi?id=491668
 	if ( val <= 0 || val == null ) {
+
 		// Fall back to computed then uncomputed css if necessary
 		val = curCSS( elem, name, styles );
 		if ( val < 0 || val == null ) {
@@ -6602,13 +7009,14 @@ function getWidthOrHeight( elem, name, extra ) {
 		}
 
 		// Computed unit is not pixels. Stop here and return.
-		if ( rnumnonpx.test(val) ) {
+		if ( rnumnonpx.test( val ) ) {
 			return val;
 		}
 
 		// we need the check for style in case a browser which returns unreliable values
 		// for getComputedStyle silently falls back to the reliable elem.style
-		valueIsBorderBox = isBorderBox && ( support.boxSizingReliable() || val === elem.style[ name ] );
+		valueIsBorderBox = isBorderBox &&
+			( support.boxSizingReliable() || val === elem.style[ name ] );
 
 		// Normalize "", auto, and prepare for extra
 		val = parseFloat( val ) || 0;
@@ -6626,13 +7034,15 @@ function getWidthOrHeight( elem, name, extra ) {
 	) + "px";
 }
 
-jQuery.extend({
+jQuery.extend( {
+
 	// Add in style property hooks for overriding the default
 	// behavior of getting and setting a style property
 	cssHooks: {
 		opacity: {
 			get: function( elem, computed ) {
 				if ( computed ) {
+
 					// We should always get a number back from opacity
 					var ret = curCSS( elem, "opacity" );
 					return ret === "" ? "1" : ret;
@@ -6643,6 +7053,7 @@ jQuery.extend({
 
 	// Don't automatically add "px" to these possibly-unitless properties
 	cssNumber: {
+		"animationIterationCount": true,
 		"columnCount": true,
 		"fillOpacity": true,
 		"flexGrow": true,
@@ -6660,12 +7071,14 @@ jQuery.extend({
 	// Add in properties whose names you wish to fix before
 	// setting or getting the value
 	cssProps: {
+
 		// normalize float css property
 		"float": support.cssFloat ? "cssFloat" : "styleFloat"
 	},
 
 	// Get and set the style property on a DOM Node
 	style: function( elem, name, value, extra ) {
+
 		// Don't set styles on text and comment nodes
 		if ( !elem || elem.nodeType === 3 || elem.nodeType === 8 || !elem.style ) {
 			return;
@@ -6676,7 +7089,8 @@ jQuery.extend({
 			origName = jQuery.camelCase( name ),
 			style = elem.style;
 
-		name = jQuery.cssProps[ origName ] || ( jQuery.cssProps[ origName ] = vendorPropName( style, origName ) );
+		name = jQuery.cssProps[ origName ] ||
+			( jQuery.cssProps[ origName ] = vendorPropName( origName ) || origName );
 
 		// gets hook for the prefixed version
 		// followed by the unprefixed version
@@ -6686,9 +7100,10 @@ jQuery.extend({
 		if ( value !== undefined ) {
 			type = typeof value;
 
-			// convert relative number strings (+= or -=) to relative numbers. #7345
-			if ( type === "string" && (ret = rrelNum.exec( value )) ) {
-				value = ( ret[1] + 1 ) * ret[2] + parseFloat( jQuery.css( elem, name ) );
+			// Convert "+=" or "-=" to relative numbers (#7345)
+			if ( type === "string" && ( ret = rcssNum.exec( value ) ) && ret[ 1 ] ) {
+				value = adjustCSS( elem, name, ret );
+
 				// Fixes bug #9237
 				type = "number";
 			}
@@ -6698,30 +7113,35 @@ jQuery.extend({
 				return;
 			}
 
-			// If a number was passed in, add 'px' to the (except for certain CSS properties)
-			if ( type === "number" && !jQuery.cssNumber[ origName ] ) {
-				value += "px";
+			// If a number was passed in, add the unit (except for certain CSS properties)
+			if ( type === "number" ) {
+				value += ret && ret[ 3 ] || ( jQuery.cssNumber[ origName ] ? "" : "px" );
 			}
 
 			// Fixes #8908, it can be done more correctly by specifing setters in cssHooks,
-			// but it would mean to define eight (for every problematic property) identical functions
-			if ( !support.clearCloneStyle && value === "" && name.indexOf("background") === 0 ) {
+			// but it would mean to define eight
+			// (for every problematic property) identical functions
+			if ( !support.clearCloneStyle && value === "" && name.indexOf( "background" ) === 0 ) {
 				style[ name ] = "inherit";
 			}
 
 			// If a hook was provided, use that value, otherwise just set the specified value
-			if ( !hooks || !("set" in hooks) || (value = hooks.set( elem, value, extra )) !== undefined ) {
+			if ( !hooks || !( "set" in hooks ) ||
+				( value = hooks.set( elem, value, extra ) ) !== undefined ) {
 
 				// Support: IE
 				// Swallow errors from 'invalid' CSS values (#5509)
 				try {
 					style[ name ] = value;
-				} catch(e) {}
+				} catch ( e ) {}
 			}
 
 		} else {
+
 			// If a hook was provided get the non-computed value from there
-			if ( hooks && "get" in hooks && (ret = hooks.get( elem, false, extra )) !== undefined ) {
+			if ( hooks && "get" in hooks &&
+				( ret = hooks.get( elem, false, extra ) ) !== undefined ) {
+
 				return ret;
 			}
 
@@ -6735,7 +7155,8 @@ jQuery.extend({
 			origName = jQuery.camelCase( name );
 
 		// Make sure that we're working with the right name
-		name = jQuery.cssProps[ origName ] || ( jQuery.cssProps[ origName ] = vendorPropName( elem.style, origName ) );
+		name = jQuery.cssProps[ origName ] ||
+			( jQuery.cssProps[ origName ] = vendorPropName( origName ) || origName );
 
 		// gets hook for the prefixed version
 		// followed by the unprefixed version
@@ -6759,23 +7180,25 @@ jQuery.extend({
 		// Return, converting to number if forced or a qualifier was provided and val looks numeric
 		if ( extra === "" || extra ) {
 			num = parseFloat( val );
-			return extra === true || jQuery.isNumeric( num ) ? num || 0 : val;
+			return extra === true || isFinite( num ) ? num || 0 : val;
 		}
 		return val;
 	}
-});
+} );
 
-jQuery.each([ "height", "width" ], function( i, name ) {
+jQuery.each( [ "height", "width" ], function( i, name ) {
 	jQuery.cssHooks[ name ] = {
 		get: function( elem, computed, extra ) {
 			if ( computed ) {
+
 				// certain elements can have dimension info if we invisibly show them
 				// however, it must have a current display style that would benefit from this
-				return rdisplayswap.test( jQuery.css( elem, "display" ) ) && elem.offsetWidth === 0 ?
-					jQuery.swap( elem, cssShow, function() {
-						return getWidthOrHeight( elem, name, extra );
-					}) :
-					getWidthOrHeight( elem, name, extra );
+				return rdisplayswap.test( jQuery.css( elem, "display" ) ) &&
+					elem.offsetWidth === 0 ?
+						swap( elem, cssShow, function() {
+							return getWidthOrHeight( elem, name, extra );
+						} ) :
+						getWidthOrHeight( elem, name, extra );
 			}
 		},
 
@@ -6786,21 +7209,25 @@ jQuery.each([ "height", "width" ], function( i, name ) {
 					elem,
 					name,
 					extra,
-					support.boxSizing && jQuery.css( elem, "boxSizing", false, styles ) === "border-box",
+					support.boxSizing &&
+						jQuery.css( elem, "boxSizing", false, styles ) === "border-box",
 					styles
 				) : 0
 			);
 		}
 	};
-});
+} );
 
 if ( !support.opacity ) {
 	jQuery.cssHooks.opacity = {
 		get: function( elem, computed ) {
+
 			// IE uses filters for opacity
-			return ropacity.test( (computed && elem.currentStyle ? elem.currentStyle.filter : elem.style.filter) || "" ) ?
-				( 0.01 * parseFloat( RegExp.$1 ) ) + "" :
-				computed ? "1" : "";
+			return ropacity.test( ( computed && elem.currentStyle ?
+				elem.currentStyle.filter :
+				elem.style.filter ) || "" ) ?
+					( 0.01 * parseFloat( RegExp.$1 ) ) + "" :
+					computed ? "1" : "";
 		},
 
 		set: function( elem, value ) {
@@ -6813,7 +7240,8 @@ if ( !support.opacity ) {
 			// Force it by setting the zoom level
 			style.zoom = 1;
 
-			// if setting opacity to 1, and no other filters exist - attempt to remove filter attribute #6652
+			// if setting opacity to 1, and no other filters exist -
+			// attempt to remove filter attribute #6652
 			// if value === "", then remove inline opacity #12685
 			if ( ( value >= 1 || value === "" ) &&
 					jQuery.trim( filter.replace( ralpha, "" ) ) === "" &&
@@ -6824,7 +7252,8 @@ if ( !support.opacity ) {
 				// style.removeAttribute is IE Only, but so apparently is this code path...
 				style.removeAttribute( "filter" );
 
-				// if there is no filter style applied in a css rule or unset inline opacity, we are done
+				// if there is no filter style applied in a css rule
+				// or unset inline opacity, we are done
 				if ( value === "" || currentStyle && !currentStyle.filter ) {
 					return;
 				}
@@ -6841,16 +7270,36 @@ if ( !support.opacity ) {
 jQuery.cssHooks.marginRight = addGetHookIf( support.reliableMarginRight,
 	function( elem, computed ) {
 		if ( computed ) {
-			// WebKit Bug 13343 - getComputedStyle returns wrong value for margin-right
-			// Work around by temporarily setting element display to inline-block
-			return jQuery.swap( elem, { "display": "inline-block" },
+			return swap( elem, { "display": "inline-block" },
 				curCSS, [ elem, "marginRight" ] );
 		}
 	}
 );
 
+jQuery.cssHooks.marginLeft = addGetHookIf( support.reliableMarginLeft,
+	function( elem, computed ) {
+		if ( computed ) {
+			return (
+				parseFloat( curCSS( elem, "marginLeft" ) ) ||
+
+				// Support: IE<=11+
+				// Running getBoundingClientRect on a disconnected node in IE throws an error
+				// Support: IE8 only
+				// getClientRects() errors on disconnected elems
+				( jQuery.contains( elem.ownerDocument, elem ) ?
+					elem.getBoundingClientRect().left -
+						swap( elem, { marginLeft: 0 }, function() {
+							return elem.getBoundingClientRect().left;
+						} ) :
+					0
+				)
+			) + "px";
+		}
+	}
+);
+
 // These hooks are used by animate to expand properties
-jQuery.each({
+jQuery.each( {
 	margin: "",
 	padding: "",
 	border: "Width"
@@ -6861,7 +7310,7 @@ jQuery.each({
 				expanded = {},
 
 				// assumes a single number if not a string
-				parts = typeof value === "string" ? value.split(" ") : [ value ];
+				parts = typeof value === "string" ? value.split( " " ) : [ value ];
 
 			for ( ; i < 4; i++ ) {
 				expanded[ prefix + cssExpand[ i ] + suffix ] =
@@ -6875,9 +7324,9 @@ jQuery.each({
 	if ( !rmargin.test( prefix ) ) {
 		jQuery.cssHooks[ prefix + suffix ].set = setPositiveNumber;
 	}
-});
+} );
 
-jQuery.fn.extend({
+jQuery.fn.extend( {
 	css: function( name, value ) {
 		return access( this, function( elem, name, value ) {
 			var styles, len,
@@ -6911,15 +7360,15 @@ jQuery.fn.extend({
 			return state ? this.show() : this.hide();
 		}
 
-		return this.each(function() {
+		return this.each( function() {
 			if ( isHidden( this ) ) {
 				jQuery( this ).show();
 			} else {
 				jQuery( this ).hide();
 			}
-		});
+		} );
 	}
-});
+} );
 
 
 function Tween( elem, options, prop, end, easing ) {
@@ -6932,7 +7381,7 @@ Tween.prototype = {
 	init: function( elem, options, prop, end, easing, unit ) {
 		this.elem = elem;
 		this.prop = prop;
-		this.easing = easing || "swing";
+		this.easing = easing || jQuery.easing._default;
 		this.options = options;
 		this.start = this.now = this.cur();
 		this.end = end;
@@ -6978,8 +7427,10 @@ Tween.propHooks = {
 		get: function( tween ) {
 			var result;
 
-			if ( tween.elem[ tween.prop ] != null &&
-				(!tween.elem.style || tween.elem.style[ tween.prop ] == null) ) {
+			// Use a property on the element directly when it is not a DOM element,
+			// or when there is no matching style property that exists.
+			if ( tween.elem.nodeType !== 1 ||
+				tween.elem[ tween.prop ] != null && tween.elem.style[ tween.prop ] == null ) {
 				return tween.elem[ tween.prop ];
 			}
 
@@ -6988,15 +7439,19 @@ Tween.propHooks = {
 			// so, simple values such as "10px" are parsed to Float.
 			// complex values such as "rotate(1rad)" are returned as is.
 			result = jQuery.css( tween.elem, tween.prop, "" );
+
 			// Empty strings, null, undefined and "auto" are converted to 0.
 			return !result || result === "auto" ? 0 : result;
 		},
 		set: function( tween ) {
+
 			// use step hook for back compat - use cssHook if its there - use .style if its
 			// available and use plain properties where available
 			if ( jQuery.fx.step[ tween.prop ] ) {
 				jQuery.fx.step[ tween.prop ]( tween );
-			} else if ( tween.elem.style && ( tween.elem.style[ jQuery.cssProps[ tween.prop ] ] != null || jQuery.cssHooks[ tween.prop ] ) ) {
+			} else if ( tween.elem.nodeType === 1 &&
+				( tween.elem.style[ jQuery.cssProps[ tween.prop ] ] != null ||
+					jQuery.cssHooks[ tween.prop ] ) ) {
 				jQuery.style( tween.elem, tween.prop, tween.now + tween.unit );
 			} else {
 				tween.elem[ tween.prop ] = tween.now;
@@ -7022,7 +7477,8 @@ jQuery.easing = {
 	},
 	swing: function( p ) {
 		return 0.5 - Math.cos( p * Math.PI ) / 2;
-	}
+	},
+	_default: "swing"
 };
 
 jQuery.fx = Tween.prototype.init;
@@ -7036,65 +7492,13 @@ jQuery.fx.step = {};
 var
 	fxNow, timerId,
 	rfxtypes = /^(?:toggle|show|hide)$/,
-	rfxnum = new RegExp( "^(?:([+-])=|)(" + pnum + ")([a-z%]*)$", "i" ),
-	rrun = /queueHooks$/,
-	animationPrefilters = [ defaultPrefilter ],
-	tweeners = {
-		"*": [ function( prop, value ) {
-			var tween = this.createTween( prop, value ),
-				target = tween.cur(),
-				parts = rfxnum.exec( value ),
-				unit = parts && parts[ 3 ] || ( jQuery.cssNumber[ prop ] ? "" : "px" ),
-
-				// Starting value computation is required for potential unit mismatches
-				start = ( jQuery.cssNumber[ prop ] || unit !== "px" && +target ) &&
-					rfxnum.exec( jQuery.css( tween.elem, prop ) ),
-				scale = 1,
-				maxIterations = 20;
-
-			if ( start && start[ 3 ] !== unit ) {
-				// Trust units reported by jQuery.css
-				unit = unit || start[ 3 ];
-
-				// Make sure we update the tween properties later on
-				parts = parts || [];
-
-				// Iteratively approximate from a nonzero starting point
-				start = +target || 1;
-
-				do {
-					// If previous iteration zeroed out, double until we get *something*
-					// Use a string for doubling factor so we don't accidentally see scale as unchanged below
-					scale = scale || ".5";
-
-					// Adjust and apply
-					start = start / scale;
-					jQuery.style( tween.elem, prop, start + unit );
-
-				// Update scale, tolerating zero or NaN from tween.cur()
-				// And breaking the loop if scale is unchanged or perfect, or if we've just had enough
-				} while ( scale !== (scale = tween.cur() / target) && scale !== 1 && --maxIterations );
-			}
-
-			// Update tween properties
-			if ( parts ) {
-				start = tween.start = +start || +target || 0;
-				tween.unit = unit;
-				// If a +=/-= token was provided, we're doing a relative animation
-				tween.end = parts[ 1 ] ?
-					start + ( parts[ 1 ] + 1 ) * parts[ 2 ] :
-					+parts[ 2 ];
-			}
-
-			return tween;
-		} ]
-	};
+	rrun = /queueHooks$/;
 
 // Animations created synchronously will run synchronously
 function createFxNow() {
-	setTimeout(function() {
+	window.setTimeout( function() {
 		fxNow = undefined;
-	});
+	} );
 	return ( fxNow = jQuery.now() );
 }
 
@@ -7121,11 +7525,11 @@ function genFx( type, includeWidth ) {
 
 function createTween( value, prop, animation ) {
 	var tween,
-		collection = ( tweeners[ prop ] || [] ).concat( tweeners[ "*" ] ),
+		collection = ( Animation.tweeners[ prop ] || [] ).concat( Animation.tweeners[ "*" ] ),
 		index = 0,
 		length = collection.length;
 	for ( ; index < length; index++ ) {
-		if ( (tween = collection[ index ].call( animation, prop, value )) ) {
+		if ( ( tween = collection[ index ].call( animation, prop, value ) ) ) {
 
 			// we're done with this property
 			return tween;
@@ -7156,20 +7560,22 @@ function defaultPrefilter( elem, props, opts ) {
 		}
 		hooks.unqueued++;
 
-		anim.always(function() {
+		anim.always( function() {
+
 			// doing this makes sure that the complete handler will be called
 			// before this completes
-			anim.always(function() {
+			anim.always( function() {
 				hooks.unqueued--;
 				if ( !jQuery.queue( elem, "fx" ).length ) {
 					hooks.empty.fire();
 				}
-			});
-		});
+			} );
+		} );
 	}
 
 	// height/width overflow pass
 	if ( elem.nodeType === 1 && ( "height" in props || "width" in props ) ) {
+
 		// Make sure that nothing sneaks out
 		// Record all 3 overflow attributes because IE does not
 		// change the overflow attribute when overflowX and
@@ -7199,11 +7605,11 @@ function defaultPrefilter( elem, props, opts ) {
 	if ( opts.overflow ) {
 		style.overflow = "hidden";
 		if ( !support.shrinkWrapBlocks() ) {
-			anim.always(function() {
+			anim.always( function() {
 				style.overflow = opts.overflow[ 0 ];
 				style.overflowX = opts.overflow[ 1 ];
 				style.overflowY = opts.overflow[ 2 ];
-			});
+			} );
 		}
 	}
 
@@ -7215,7 +7621,8 @@ function defaultPrefilter( elem, props, opts ) {
 			toggle = toggle || value === "toggle";
 			if ( value === ( hidden ? "hide" : "show" ) ) {
 
-				// If there is dataShow left over from a stopped hide or show and we are going to proceed with show, we should pretend to be hidden
+				// If there is dataShow left over from a stopped hide or show
+				// and we are going to proceed with show, we should pretend to be hidden
 				if ( value === "show" && dataShow && dataShow[ prop ] !== undefined ) {
 					hidden = true;
 				} else {
@@ -7246,17 +7653,17 @@ function defaultPrefilter( elem, props, opts ) {
 		if ( hidden ) {
 			jQuery( elem ).show();
 		} else {
-			anim.done(function() {
+			anim.done( function() {
 				jQuery( elem ).hide();
-			});
+			} );
 		}
-		anim.done(function() {
+		anim.done( function() {
 			var prop;
 			jQuery._removeData( elem, "fxshow" );
 			for ( prop in orig ) {
 				jQuery.style( elem, prop, orig[ prop ] );
 			}
-		});
+		} );
 		for ( prop in orig ) {
 			tween = createTween( hidden ? dataShow[ prop ] : 0, prop, anim );
 
@@ -7270,7 +7677,7 @@ function defaultPrefilter( elem, props, opts ) {
 		}
 
 	// If this is a noop like .hide().hide(), restore an overwritten display value
-	} else if ( (display === "none" ? defaultDisplay( elem.nodeName ) : display) === "inline" ) {
+	} else if ( ( display === "none" ? defaultDisplay( elem.nodeName ) : display ) === "inline" ) {
 		style.display = display;
 	}
 }
@@ -7316,18 +7723,21 @@ function Animation( elem, properties, options ) {
 	var result,
 		stopped,
 		index = 0,
-		length = animationPrefilters.length,
+		length = Animation.prefilters.length,
 		deferred = jQuery.Deferred().always( function() {
+
 			// don't match elem in the :animated selector
 			delete tick.elem;
-		}),
+		} ),
 		tick = function() {
 			if ( stopped ) {
 				return false;
 			}
 			var currentTime = fxNow || createFxNow(),
 				remaining = Math.max( 0, animation.startTime + animation.duration - currentTime ),
-				// archaic crash bug won't allow us to use 1 - ( 0.5 || 0 ) (#12497)
+
+				// Support: Android 2.3
+				// Archaic crash bug won't allow us to use `1 - ( 0.5 || 0 )` (#12497)
 				temp = remaining / animation.duration || 0,
 				percent = 1 - temp,
 				index = 0,
@@ -7337,7 +7747,7 @@ function Animation( elem, properties, options ) {
 				animation.tweens[ index ].run( percent );
 			}
 
-			deferred.notifyWith( elem, [ animation, percent, remaining ]);
+			deferred.notifyWith( elem, [ animation, percent, remaining ] );
 
 			if ( percent < 1 && length ) {
 				return remaining;
@@ -7346,10 +7756,13 @@ function Animation( elem, properties, options ) {
 				return false;
 			}
 		},
-		animation = deferred.promise({
+		animation = deferred.promise( {
 			elem: elem,
 			props: jQuery.extend( {}, properties ),
-			opts: jQuery.extend( true, { specialEasing: {} }, options ),
+			opts: jQuery.extend( true, {
+				specialEasing: {},
+				easing: jQuery.easing._default
+			}, options ),
 			originalProperties: properties,
 			originalOptions: options,
 			startTime: fxNow || createFxNow(),
@@ -7363,6 +7776,7 @@ function Animation( elem, properties, options ) {
 			},
 			stop: function( gotoEnd ) {
 				var index = 0,
+
 					// if we are going to the end, we want to run all the tweens
 					// otherwise we skip this part
 					length = gotoEnd ? animation.tweens.length : 0;
@@ -7377,20 +7791,25 @@ function Animation( elem, properties, options ) {
 				// resolve when we played the last frame
 				// otherwise, reject
 				if ( gotoEnd ) {
+					deferred.notifyWith( elem, [ animation, 1, 0 ] );
 					deferred.resolveWith( elem, [ animation, gotoEnd ] );
 				} else {
 					deferred.rejectWith( elem, [ animation, gotoEnd ] );
 				}
 				return this;
 			}
-		}),
+		} ),
 		props = animation.props;
 
 	propFilter( props, animation.opts.specialEasing );
 
 	for ( ; index < length ; index++ ) {
-		result = animationPrefilters[ index ].call( animation, elem, props, animation.opts );
+		result = Animation.prefilters[ index ].call( animation, elem, props, animation.opts );
 		if ( result ) {
+			if ( jQuery.isFunction( result.stop ) ) {
+				jQuery._queueHooks( animation.elem, animation.opts.queue ).stop =
+					jQuery.proxy( result.stop, result );
+			}
 			return result;
 		}
 	}
@@ -7406,7 +7825,7 @@ function Animation( elem, properties, options ) {
 			elem: elem,
 			anim: animation,
 			queue: animation.opts.queue
-		})
+		} )
 	);
 
 	// attach callbacks from options
@@ -7417,12 +7836,21 @@ function Animation( elem, properties, options ) {
 }
 
 jQuery.Animation = jQuery.extend( Animation, {
+
+	tweeners: {
+		"*": [ function( prop, value ) {
+			var tween = this.createTween( prop, value );
+			adjustCSS( tween.elem, prop, rcssNum.exec( value ), tween );
+			return tween;
+		} ]
+	},
+
 	tweener: function( props, callback ) {
 		if ( jQuery.isFunction( props ) ) {
 			callback = props;
 			props = [ "*" ];
 		} else {
-			props = props.split(" ");
+			props = props.match( rnotwhite );
 		}
 
 		var prop,
@@ -7431,19 +7859,21 @@ jQuery.Animation = jQuery.extend( Animation, {
 
 		for ( ; index < length ; index++ ) {
 			prop = props[ index ];
-			tweeners[ prop ] = tweeners[ prop ] || [];
-			tweeners[ prop ].unshift( callback );
+			Animation.tweeners[ prop ] = Animation.tweeners[ prop ] || [];
+			Animation.tweeners[ prop ].unshift( callback );
 		}
 	},
 
+	prefilters: [ defaultPrefilter ],
+
 	prefilter: function( callback, prepend ) {
 		if ( prepend ) {
-			animationPrefilters.unshift( callback );
+			Animation.prefilters.unshift( callback );
 		} else {
-			animationPrefilters.push( callback );
+			Animation.prefilters.push( callback );
 		}
 	}
-});
+} );
 
 jQuery.speed = function( speed, easing, fn ) {
 	var opt = speed && typeof speed === "object" ? jQuery.extend( {}, speed ) : {
@@ -7454,7 +7884,8 @@ jQuery.speed = function( speed, easing, fn ) {
 	};
 
 	opt.duration = jQuery.fx.off ? 0 : typeof opt.duration === "number" ? opt.duration :
-		opt.duration in jQuery.fx.speeds ? jQuery.fx.speeds[ opt.duration ] : jQuery.fx.speeds._default;
+		opt.duration in jQuery.fx.speeds ?
+			jQuery.fx.speeds[ opt.duration ] : jQuery.fx.speeds._default;
 
 	// normalize opt.queue - true/undefined/null -> "fx"
 	if ( opt.queue == null || opt.queue === true ) {
@@ -7477,19 +7908,20 @@ jQuery.speed = function( speed, easing, fn ) {
 	return opt;
 };
 
-jQuery.fn.extend({
+jQuery.fn.extend( {
 	fadeTo: function( speed, to, easing, callback ) {
 
 		// show any hidden elements after setting opacity to 0
 		return this.filter( isHidden ).css( "opacity", 0 ).show()
 
 			// animate to the value specified
-			.end().animate({ opacity: to }, speed, easing, callback );
+			.end().animate( { opacity: to }, speed, easing, callback );
 	},
 	animate: function( prop, speed, easing, callback ) {
 		var empty = jQuery.isEmptyObject( prop ),
 			optall = jQuery.speed( speed, easing, callback ),
 			doAnimation = function() {
+
 				// Operate on a copy of prop so per-property easing won't be lost
 				var anim = Animation( this, jQuery.extend( {}, prop ), optall );
 
@@ -7520,7 +7952,7 @@ jQuery.fn.extend({
 			this.queue( type || "fx", [] );
 		}
 
-		return this.each(function() {
+		return this.each( function() {
 			var dequeue = true,
 				index = type != null && type + "queueHooks",
 				timers = jQuery.timers,
@@ -7539,7 +7971,9 @@ jQuery.fn.extend({
 			}
 
 			for ( index = timers.length; index--; ) {
-				if ( timers[ index ].elem === this && (type == null || timers[ index ].queue === type) ) {
+				if ( timers[ index ].elem === this &&
+					( type == null || timers[ index ].queue === type ) ) {
+
 					timers[ index ].anim.stop( gotoEnd );
 					dequeue = false;
 					timers.splice( index, 1 );
@@ -7552,13 +7986,13 @@ jQuery.fn.extend({
 			if ( dequeue || !gotoEnd ) {
 				jQuery.dequeue( this, type );
 			}
-		});
+		} );
 	},
 	finish: function( type ) {
 		if ( type !== false ) {
 			type = type || "fx";
 		}
-		return this.each(function() {
+		return this.each( function() {
 			var index,
 				data = jQuery._data( this ),
 				queue = data[ type + "queue" ],
@@ -7593,24 +8027,24 @@ jQuery.fn.extend({
 
 			// turn off finishing flag
 			delete data.finish;
-		});
+		} );
 	}
-});
+} );
 
-jQuery.each([ "toggle", "show", "hide" ], function( i, name ) {
+jQuery.each( [ "toggle", "show", "hide" ], function( i, name ) {
 	var cssFn = jQuery.fn[ name ];
 	jQuery.fn[ name ] = function( speed, easing, callback ) {
 		return speed == null || typeof speed === "boolean" ?
 			cssFn.apply( this, arguments ) :
 			this.animate( genFx( name, true ), speed, easing, callback );
 	};
-});
+} );
 
 // Generate shortcuts for custom animations
-jQuery.each({
-	slideDown: genFx("show"),
-	slideUp: genFx("hide"),
-	slideToggle: genFx("toggle"),
+jQuery.each( {
+	slideDown: genFx( "show" ),
+	slideUp: genFx( "hide" ),
+	slideToggle: genFx( "toggle" ),
 	fadeIn: { opacity: "show" },
 	fadeOut: { opacity: "hide" },
 	fadeToggle: { opacity: "toggle" }
@@ -7618,7 +8052,7 @@ jQuery.each({
 	jQuery.fn[ name ] = function( speed, easing, callback ) {
 		return this.animate( props, speed, easing, callback );
 	};
-});
+} );
 
 jQuery.timers = [];
 jQuery.fx.tick = function() {
@@ -7630,6 +8064,7 @@ jQuery.fx.tick = function() {
 
 	for ( ; i < timers.length; i++ ) {
 		timer = timers[ i ];
+
 		// Checks the timer has not already been removed
 		if ( !timer() && timers[ i ] === timer ) {
 			timers.splice( i--, 1 );
@@ -7655,65 +8090,73 @@ jQuery.fx.interval = 13;
 
 jQuery.fx.start = function() {
 	if ( !timerId ) {
-		timerId = setInterval( jQuery.fx.tick, jQuery.fx.interval );
+		timerId = window.setInterval( jQuery.fx.tick, jQuery.fx.interval );
 	}
 };
 
 jQuery.fx.stop = function() {
-	clearInterval( timerId );
+	window.clearInterval( timerId );
 	timerId = null;
 };
 
 jQuery.fx.speeds = {
 	slow: 600,
 	fast: 200,
+
 	// Default speed
 	_default: 400
 };
 
 
 // Based off of the plugin by Clint Helfers, with permission.
-// http://blindsignals.com/index.php/2009/07/jquery-delay/
+// http://web.archive.org/web/20100324014747/http://blindsignals.com/index.php/2009/07/jquery-delay/
 jQuery.fn.delay = function( time, type ) {
 	time = jQuery.fx ? jQuery.fx.speeds[ time ] || time : time;
 	type = type || "fx";
 
 	return this.queue( type, function( next, hooks ) {
-		var timeout = setTimeout( next, time );
+		var timeout = window.setTimeout( next, time );
 		hooks.stop = function() {
-			clearTimeout( timeout );
+			window.clearTimeout( timeout );
 		};
-	});
+	} );
 };
 
 
-(function() {
-	// Minified: var a,b,c,d,e
-	var input, div, select, a, opt;
+( function() {
+	var a,
+		input = document.createElement( "input" ),
+		div = document.createElement( "div" ),
+		select = document.createElement( "select" ),
+		opt = select.appendChild( document.createElement( "option" ) );
 
 	// Setup
 	div = document.createElement( "div" );
 	div.setAttribute( "className", "t" );
 	div.innerHTML = "  <link/><table></table><a href='/a'>a</a><input type='checkbox'/>";
-	a = div.getElementsByTagName("a")[ 0 ];
+	a = div.getElementsByTagName( "a" )[ 0 ];
+
+	// Support: Windows Web Apps (WWA)
+	// `type` must use .setAttribute for WWA (#14901)
+	input.setAttribute( "type", "checkbox" );
+	div.appendChild( input );
+
+	a = div.getElementsByTagName( "a" )[ 0 ];
 
 	// First batch of tests.
-	select = document.createElement("select");
-	opt = select.appendChild( document.createElement("option") );
-	input = div.getElementsByTagName("input")[ 0 ];
-
 	a.style.cssText = "top:1px";
 
-	// Test setAttribute on camelCase class. If it works, we need attrFixes when doing get/setAttribute (ie6/7)
+	// Test setAttribute on camelCase class.
+	// If it works, we need attrFixes when doing get/setAttribute (ie6/7)
 	support.getSetAttribute = div.className !== "t";
 
 	// Get the style information from getAttribute
 	// (IE uses .cssText instead)
-	support.style = /top/.test( a.getAttribute("style") );
+	support.style = /top/.test( a.getAttribute( "style" ) );
 
 	// Make sure that URLs aren't manipulated
 	// (IE normalizes it by default)
-	support.hrefNormalized = a.getAttribute("href") === "/a";
+	support.hrefNormalized = a.getAttribute( "href" ) === "/a";
 
 	// Check the default checkbox/radio value ("" on WebKit; "on" elsewhere)
 	support.checkOn = !!input.value;
@@ -7723,7 +8166,7 @@ jQuery.fn.delay = function( time, type ) {
 	support.optSelected = opt.selected;
 
 	// Tests for enctype support on a form (#6743)
-	support.enctype = !!document.createElement("form").enctype;
+	support.enctype = !!document.createElement( "form" ).enctype;
 
 	// Make sure that the options inside disabled selects aren't marked as disabled
 	// (WebKit marks them as disabled)
@@ -7740,29 +8183,37 @@ jQuery.fn.delay = function( time, type ) {
 	input.value = "t";
 	input.setAttribute( "type", "radio" );
 	support.radioValue = input.value === "t";
-})();
+} )();
 
 
-var rreturn = /\r/g;
+var rreturn = /\r/g,
+	rspaces = /[\x20\t\r\n\f]+/g;
 
-jQuery.fn.extend({
+jQuery.fn.extend( {
 	val: function( value ) {
 		var hooks, ret, isFunction,
-			elem = this[0];
+			elem = this[ 0 ];
 
 		if ( !arguments.length ) {
 			if ( elem ) {
-				hooks = jQuery.valHooks[ elem.type ] || jQuery.valHooks[ elem.nodeName.toLowerCase() ];
+				hooks = jQuery.valHooks[ elem.type ] ||
+					jQuery.valHooks[ elem.nodeName.toLowerCase() ];
 
-				if ( hooks && "get" in hooks && (ret = hooks.get( elem, "value" )) !== undefined ) {
+				if (
+					hooks &&
+					"get" in hooks &&
+					( ret = hooks.get( elem, "value" ) ) !== undefined
+				) {
 					return ret;
 				}
 
 				ret = elem.value;
 
 				return typeof ret === "string" ?
+
 					// handle most common string cases
-					ret.replace(rreturn, "") :
+					ret.replace( rreturn, "" ) :
+
 					// handle cases where value is null/undef or number
 					ret == null ? "" : ret;
 			}
@@ -7772,7 +8223,7 @@ jQuery.fn.extend({
 
 		isFunction = jQuery.isFunction( value );
 
-		return this.each(function( i ) {
+		return this.each( function( i ) {
 			var val;
 
 			if ( this.nodeType !== 1 ) {
@@ -7793,29 +8244,32 @@ jQuery.fn.extend({
 			} else if ( jQuery.isArray( val ) ) {
 				val = jQuery.map( val, function( value ) {
 					return value == null ? "" : value + "";
-				});
+				} );
 			}
 
 			hooks = jQuery.valHooks[ this.type ] || jQuery.valHooks[ this.nodeName.toLowerCase() ];
 
 			// If set returns undefined, fall back to normal setting
-			if ( !hooks || !("set" in hooks) || hooks.set( this, val, "value" ) === undefined ) {
+			if ( !hooks || !( "set" in hooks ) || hooks.set( this, val, "value" ) === undefined ) {
 				this.value = val;
 			}
-		});
+		} );
 	}
-});
+} );
 
-jQuery.extend({
+jQuery.extend( {
 	valHooks: {
 		option: {
 			get: function( elem ) {
 				var val = jQuery.find.attr( elem, "value" );
 				return val != null ?
 					val :
+
 					// Support: IE10-11+
 					// option.text throws exceptions (#14686, #14858)
-					jQuery.trim( jQuery.text( elem ) );
+					// Strip and collapse whitespace
+					// https://html.spec.whatwg.org/#strip-and-collapse-whitespace
+					jQuery.trim( jQuery.text( elem ) ).replace( rspaces, " " );
 			}
 		},
 		select: {
@@ -7836,9 +8290,13 @@ jQuery.extend({
 
 					// oldIE doesn't update selected after form reset (#2551)
 					if ( ( option.selected || i === index ) &&
+
 							// Don't return options that are disabled or in a disabled optgroup
-							( support.optDisabled ? !option.disabled : option.getAttribute("disabled") === null ) &&
-							( !option.parentNode.disabled || !jQuery.nodeName( option.parentNode, "optgroup" ) ) ) {
+							( support.optDisabled ?
+								!option.disabled :
+								option.getAttribute( "disabled" ) === null ) &&
+							( !option.parentNode.disabled ||
+								!jQuery.nodeName( option.parentNode, "optgroup" ) ) ) {
 
 						// Get the specific value for the option
 						value = jQuery( option ).val();
@@ -7865,7 +8323,7 @@ jQuery.extend({
 				while ( i-- ) {
 					option = options[ i ];
 
-					if ( jQuery.inArray( jQuery.valHooks.option.get( option ), values ) >= 0 ) {
+					if ( jQuery.inArray( jQuery.valHooks.option.get( option ), values ) > -1 ) {
 
 						// Support: IE6
 						// When new option element is added to select box we need to
@@ -7894,25 +8352,23 @@ jQuery.extend({
 			}
 		}
 	}
-});
+} );
 
 // Radios and checkboxes getter/setter
-jQuery.each([ "radio", "checkbox" ], function() {
+jQuery.each( [ "radio", "checkbox" ], function() {
 	jQuery.valHooks[ this ] = {
 		set: function( elem, value ) {
 			if ( jQuery.isArray( value ) ) {
-				return ( elem.checked = jQuery.inArray( jQuery(elem).val(), value ) >= 0 );
+				return ( elem.checked = jQuery.inArray( jQuery( elem ).val(), value ) > -1 );
 			}
 		}
 	};
 	if ( !support.checkOn ) {
 		jQuery.valHooks[ this ].get = function( elem ) {
-			// Support: Webkit
-			// "" is returned instead of "on" if a value isn't specified
-			return elem.getAttribute("value") === null ? "on" : elem.value;
+			return elem.getAttribute( "value" ) === null ? "on" : elem.value;
 		};
 	}
-});
+} );
 
 
 
@@ -7923,30 +8379,30 @@ var nodeHook, boolHook,
 	getSetAttribute = support.getSetAttribute,
 	getSetInput = support.input;
 
-jQuery.fn.extend({
+jQuery.fn.extend( {
 	attr: function( name, value ) {
 		return access( this, jQuery.attr, name, value, arguments.length > 1 );
 	},
 
 	removeAttr: function( name ) {
-		return this.each(function() {
+		return this.each( function() {
 			jQuery.removeAttr( this, name );
-		});
+		} );
 	}
-});
+} );
 
-jQuery.extend({
+jQuery.extend( {
 	attr: function( elem, name, value ) {
-		var hooks, ret,
+		var ret, hooks,
 			nType = elem.nodeType;
 
-		// don't get/set attributes on text, comment and attribute nodes
-		if ( !elem || nType === 3 || nType === 8 || nType === 2 ) {
+		// Don't get/set attributes on text, comment and attribute nodes
+		if ( nType === 3 || nType === 8 || nType === 2 ) {
 			return;
 		}
 
 		// Fallback to prop when attributes are not supported
-		if ( typeof elem.getAttribute === strundefined ) {
+		if ( typeof elem.getAttribute === "undefined" ) {
 			return jQuery.prop( elem, name, value );
 		}
 
@@ -7959,28 +8415,46 @@ jQuery.extend({
 		}
 
 		if ( value !== undefined ) {
-
 			if ( value === null ) {
 				jQuery.removeAttr( elem, name );
-
-			} else if ( hooks && "set" in hooks && (ret = hooks.set( elem, value, name )) !== undefined ) {
-				return ret;
-
-			} else {
-				elem.setAttribute( name, value + "" );
-				return value;
+				return;
 			}
 
-		} else if ( hooks && "get" in hooks && (ret = hooks.get( elem, name )) !== null ) {
+			if ( hooks && "set" in hooks &&
+				( ret = hooks.set( elem, value, name ) ) !== undefined ) {
+				return ret;
+			}
+
+			elem.setAttribute( name, value + "" );
+			return value;
+		}
+
+		if ( hooks && "get" in hooks && ( ret = hooks.get( elem, name ) ) !== null ) {
 			return ret;
+		}
 
-		} else {
-			ret = jQuery.find.attr( elem, name );
+		ret = jQuery.find.attr( elem, name );
 
-			// Non-existent attributes return null, we normalize to undefined
-			return ret == null ?
-				undefined :
-				ret;
+		// Non-existent attributes return null, we normalize to undefined
+		return ret == null ? undefined : ret;
+	},
+
+	attrHooks: {
+		type: {
+			set: function( elem, value ) {
+				if ( !support.radioValue && value === "radio" &&
+					jQuery.nodeName( elem, "input" ) ) {
+
+					// Setting the type on a radio button after the value resets the value in IE8-9
+					// Reset value to default in case type is set after value during creation
+					var val = elem.value;
+					elem.setAttribute( "type", value );
+					if ( val ) {
+						elem.value = val;
+					}
+					return value;
+				}
+			}
 		}
 	},
 
@@ -7990,14 +8464,16 @@ jQuery.extend({
 			attrNames = value && value.match( rnotwhite );
 
 		if ( attrNames && elem.nodeType === 1 ) {
-			while ( (name = attrNames[i++]) ) {
+			while ( ( name = attrNames[ i++ ] ) ) {
 				propName = jQuery.propFix[ name ] || name;
 
 				// Boolean attributes get special treatment (#10870)
 				if ( jQuery.expr.match.bool.test( name ) ) {
+
 					// Set corresponding property to false
 					if ( getSetInput && getSetAttribute || !ruseDefault.test( name ) ) {
 						elem[ propName ] = false;
+
 					// Support: IE<9
 					// Also clear defaultChecked/defaultSelected (if appropriate)
 					} else {
@@ -8013,54 +8489,39 @@ jQuery.extend({
 				elem.removeAttribute( getSetAttribute ? name : propName );
 			}
 		}
-	},
-
-	attrHooks: {
-		type: {
-			set: function( elem, value ) {
-				if ( !support.radioValue && value === "radio" && jQuery.nodeName(elem, "input") ) {
-					// Setting the type on a radio button after the value resets the value in IE6-9
-					// Reset value to default in case type is set after value during creation
-					var val = elem.value;
-					elem.setAttribute( "type", value );
-					if ( val ) {
-						elem.value = val;
-					}
-					return value;
-				}
-			}
-		}
 	}
-});
+} );
 
-// Hook for boolean attributes
+// Hooks for boolean attributes
 boolHook = {
 	set: function( elem, value, name ) {
 		if ( value === false ) {
+
 			// Remove boolean attributes when set to false
 			jQuery.removeAttr( elem, name );
 		} else if ( getSetInput && getSetAttribute || !ruseDefault.test( name ) ) {
+
 			// IE<8 needs the *property* name
 			elem.setAttribute( !getSetAttribute && jQuery.propFix[ name ] || name, name );
 
-		// Use defaultChecked and defaultSelected for oldIE
 		} else {
+
+			// Support: IE<9
+			// Use defaultChecked and defaultSelected for oldIE
 			elem[ jQuery.camelCase( "default-" + name ) ] = elem[ name ] = true;
 		}
-
 		return name;
 	}
 };
 
-// Retrieve booleans specially
 jQuery.each( jQuery.expr.match.bool.source.match( /\w+/g ), function( i, name ) {
-
 	var getter = attrHandle[ name ] || jQuery.find.attr;
 
-	attrHandle[ name ] = getSetInput && getSetAttribute || !ruseDefault.test( name ) ?
-		function( elem, name, isXML ) {
+	if ( getSetInput && getSetAttribute || !ruseDefault.test( name ) ) {
+		attrHandle[ name ] = function( elem, name, isXML ) {
 			var ret, handle;
 			if ( !isXML ) {
+
 				// Avoid an infinite loop by temporarily removing this function from the getter
 				handle = attrHandle[ name ];
 				attrHandle[ name ] = ret;
@@ -8070,24 +8531,28 @@ jQuery.each( jQuery.expr.match.bool.source.match( /\w+/g ), function( i, name ) 
 				attrHandle[ name ] = handle;
 			}
 			return ret;
-		} :
-		function( elem, name, isXML ) {
+		};
+	} else {
+		attrHandle[ name ] = function( elem, name, isXML ) {
 			if ( !isXML ) {
 				return elem[ jQuery.camelCase( "default-" + name ) ] ?
 					name.toLowerCase() :
 					null;
 			}
 		};
-});
+	}
+} );
 
 // fix oldIE attroperties
 if ( !getSetInput || !getSetAttribute ) {
 	jQuery.attrHooks.value = {
 		set: function( elem, value, name ) {
 			if ( jQuery.nodeName( elem, "input" ) ) {
+
 				// Does not return so that setAttribute is also used
 				elem.defaultValue = value;
 			} else {
+
 				// Use nodeHook if defined (#1954); otherwise setAttribute is fine
 				return nodeHook && nodeHook.set( elem, value, name );
 			}
@@ -8102,11 +8567,12 @@ if ( !getSetAttribute ) {
 	// This fixes almost every IE6/7 issue
 	nodeHook = {
 		set: function( elem, value, name ) {
+
 			// Set the existing or create a new attribute node
 			var ret = elem.getAttributeNode( name );
 			if ( !ret ) {
 				elem.setAttributeNode(
-					(ret = elem.ownerDocument.createAttribute( name ))
+					( ret = elem.ownerDocument.createAttribute( name ) )
 				);
 			}
 
@@ -8124,7 +8590,7 @@ if ( !getSetAttribute ) {
 		function( elem, name, isXML ) {
 			var ret;
 			if ( !isXML ) {
-				return (ret = elem.getAttributeNode( name )) && ret.value !== "" ?
+				return ( ret = elem.getAttributeNode( name ) ) && ret.value !== "" ?
 					ret.value :
 					null;
 			}
@@ -8151,7 +8617,7 @@ if ( !getSetAttribute ) {
 
 	// Set width and height to auto instead of 0 on empty string( Bug #8150 )
 	// This is for removals
-	jQuery.each([ "width", "height" ], function( i, name ) {
+	jQuery.each( [ "width", "height" ], function( i, name ) {
 		jQuery.attrHooks[ name ] = {
 			set: function( elem, value ) {
 				if ( value === "" ) {
@@ -8160,15 +8626,16 @@ if ( !getSetAttribute ) {
 				}
 			}
 		};
-	});
+	} );
 }
 
 if ( !support.style ) {
 	jQuery.attrHooks.style = {
 		get: function( elem ) {
+
 			// Return undefined in the case of empty string
 			// Note: IE uppercases css property names, but if we were to .toLowerCase()
-			// .cssText, that would destroy case senstitivity in URL's, like in "background"
+			// .cssText, that would destroy case sensitivity in URL's, like in "background"
 			return elem.style.cssText || undefined;
 		},
 		set: function( elem, value ) {
@@ -8183,92 +8650,103 @@ if ( !support.style ) {
 var rfocusable = /^(?:input|select|textarea|button|object)$/i,
 	rclickable = /^(?:a|area)$/i;
 
-jQuery.fn.extend({
+jQuery.fn.extend( {
 	prop: function( name, value ) {
 		return access( this, jQuery.prop, name, value, arguments.length > 1 );
 	},
 
 	removeProp: function( name ) {
 		name = jQuery.propFix[ name ] || name;
-		return this.each(function() {
+		return this.each( function() {
+
 			// try/catch handles cases where IE balks (such as removing a property on window)
 			try {
 				this[ name ] = undefined;
 				delete this[ name ];
-			} catch( e ) {}
-		});
+			} catch ( e ) {}
+		} );
 	}
-});
+} );
 
-jQuery.extend({
-	propFix: {
-		"for": "htmlFor",
-		"class": "className"
-	},
-
+jQuery.extend( {
 	prop: function( elem, name, value ) {
-		var ret, hooks, notxml,
+		var ret, hooks,
 			nType = elem.nodeType;
 
-		// don't get/set properties on text, comment and attribute nodes
-		if ( !elem || nType === 3 || nType === 8 || nType === 2 ) {
+		// Don't get/set properties on text, comment and attribute nodes
+		if ( nType === 3 || nType === 8 || nType === 2 ) {
 			return;
 		}
 
-		notxml = nType !== 1 || !jQuery.isXMLDoc( elem );
+		if ( nType !== 1 || !jQuery.isXMLDoc( elem ) ) {
 
-		if ( notxml ) {
 			// Fix name and attach hooks
 			name = jQuery.propFix[ name ] || name;
 			hooks = jQuery.propHooks[ name ];
 		}
 
 		if ( value !== undefined ) {
-			return hooks && "set" in hooks && (ret = hooks.set( elem, value, name )) !== undefined ?
-				ret :
-				( elem[ name ] = value );
+			if ( hooks && "set" in hooks &&
+				( ret = hooks.set( elem, value, name ) ) !== undefined ) {
+				return ret;
+			}
 
-		} else {
-			return hooks && "get" in hooks && (ret = hooks.get( elem, name )) !== null ?
-				ret :
-				elem[ name ];
+			return ( elem[ name ] = value );
 		}
+
+		if ( hooks && "get" in hooks && ( ret = hooks.get( elem, name ) ) !== null ) {
+			return ret;
+		}
+
+		return elem[ name ];
 	},
 
 	propHooks: {
 		tabIndex: {
 			get: function( elem ) {
-				// elem.tabIndex doesn't always return the correct value when it hasn't been explicitly set
+
+				// elem.tabIndex doesn't always return the
+				// correct value when it hasn't been explicitly set
 				// http://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/
 				// Use proper attribute retrieval(#12072)
 				var tabindex = jQuery.find.attr( elem, "tabindex" );
 
 				return tabindex ?
 					parseInt( tabindex, 10 ) :
-					rfocusable.test( elem.nodeName ) || rclickable.test( elem.nodeName ) && elem.href ?
-						0 :
-						-1;
+					rfocusable.test( elem.nodeName ) ||
+						rclickable.test( elem.nodeName ) && elem.href ?
+							0 :
+							-1;
 			}
 		}
+	},
+
+	propFix: {
+		"for": "htmlFor",
+		"class": "className"
 	}
-});
+} );
 
 // Some attributes require a special call on IE
 // http://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx
 if ( !support.hrefNormalized ) {
+
 	// href/src property should get the full normalized URL (#10299/#12915)
-	jQuery.each([ "href", "src" ], function( i, name ) {
+	jQuery.each( [ "href", "src" ], function( i, name ) {
 		jQuery.propHooks[ name ] = {
 			get: function( elem ) {
 				return elem.getAttribute( name, 4 );
 			}
 		};
-	});
+	} );
 }
 
 // Support: Safari, IE9+
-// mis-reports the default selected property of an option
-// Accessing the parent's selectedIndex property fixes it
+// Accessing the selectedIndex property
+// forces the browser to respect setting selected
+// on the option
+// The getter ensures a default option is selected
+// when in an optgroup
 if ( !support.optSelected ) {
 	jQuery.propHooks.selected = {
 		get: function( elem ) {
@@ -8283,11 +8761,21 @@ if ( !support.optSelected ) {
 				}
 			}
 			return null;
+		},
+		set: function( elem ) {
+			var parent = elem.parentNode;
+			if ( parent ) {
+				parent.selectedIndex;
+
+				if ( parent.parentNode ) {
+					parent.parentNode.selectedIndex;
+				}
+			}
 		}
 	};
 }
 
-jQuery.each([
+jQuery.each( [
 	"tabIndex",
 	"readOnly",
 	"maxLength",
@@ -8300,7 +8788,7 @@ jQuery.each([
 	"contentEditable"
 ], function() {
 	jQuery.propFix[ this.toLowerCase() ] = this;
-});
+} );
 
 // IE6/7 call enctype encoding
 if ( !support.enctype ) {
@@ -8312,33 +8800,32 @@ if ( !support.enctype ) {
 
 var rclass = /[\t\r\n\f]/g;
 
-jQuery.fn.extend({
+function getClass( elem ) {
+	return jQuery.attr( elem, "class" ) || "";
+}
+
+jQuery.fn.extend( {
 	addClass: function( value ) {
-		var classes, elem, cur, clazz, j, finalValue,
-			i = 0,
-			len = this.length,
-			proceed = typeof value === "string" && value;
+		var classes, elem, cur, curValue, clazz, j, finalValue,
+			i = 0;
 
 		if ( jQuery.isFunction( value ) ) {
-			return this.each(function( j ) {
-				jQuery( this ).addClass( value.call( this, j, this.className ) );
-			});
+			return this.each( function( j ) {
+				jQuery( this ).addClass( value.call( this, j, getClass( this ) ) );
+			} );
 		}
 
-		if ( proceed ) {
-			// The disjunction here is for better compressibility (see removeClass)
-			classes = ( value || "" ).match( rnotwhite ) || [];
+		if ( typeof value === "string" && value ) {
+			classes = value.match( rnotwhite ) || [];
 
-			for ( ; i < len; i++ ) {
-				elem = this[ i ];
-				cur = elem.nodeType === 1 && ( elem.className ?
-					( " " + elem.className + " " ).replace( rclass, " " ) :
-					" "
-				);
+			while ( ( elem = this[ i++ ] ) ) {
+				curValue = getClass( elem );
+				cur = elem.nodeType === 1 &&
+					( " " + curValue + " " ).replace( rclass, " " );
 
 				if ( cur ) {
 					j = 0;
-					while ( (clazz = classes[j++]) ) {
+					while ( ( clazz = classes[ j++ ] ) ) {
 						if ( cur.indexOf( " " + clazz + " " ) < 0 ) {
 							cur += clazz + " ";
 						}
@@ -8346,8 +8833,8 @@ jQuery.fn.extend({
 
 					// only assign if different to avoid unneeded rendering.
 					finalValue = jQuery.trim( cur );
-					if ( elem.className !== finalValue ) {
-						elem.className = finalValue;
+					if ( curValue !== finalValue ) {
+						jQuery.attr( elem, "class", finalValue );
 					}
 				}
 			}
@@ -8357,40 +8844,43 @@ jQuery.fn.extend({
 	},
 
 	removeClass: function( value ) {
-		var classes, elem, cur, clazz, j, finalValue,
-			i = 0,
-			len = this.length,
-			proceed = arguments.length === 0 || typeof value === "string" && value;
+		var classes, elem, cur, curValue, clazz, j, finalValue,
+			i = 0;
 
 		if ( jQuery.isFunction( value ) ) {
-			return this.each(function( j ) {
-				jQuery( this ).removeClass( value.call( this, j, this.className ) );
-			});
+			return this.each( function( j ) {
+				jQuery( this ).removeClass( value.call( this, j, getClass( this ) ) );
+			} );
 		}
-		if ( proceed ) {
-			classes = ( value || "" ).match( rnotwhite ) || [];
 
-			for ( ; i < len; i++ ) {
-				elem = this[ i ];
+		if ( !arguments.length ) {
+			return this.attr( "class", "" );
+		}
+
+		if ( typeof value === "string" && value ) {
+			classes = value.match( rnotwhite ) || [];
+
+			while ( ( elem = this[ i++ ] ) ) {
+				curValue = getClass( elem );
+
 				// This expression is here for better compressibility (see addClass)
-				cur = elem.nodeType === 1 && ( elem.className ?
-					( " " + elem.className + " " ).replace( rclass, " " ) :
-					""
-				);
+				cur = elem.nodeType === 1 &&
+					( " " + curValue + " " ).replace( rclass, " " );
 
 				if ( cur ) {
 					j = 0;
-					while ( (clazz = classes[j++]) ) {
+					while ( ( clazz = classes[ j++ ] ) ) {
+
 						// Remove *all* instances
-						while ( cur.indexOf( " " + clazz + " " ) >= 0 ) {
+						while ( cur.indexOf( " " + clazz + " " ) > -1 ) {
 							cur = cur.replace( " " + clazz + " ", " " );
 						}
 					}
 
-					// only assign if different to avoid unneeded rendering.
-					finalValue = value ? jQuery.trim( cur ) : "";
-					if ( elem.className !== finalValue ) {
-						elem.className = finalValue;
+					// Only assign if different to avoid unneeded rendering.
+					finalValue = jQuery.trim( cur );
+					if ( curValue !== finalValue ) {
+						jQuery.attr( elem, "class", finalValue );
 					}
 				}
 			}
@@ -8407,21 +8897,27 @@ jQuery.fn.extend({
 		}
 
 		if ( jQuery.isFunction( value ) ) {
-			return this.each(function( i ) {
-				jQuery( this ).toggleClass( value.call(this, i, this.className, stateVal), stateVal );
-			});
+			return this.each( function( i ) {
+				jQuery( this ).toggleClass(
+					value.call( this, i, getClass( this ), stateVal ),
+					stateVal
+				);
+			} );
 		}
 
-		return this.each(function() {
-			if ( type === "string" ) {
-				// toggle individual class names
-				var className,
-					i = 0,
-					self = jQuery( this ),
-					classNames = value.match( rnotwhite ) || [];
+		return this.each( function() {
+			var className, i, self, classNames;
 
-				while ( (className = classNames[ i++ ]) ) {
-					// check each className given, space separated list
+			if ( type === "string" ) {
+
+				// Toggle individual class names
+				i = 0;
+				self = jQuery( this );
+				classNames = value.match( rnotwhite ) || [];
+
+				while ( ( className = classNames[ i++ ] ) ) {
+
+					// Check each className given, space separated list
 					if ( self.hasClass( className ) ) {
 						self.removeClass( className );
 					} else {
@@ -8430,34 +8926,44 @@ jQuery.fn.extend({
 				}
 
 			// Toggle whole class name
-			} else if ( type === strundefined || type === "boolean" ) {
-				if ( this.className ) {
+			} else if ( value === undefined || type === "boolean" ) {
+				className = getClass( this );
+				if ( className ) {
+
 					// store className if set
-					jQuery._data( this, "__className__", this.className );
+					jQuery._data( this, "__className__", className );
 				}
 
 				// If the element has a class name or if we're passed "false",
 				// then remove the whole classname (if there was one, the above saved it).
 				// Otherwise bring back whatever was previously saved (if anything),
 				// falling back to the empty string if nothing was stored.
-				this.className = this.className || value === false ? "" : jQuery._data( this, "__className__" ) || "";
+				jQuery.attr( this, "class",
+					className || value === false ?
+					"" :
+					jQuery._data( this, "__className__" ) || ""
+				);
 			}
-		});
+		} );
 	},
 
 	hasClass: function( selector ) {
-		var className = " " + selector + " ",
-			i = 0,
-			l = this.length;
-		for ( ; i < l; i++ ) {
-			if ( this[i].nodeType === 1 && (" " + this[i].className + " ").replace(rclass, " ").indexOf( className ) >= 0 ) {
+		var className, elem,
+			i = 0;
+
+		className = " " + selector + " ";
+		while ( ( elem = this[ i++ ] ) ) {
+			if ( elem.nodeType === 1 &&
+				( " " + getClass( elem ) + " " ).replace( rclass, " " )
+					.indexOf( className ) > -1
+			) {
 				return true;
 			}
 		}
 
 		return false;
 	}
-});
+} );
 
 
 
@@ -8465,9 +8971,10 @@ jQuery.fn.extend({
 // Return jQuery for attributes-only inclusion
 
 
-jQuery.each( ("blur focus focusin focusout load resize scroll unload click dblclick " +
+jQuery.each( ( "blur focus focusin focusout load resize scroll unload click dblclick " +
 	"mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave " +
-	"change select submit keydown keypress keyup error contextmenu").split(" "), function( i, name ) {
+	"change select submit keydown keypress keyup error contextmenu" ).split( " " ),
+	function( i, name ) {
 
 	// Handle event binding
 	jQuery.fn[ name ] = function( data, fn ) {
@@ -8475,41 +8982,30 @@ jQuery.each( ("blur focus focusin focusout load resize scroll unload click dblcl
 			this.on( name, null, data, fn ) :
 			this.trigger( name );
 	};
-});
+} );
 
-jQuery.fn.extend({
+jQuery.fn.extend( {
 	hover: function( fnOver, fnOut ) {
 		return this.mouseenter( fnOver ).mouseleave( fnOut || fnOver );
-	},
-
-	bind: function( types, data, fn ) {
-		return this.on( types, null, data, fn );
-	},
-	unbind: function( types, fn ) {
-		return this.off( types, null, fn );
-	},
-
-	delegate: function( selector, types, data, fn ) {
-		return this.on( types, selector, data, fn );
-	},
-	undelegate: function( selector, types, fn ) {
-		// ( namespace ) or ( selector, types [, fn] )
-		return arguments.length === 1 ? this.off( selector, "**" ) : this.off( types, selector || "**", fn );
 	}
-});
+} );
 
+
+var location = window.location;
 
 var nonce = jQuery.now();
 
-var rquery = (/\?/);
+var rquery = ( /\?/ );
 
 
 
 var rvalidtokens = /(,)|(\[|{)|(}|])|"(?:[^"\\\r\n]|\\["\\\/bfnrt]|\\u[\da-fA-F]{4})*"\s*:?|true|false|null|-?(?!0\d)\d+(?:\.\d+|)(?:[eE][+-]?\d+|)/g;
 
 jQuery.parseJSON = function( data ) {
+
 	// Attempt to parse using the native JSON parser first
 	if ( window.JSON && window.JSON.parse ) {
+
 		// Support: Android 2.3
 		// Workaround failure to string-cast null input
 		return window.JSON.parse( data + "" );
@@ -8544,7 +9040,7 @@ jQuery.parseJSON = function( data ) {
 
 		// Remove this token
 		return "";
-	}) ) ?
+	} ) ) ?
 		( Function( "return " + str ) )() :
 		jQuery.error( "Invalid JSON: " + data );
 };
@@ -8558,14 +9054,14 @@ jQuery.parseXML = function( data ) {
 	}
 	try {
 		if ( window.DOMParser ) { // Standard
-			tmp = new DOMParser();
+			tmp = new window.DOMParser();
 			xml = tmp.parseFromString( data, "text/xml" );
 		} else { // IE
-			xml = new ActiveXObject( "Microsoft.XMLDOM" );
+			xml = new window.ActiveXObject( "Microsoft.XMLDOM" );
 			xml.async = "false";
 			xml.loadXML( data );
 		}
-	} catch( e ) {
+	} catch ( e ) {
 		xml = undefined;
 	}
 	if ( !xml || !xml.documentElement || xml.getElementsByTagName( "parsererror" ).length ) {
@@ -8576,13 +9072,12 @@ jQuery.parseXML = function( data ) {
 
 
 var
-	// Document location
-	ajaxLocParts,
-	ajaxLocation,
-
 	rhash = /#.*$/,
 	rts = /([?&])_=[^&]*/,
-	rheaders = /^(.*?):[ \t]*([^\r\n]*)\r?$/mg, // IE leaves an \r character at EOL
+
+	// IE leaves an \r character at EOL
+	rheaders = /^(.*?):[ \t]*([^\r\n]*)\r?$/mg,
+
 	// #7653, #8125, #8152: local protocol detection
 	rlocalProtocol = /^(?:about|app|app-storage|.+-extension|file|res|widget):$/,
 	rnoContent = /^(?:GET|HEAD)$/,
@@ -8608,22 +9103,13 @@ var
 	transports = {},
 
 	// Avoid comment-prolog char sequence (#10098); must appease lint and evade compression
-	allTypes = "*/".concat("*");
+	allTypes = "*/".concat( "*" ),
 
-// #8138, IE may throw an exception when accessing
-// a field from window.location if document.domain has been set
-try {
-	ajaxLocation = location.href;
-} catch( e ) {
-	// Use the href attribute of an A element
-	// since IE will modify it given document.location
-	ajaxLocation = document.createElement( "a" );
-	ajaxLocation.href = "";
-	ajaxLocation = ajaxLocation.href;
-}
+	// Document location
+	ajaxLocation = location.href,
 
-// Segment location into parts
-ajaxLocParts = rurl.exec( ajaxLocation.toLowerCase() ) || [];
+	// Segment location into parts
+	ajaxLocParts = rurl.exec( ajaxLocation.toLowerCase() ) || [];
 
 // Base "constructor" for jQuery.ajaxPrefilter and jQuery.ajaxTransport
 function addToPrefiltersOrTransports( structure ) {
@@ -8641,16 +9127,18 @@ function addToPrefiltersOrTransports( structure ) {
 			dataTypes = dataTypeExpression.toLowerCase().match( rnotwhite ) || [];
 
 		if ( jQuery.isFunction( func ) ) {
+
 			// For each dataType in the dataTypeExpression
-			while ( (dataType = dataTypes[i++]) ) {
+			while ( ( dataType = dataTypes[ i++ ] ) ) {
+
 				// Prepend if requested
 				if ( dataType.charAt( 0 ) === "+" ) {
 					dataType = dataType.slice( 1 ) || "*";
-					(structure[ dataType ] = structure[ dataType ] || []).unshift( func );
+					( structure[ dataType ] = structure[ dataType ] || [] ).unshift( func );
 
 				// Otherwise append
 				} else {
-					(structure[ dataType ] = structure[ dataType ] || []).push( func );
+					( structure[ dataType ] = structure[ dataType ] || [] ).push( func );
 				}
 			}
 		}
@@ -8668,14 +9156,16 @@ function inspectPrefiltersOrTransports( structure, options, originalOptions, jqX
 		inspected[ dataType ] = true;
 		jQuery.each( structure[ dataType ] || [], function( _, prefilterOrFactory ) {
 			var dataTypeOrTransport = prefilterOrFactory( options, originalOptions, jqXHR );
-			if ( typeof dataTypeOrTransport === "string" && !seekingTransport && !inspected[ dataTypeOrTransport ] ) {
+			if ( typeof dataTypeOrTransport === "string" &&
+				!seekingTransport && !inspected[ dataTypeOrTransport ] ) {
+
 				options.dataTypes.unshift( dataTypeOrTransport );
 				inspect( dataTypeOrTransport );
 				return false;
 			} else if ( seekingTransport ) {
 				return !( selected = dataTypeOrTransport );
 			}
-		});
+		} );
 		return selected;
 	}
 
@@ -8691,7 +9181,7 @@ function ajaxExtend( target, src ) {
 
 	for ( key in src ) {
 		if ( src[ key ] !== undefined ) {
-			( flatOptions[ key ] ? target : ( deep || (deep = {}) ) )[ key ] = src[ key ];
+			( flatOptions[ key ] ? target : ( deep || ( deep = {} ) ) )[ key ] = src[ key ];
 		}
 	}
 	if ( deep ) {
@@ -8714,7 +9204,7 @@ function ajaxHandleResponses( s, jqXHR, responses ) {
 	while ( dataTypes[ 0 ] === "*" ) {
 		dataTypes.shift();
 		if ( ct === undefined ) {
-			ct = s.mimeType || jqXHR.getResponseHeader("Content-Type");
+			ct = s.mimeType || jqXHR.getResponseHeader( "Content-Type" );
 		}
 	}
 
@@ -8732,9 +9222,10 @@ function ajaxHandleResponses( s, jqXHR, responses ) {
 	if ( dataTypes[ 0 ] in responses ) {
 		finalDataType = dataTypes[ 0 ];
 	} else {
+
 		// Try convertible dataTypes
 		for ( type in responses ) {
-			if ( !dataTypes[ 0 ] || s.converters[ type + " " + dataTypes[0] ] ) {
+			if ( !dataTypes[ 0 ] || s.converters[ type + " " + dataTypes[ 0 ] ] ) {
 				finalDataType = type;
 				break;
 			}
@@ -8742,6 +9233,7 @@ function ajaxHandleResponses( s, jqXHR, responses ) {
 				firstDataType = type;
 			}
 		}
+
 		// Or just use first one
 		finalDataType = finalDataType || firstDataType;
 	}
@@ -8763,6 +9255,7 @@ function ajaxHandleResponses( s, jqXHR, responses ) {
 function ajaxConvert( s, response, jqXHR, isSuccess ) {
 	var conv2, current, conv, tmp, prev,
 		converters = {},
+
 		// Work with a copy of dataTypes in case we need to modify it for conversion
 		dataTypes = s.dataTypes.slice();
 
@@ -8815,6 +9308,7 @@ function ajaxConvert( s, response, jqXHR, isSuccess ) {
 							conv = converters[ prev + " " + tmp[ 0 ] ] ||
 								converters[ "* " + tmp[ 0 ] ];
 							if ( conv ) {
+
 								// Condense equivalence converters
 								if ( conv === true ) {
 									conv = converters[ conv2 ];
@@ -8834,13 +9328,16 @@ function ajaxConvert( s, response, jqXHR, isSuccess ) {
 				if ( conv !== true ) {
 
 					// Unless errors are allowed to bubble, catch and return them
-					if ( conv && s[ "throws" ] ) {
+					if ( conv && s[ "throws" ] ) { // jscs:ignore requireDotNotation
 						response = conv( response );
 					} else {
 						try {
 							response = conv( response );
 						} catch ( e ) {
-							return { state: "parsererror", error: conv ? e : "No conversion from " + prev + " to " + current };
+							return {
+								state: "parsererror",
+								error: conv ? e : "No conversion from " + prev + " to " + current
+							};
 						}
 					}
 				}
@@ -8851,7 +9348,7 @@ function ajaxConvert( s, response, jqXHR, isSuccess ) {
 	return { state: "success", data: response };
 }
 
-jQuery.extend({
+jQuery.extend( {
 
 	// Counter for holding the number of active queries
 	active: 0,
@@ -8889,9 +9386,9 @@ jQuery.extend({
 		},
 
 		contents: {
-			xml: /xml/,
-			html: /html/,
-			json: /json/
+			xml: /\bxml\b/,
+			html: /\bhtml/,
+			json: /\bjson\b/
 		},
 
 		responseFields: {
@@ -8955,14 +9452,20 @@ jQuery.extend({
 		// Force options to be an object
 		options = options || {};
 
-		var // Cross-domain detection vars
+		var
+
+			// Cross-domain detection vars
 			parts,
+
 			// Loop variable
 			i,
+
 			// URL without anti-cache param
 			cacheURL,
+
 			// Response headers as string
 			responseHeadersString,
+
 			// timeout handle
 			timeoutTimer,
 
@@ -8970,28 +9473,39 @@ jQuery.extend({
 			fireGlobals,
 
 			transport,
+
 			// Response headers
 			responseHeaders,
+
 			// Create the final options object
 			s = jQuery.ajaxSetup( {}, options ),
+
 			// Callbacks context
 			callbackContext = s.context || s,
+
 			// Context for global events is callbackContext if it is a DOM node or jQuery collection
-			globalEventContext = s.context && ( callbackContext.nodeType || callbackContext.jquery ) ?
-				jQuery( callbackContext ) :
-				jQuery.event,
+			globalEventContext = s.context &&
+				( callbackContext.nodeType || callbackContext.jquery ) ?
+					jQuery( callbackContext ) :
+					jQuery.event,
+
 			// Deferreds
 			deferred = jQuery.Deferred(),
-			completeDeferred = jQuery.Callbacks("once memory"),
+			completeDeferred = jQuery.Callbacks( "once memory" ),
+
 			// Status-dependent callbacks
 			statusCode = s.statusCode || {},
+
 			// Headers (they are sent all at once)
 			requestHeaders = {},
 			requestHeadersNames = {},
+
 			// The jqXHR state
 			state = 0,
+
 			// Default abort message
 			strAbort = "canceled",
+
 			// Fake xhr
 			jqXHR = {
 				readyState: 0,
@@ -9002,8 +9516,8 @@ jQuery.extend({
 					if ( state === 2 ) {
 						if ( !responseHeaders ) {
 							responseHeaders = {};
-							while ( (match = rheaders.exec( responseHeadersString )) ) {
-								responseHeaders[ match[1].toLowerCase() ] = match[ 2 ];
+							while ( ( match = rheaders.exec( responseHeadersString ) ) ) {
+								responseHeaders[ match[ 1 ].toLowerCase() ] = match[ 2 ];
 							}
 						}
 						match = responseHeaders[ key.toLowerCase() ];
@@ -9040,10 +9554,12 @@ jQuery.extend({
 					if ( map ) {
 						if ( state < 2 ) {
 							for ( code in map ) {
+
 								// Lazy-add the new callback in a way that preserves old ones
 								statusCode[ code ] = [ statusCode[ code ], map[ code ] ];
 							}
 						} else {
+
 							// Execute the appropriate callbacks
 							jqXHR.always( map[ jqXHR.status ] );
 						}
@@ -9071,7 +9587,9 @@ jQuery.extend({
 		// Add protocol if not provided (#5866: IE7 issue with protocol-less urls)
 		// Handle falsy url in the settings object (#10093: consistency with old signature)
 		// We also use the url parameter if available
-		s.url = ( ( url || s.url || ajaxLocation ) + "" ).replace( rhash, "" ).replace( rprotocol, ajaxLocParts[ 1 ] + "//" );
+		s.url = ( ( url || s.url || ajaxLocation ) + "" )
+			.replace( rhash, "" )
+			.replace( rprotocol, ajaxLocParts[ 1 ] + "//" );
 
 		// Alias method option to type as per ticket #12004
 		s.type = options.method || options.type || s.method || s.type;
@@ -9108,7 +9626,7 @@ jQuery.extend({
 
 		// Watch for a new set of requests
 		if ( fireGlobals && jQuery.active++ === 0 ) {
-			jQuery.event.trigger("ajaxStart");
+			jQuery.event.trigger( "ajaxStart" );
 		}
 
 		// Uppercase the type
@@ -9127,6 +9645,7 @@ jQuery.extend({
 			// If data is available, append data to url
 			if ( s.data ) {
 				cacheURL = ( s.url += ( rquery.test( cacheURL ) ? "&" : "?" ) + s.data );
+
 				// #9682: remove data so that it's not used in an eventual retry
 				delete s.data;
 			}
@@ -9161,8 +9680,9 @@ jQuery.extend({
 		// Set the Accepts header for the server, depending on the dataType
 		jqXHR.setRequestHeader(
 			"Accept",
-			s.dataTypes[ 0 ] && s.accepts[ s.dataTypes[0] ] ?
-				s.accepts[ s.dataTypes[0] ] + ( s.dataTypes[ 0 ] !== "*" ? ", " + allTypes + "; q=0.01" : "" ) :
+			s.dataTypes[ 0 ] && s.accepts[ s.dataTypes[ 0 ] ] ?
+				s.accepts[ s.dataTypes[ 0 ] ] +
+					( s.dataTypes[ 0 ] !== "*" ? ", " + allTypes + "; q=0.01" : "" ) :
 				s.accepts[ "*" ]
 		);
 
@@ -9172,7 +9692,9 @@ jQuery.extend({
 		}
 
 		// Allow custom headers/mimetypes and early abort
-		if ( s.beforeSend && ( s.beforeSend.call( callbackContext, jqXHR, s ) === false || state === 2 ) ) {
+		if ( s.beforeSend &&
+			( s.beforeSend.call( callbackContext, jqXHR, s ) === false || state === 2 ) ) {
+
 			// Abort if not done already and return
 			return jqXHR.abort();
 		}
@@ -9198,10 +9720,16 @@ jQuery.extend({
 			if ( fireGlobals ) {
 				globalEventContext.trigger( "ajaxSend", [ jqXHR, s ] );
 			}
+
+			// If request was aborted inside ajaxSend, stop there
+			if ( state === 2 ) {
+				return jqXHR;
+			}
+
 			// Timeout
 			if ( s.async && s.timeout > 0 ) {
-				timeoutTimer = setTimeout(function() {
-					jqXHR.abort("timeout");
+				timeoutTimer = window.setTimeout( function() {
+					jqXHR.abort( "timeout" );
 				}, s.timeout );
 			}
 
@@ -9209,9 +9737,11 @@ jQuery.extend({
 				state = 1;
 				transport.send( requestHeaders, done );
 			} catch ( e ) {
+
 				// Propagate exception as error if not done
 				if ( state < 2 ) {
 					done( -1, e );
+
 				// Simply rethrow otherwise
 				} else {
 					throw e;
@@ -9234,7 +9764,7 @@ jQuery.extend({
 
 			// Clear timeout if it exists
 			if ( timeoutTimer ) {
-				clearTimeout( timeoutTimer );
+				window.clearTimeout( timeoutTimer );
 			}
 
 			// Dereference transport for early garbage collection
@@ -9263,11 +9793,11 @@ jQuery.extend({
 
 				// Set the If-Modified-Since and/or If-None-Match header, if in ifModified mode.
 				if ( s.ifModified ) {
-					modified = jqXHR.getResponseHeader("Last-Modified");
+					modified = jqXHR.getResponseHeader( "Last-Modified" );
 					if ( modified ) {
 						jQuery.lastModified[ cacheURL ] = modified;
 					}
-					modified = jqXHR.getResponseHeader("etag");
+					modified = jqXHR.getResponseHeader( "etag" );
 					if ( modified ) {
 						jQuery.etag[ cacheURL ] = modified;
 					}
@@ -9289,6 +9819,7 @@ jQuery.extend({
 					isSuccess = !error;
 				}
 			} else {
+
 				// We extract error from statusText
 				// then normalize statusText and status for non-aborts
 				error = statusText;
@@ -9325,9 +9856,10 @@ jQuery.extend({
 
 			if ( fireGlobals ) {
 				globalEventContext.trigger( "ajaxComplete", [ jqXHR, s ] );
+
 				// Handle the global AJAX counter
 				if ( !( --jQuery.active ) ) {
-					jQuery.event.trigger("ajaxStop");
+					jQuery.event.trigger( "ajaxStop" );
 				}
 			}
 		}
@@ -9342,10 +9874,11 @@ jQuery.extend({
 	getScript: function( url, callback ) {
 		return jQuery.get( url, undefined, callback, "script" );
 	}
-});
+} );
 
 jQuery.each( [ "get", "post" ], function( i, method ) {
 	jQuery[ method ] = function( url, data, callback, type ) {
+
 		// shift arguments if data argument was omitted
 		if ( jQuery.isFunction( data ) ) {
 			type = type || callback;
@@ -9353,46 +9886,51 @@ jQuery.each( [ "get", "post" ], function( i, method ) {
 			data = undefined;
 		}
 
-		return jQuery.ajax({
+		// The url can be an options object (which then must have .url)
+		return jQuery.ajax( jQuery.extend( {
 			url: url,
 			type: method,
 			dataType: type,
 			data: data,
 			success: callback
-		});
+		}, jQuery.isPlainObject( url ) && url ) );
 	};
-});
+} );
 
 
 jQuery._evalUrl = function( url ) {
-	return jQuery.ajax({
+	return jQuery.ajax( {
 		url: url,
+
+		// Make this explicit, since user can override this through ajaxSetup (#11264)
 		type: "GET",
 		dataType: "script",
+		cache: true,
 		async: false,
 		global: false,
 		"throws": true
-	});
+	} );
 };
 
 
-jQuery.fn.extend({
+jQuery.fn.extend( {
 	wrapAll: function( html ) {
 		if ( jQuery.isFunction( html ) ) {
-			return this.each(function(i) {
-				jQuery(this).wrapAll( html.call(this, i) );
-			});
+			return this.each( function( i ) {
+				jQuery( this ).wrapAll( html.call( this, i ) );
+			} );
 		}
 
-		if ( this[0] ) {
-			// The elements to wrap the target around
-			var wrap = jQuery( html, this[0].ownerDocument ).eq(0).clone(true);
+		if ( this[ 0 ] ) {
 
-			if ( this[0].parentNode ) {
-				wrap.insertBefore( this[0] );
+			// The elements to wrap the target around
+			var wrap = jQuery( html, this[ 0 ].ownerDocument ).eq( 0 ).clone( true );
+
+			if ( this[ 0 ].parentNode ) {
+				wrap.insertBefore( this[ 0 ] );
 			}
 
-			wrap.map(function() {
+			wrap.map( function() {
 				var elem = this;
 
 				while ( elem.firstChild && elem.firstChild.nodeType === 1 ) {
@@ -9400,7 +9938,7 @@ jQuery.fn.extend({
 				}
 
 				return elem;
-			}).append( this );
+			} ).append( this );
 		}
 
 		return this;
@@ -9408,12 +9946,12 @@ jQuery.fn.extend({
 
 	wrapInner: function( html ) {
 		if ( jQuery.isFunction( html ) ) {
-			return this.each(function(i) {
-				jQuery(this).wrapInner( html.call(this, i) );
-			});
+			return this.each( function( i ) {
+				jQuery( this ).wrapInner( html.call( this, i ) );
+			} );
 		}
 
-		return this.each(function() {
+		return this.each( function() {
 			var self = jQuery( this ),
 				contents = self.contents();
 
@@ -9423,33 +9961,54 @@ jQuery.fn.extend({
 			} else {
 				self.append( html );
 			}
-		});
+		} );
 	},
 
 	wrap: function( html ) {
 		var isFunction = jQuery.isFunction( html );
 
-		return this.each(function(i) {
-			jQuery( this ).wrapAll( isFunction ? html.call(this, i) : html );
-		});
+		return this.each( function( i ) {
+			jQuery( this ).wrapAll( isFunction ? html.call( this, i ) : html );
+		} );
 	},
 
 	unwrap: function() {
-		return this.parent().each(function() {
+		return this.parent().each( function() {
 			if ( !jQuery.nodeName( this, "body" ) ) {
 				jQuery( this ).replaceWith( this.childNodes );
 			}
-		}).end();
+		} ).end();
 	}
-});
+} );
 
+
+function getDisplay( elem ) {
+	return elem.style && elem.style.display || jQuery.css( elem, "display" );
+}
+
+function filterHidden( elem ) {
+
+	// Disconnected elements are considered hidden
+	if ( !jQuery.contains( elem.ownerDocument || document, elem ) ) {
+		return true;
+	}
+	while ( elem && elem.nodeType === 1 ) {
+		if ( getDisplay( elem ) === "none" || elem.type === "hidden" ) {
+			return true;
+		}
+		elem = elem.parentNode;
+	}
+	return false;
+}
 
 jQuery.expr.filters.hidden = function( elem ) {
+
 	// Support: Opera <= 12.12
 	// Opera reports offsetWidths and offsetHeights less than zero on some elements
-	return elem.offsetWidth <= 0 && elem.offsetHeight <= 0 ||
-		(!support.reliableHiddenOffsets() &&
-			((elem.style && elem.style.display) || jQuery.css( elem, "display" )) === "none");
+	return support.reliableHiddenOffsets() ?
+		( elem.offsetWidth <= 0 && elem.offsetHeight <= 0 &&
+			!elem.getClientRects().length ) :
+			filterHidden( elem );
 };
 
 jQuery.expr.filters.visible = function( elem ) {
@@ -9469,25 +10028,35 @@ function buildParams( prefix, obj, traditional, add ) {
 	var name;
 
 	if ( jQuery.isArray( obj ) ) {
+
 		// Serialize array item.
 		jQuery.each( obj, function( i, v ) {
 			if ( traditional || rbracket.test( prefix ) ) {
+
 				// Treat each array item as a scalar.
 				add( prefix, v );
 
 			} else {
+
 				// Item is non-scalar (array or object), encode its numeric index.
-				buildParams( prefix + "[" + ( typeof v === "object" ? i : "" ) + "]", v, traditional, add );
+				buildParams(
+					prefix + "[" + ( typeof v === "object" && v != null ? i : "" ) + "]",
+					v,
+					traditional,
+					add
+				);
 			}
-		});
+		} );
 
 	} else if ( !traditional && jQuery.type( obj ) === "object" ) {
+
 		// Serialize object item.
 		for ( name in obj ) {
 			buildParams( prefix + "[" + name + "]", obj[ name ], traditional, add );
 		}
 
 	} else {
+
 		// Serialize scalar item.
 		add( prefix, obj );
 	}
@@ -9499,6 +10068,7 @@ jQuery.param = function( a, traditional ) {
 	var prefix,
 		s = [],
 		add = function( key, value ) {
+
 			// If value is a function, invoke it and return its value
 			value = jQuery.isFunction( value ) ? value() : ( value == null ? "" : value );
 			s[ s.length ] = encodeURIComponent( key ) + "=" + encodeURIComponent( value );
@@ -9511,12 +10081,14 @@ jQuery.param = function( a, traditional ) {
 
 	// If an array was passed in, assume that it is an array of form elements.
 	if ( jQuery.isArray( a ) || ( a.jquery && !jQuery.isPlainObject( a ) ) ) {
+
 		// Serialize the form elements
 		jQuery.each( a, function() {
 			add( this.name, this.value );
-		});
+		} );
 
 	} else {
+
 		// If traditional, encode the "old" way (the way 1.3.2 or older
 		// did it), otherwise encode params recursively.
 		for ( prefix in a ) {
@@ -9528,24 +10100,26 @@ jQuery.param = function( a, traditional ) {
 	return s.join( "&" ).replace( r20, "+" );
 };
 
-jQuery.fn.extend({
+jQuery.fn.extend( {
 	serialize: function() {
 		return jQuery.param( this.serializeArray() );
 	},
 	serializeArray: function() {
-		return this.map(function() {
+		return this.map( function() {
+
 			// Can add propHook for "elements" to filter or add form elements
 			var elements = jQuery.prop( this, "elements" );
 			return elements ? jQuery.makeArray( elements ) : this;
-		})
-		.filter(function() {
+		} )
+		.filter( function() {
 			var type = this.type;
+
 			// Use .is(":disabled") so that fieldset[disabled] works
 			return this.name && !jQuery( this ).is( ":disabled" ) &&
 				rsubmittable.test( this.nodeName ) && !rsubmitterTypes.test( type ) &&
 				( this.checked || !rcheckableType.test( type ) );
-		})
-		.map(function( i, elem ) {
+		} )
+		.map( function( i, elem ) {
 			var val = jQuery( this ).val();
 
 			return val == null ?
@@ -9553,32 +10127,45 @@ jQuery.fn.extend({
 				jQuery.isArray( val ) ?
 					jQuery.map( val, function( val ) {
 						return { name: elem.name, value: val.replace( rCRLF, "\r\n" ) };
-					}) :
+					} ) :
 					{ name: elem.name, value: val.replace( rCRLF, "\r\n" ) };
-		}).get();
+		} ).get();
 	}
-});
+} );
 
 
 // Create the request object
 // (This is still attached to ajaxSettings for backward compatibility)
 jQuery.ajaxSettings.xhr = window.ActiveXObject !== undefined ?
-	// Support: IE6+
+
+	// Support: IE6-IE8
 	function() {
 
 		// XHR cannot access local files, always use ActiveX for that case
-		return !this.isLocal &&
+		if ( this.isLocal ) {
+			return createActiveXHR();
+		}
 
-			// Support: IE7-8
-			// oldIE XHR does not support non-RFC2616 methods (#13240)
-			// See http://msdn.microsoft.com/en-us/library/ie/ms536648(v=vs.85).aspx
-			// and http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9
-			// Although this check for six methods instead of eight
-			// since IE also does not support "trace" and "connect"
-			/^(get|post|head|put|delete|options)$/i.test( this.type ) &&
+		// Support: IE 9-11
+		// IE seems to error on cross-domain PATCH requests when ActiveX XHR
+		// is used. In IE 9+ always use the native XHR.
+		// Note: this condition won't catch Edge as it doesn't define
+		// document.documentMode but it also doesn't support ActiveX so it won't
+		// reach this code.
+		if ( document.documentMode > 8 ) {
+			return createStandardXHR();
+		}
 
+		// Support: IE<9
+		// oldIE XHR does not support non-RFC2616 methods (#13240)
+		// See http://msdn.microsoft.com/en-us/library/ie/ms536648(v=vs.85).aspx
+		// and http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9
+		// Although this check for six methods instead of eight
+		// since IE also does not support "trace" and "connect"
+		return /^(get|post|head|put|delete|options)$/i.test( this.type ) &&
 			createStandardXHR() || createActiveXHR();
 	} :
+
 	// For all other browsers, use the standard XMLHttpRequest object
 	createStandardXHR;
 
@@ -9594,7 +10181,7 @@ if ( window.attachEvent ) {
 		for ( var key in xhrCallbacks ) {
 			xhrCallbacks[ key ]( undefined, true );
 		}
-	});
+	} );
 }
 
 // Determine support properties
@@ -9604,7 +10191,8 @@ xhrSupported = support.ajax = !!xhrSupported;
 // Create transport if the browser can provide an xhr
 if ( xhrSupported ) {
 
-	jQuery.ajaxTransport(function( options ) {
+	jQuery.ajaxTransport( function( options ) {
+
 		// Cross domain only allowed if supported through XMLHttpRequest
 		if ( !options.crossDomain || support.cors ) {
 
@@ -9617,7 +10205,13 @@ if ( xhrSupported ) {
 						id = ++xhrId;
 
 					// Open the socket
-					xhr.open( options.type, options.url, options.async, options.username, options.password );
+					xhr.open(
+						options.type,
+						options.url,
+						options.async,
+						options.username,
+						options.password
+					);
 
 					// Apply custom fields if provided
 					if ( options.xhrFields ) {
@@ -9636,12 +10230,13 @@ if ( xhrSupported ) {
 					// akin to a jigsaw puzzle, we simply never set it to be sure.
 					// (it can always be set on a per-request basis or even using ajaxSetup)
 					// For same-domain requests, won't change header if already provided.
-					if ( !options.crossDomain && !headers["X-Requested-With"] ) {
-						headers["X-Requested-With"] = "XMLHttpRequest";
+					if ( !options.crossDomain && !headers[ "X-Requested-With" ] ) {
+						headers[ "X-Requested-With" ] = "XMLHttpRequest";
 					}
 
 					// Set headers
 					for ( i in headers ) {
+
 						// Support: IE<9
 						// IE's ActiveXObject throws a 'Type Mismatch' exception when setting
 						// request header to a null-value.
@@ -9664,6 +10259,7 @@ if ( xhrSupported ) {
 
 						// Was never called and is aborted or complete
 						if ( callback && ( isAbort || xhr.readyState === 4 ) ) {
+
 							// Clean up
 							delete xhrCallbacks[ id ];
 							callback = undefined;
@@ -9689,7 +10285,8 @@ if ( xhrSupported ) {
 								// statusText for faulty cross-domain requests
 								try {
 									statusText = xhr.statusText;
-								} catch( e ) {
+								} catch ( e ) {
+
 									// We normalize with Webkit giving an empty statusText
 									statusText = "";
 								}
@@ -9701,6 +10298,7 @@ if ( xhrSupported ) {
 								// can do given current implementations)
 								if ( !status && options.isLocal && !options.crossDomain ) {
 									status = responses.text ? 200 : 404;
+
 								// IE - #1450: sometimes returns 1223 when it should be 204
 								} else if ( status === 1223 ) {
 									status = 204;
@@ -9714,14 +10312,21 @@ if ( xhrSupported ) {
 						}
 					};
 
+					// Do send the request
+					// `xhr.send` may raise an exception, but it will be
+					// handled in jQuery.ajax (so no try/catch here)
 					if ( !options.async ) {
-						// if we're in sync mode we fire the callback
+
+						// If we're in sync mode we fire the callback
 						callback();
 					} else if ( xhr.readyState === 4 ) {
+
 						// (IE6 & IE7) if it's in cache and has been
 						// retrieved directly we need to fire the callback
-						setTimeout( callback );
+						window.setTimeout( callback );
 					} else {
+
+						// Register the callback, but delay it in case `xhr.send` throws
 						// Add to the list of active xhr callbacks
 						xhr.onreadystatechange = xhrCallbacks[ id ] = callback;
 					}
@@ -9734,32 +10339,33 @@ if ( xhrSupported ) {
 				}
 			};
 		}
-	});
+	} );
 }
 
 // Functions to create xhrs
 function createStandardXHR() {
 	try {
 		return new window.XMLHttpRequest();
-	} catch( e ) {}
+	} catch ( e ) {}
 }
 
 function createActiveXHR() {
 	try {
 		return new window.ActiveXObject( "Microsoft.XMLHTTP" );
-	} catch( e ) {}
+	} catch ( e ) {}
 }
 
 
 
 
 // Install script dataType
-jQuery.ajaxSetup({
+jQuery.ajaxSetup( {
 	accepts: {
-		script: "text/javascript, application/javascript, application/ecmascript, application/x-ecmascript"
+		script: "text/javascript, application/javascript, " +
+			"application/ecmascript, application/x-ecmascript"
 	},
 	contents: {
-		script: /(?:java|ecma)script/
+		script: /\b(?:java|ecma)script\b/
 	},
 	converters: {
 		"text script": function( text ) {
@@ -9767,7 +10373,7 @@ jQuery.ajaxSetup({
 			return text;
 		}
 	}
-});
+} );
 
 // Handle cache's special case and global
 jQuery.ajaxPrefilter( "script", function( s ) {
@@ -9778,22 +10384,22 @@ jQuery.ajaxPrefilter( "script", function( s ) {
 		s.type = "GET";
 		s.global = false;
 	}
-});
+} );
 
 // Bind script tag hack transport
-jQuery.ajaxTransport( "script", function(s) {
+jQuery.ajaxTransport( "script", function( s ) {
 
 	// This transport only deals with cross domain requests
 	if ( s.crossDomain ) {
 
 		var script,
-			head = document.head || jQuery("head")[0] || document.documentElement;
+			head = document.head || jQuery( "head" )[ 0 ] || document.documentElement;
 
 		return {
 
 			send: function( _, callback ) {
 
-				script = document.createElement("script");
+				script = document.createElement( "script" );
 
 				script.async = true;
 
@@ -9838,7 +10444,7 @@ jQuery.ajaxTransport( "script", function(s) {
 			}
 		};
 	}
-});
+} );
 
 
 
@@ -9847,14 +10453,14 @@ var oldCallbacks = [],
 	rjsonp = /(=)\?(?=&|$)|\?\?/;
 
 // Default jsonp settings
-jQuery.ajaxSetup({
+jQuery.ajaxSetup( {
 	jsonp: "callback",
 	jsonpCallback: function() {
 		var callback = oldCallbacks.pop() || ( jQuery.expando + "_" + ( nonce++ ) );
 		this[ callback ] = true;
 		return callback;
 	}
-});
+} );
 
 // Detect, normalize options and install callbacks for jsonp requests
 jQuery.ajaxPrefilter( "json jsonp", function( s, originalSettings, jqXHR ) {
@@ -9862,7 +10468,10 @@ jQuery.ajaxPrefilter( "json jsonp", function( s, originalSettings, jqXHR ) {
 	var callbackName, overwritten, responseContainer,
 		jsonProp = s.jsonp !== false && ( rjsonp.test( s.url ) ?
 			"url" :
-			typeof s.data === "string" && !( s.contentType || "" ).indexOf("application/x-www-form-urlencoded") && rjsonp.test( s.data ) && "data"
+			typeof s.data === "string" &&
+				( s.contentType || "" )
+					.indexOf( "application/x-www-form-urlencoded" ) === 0 &&
+				rjsonp.test( s.data ) && "data"
 		);
 
 	// Handle iff the expected data type is "jsonp" or we have a parameter to set
@@ -9881,7 +10490,7 @@ jQuery.ajaxPrefilter( "json jsonp", function( s, originalSettings, jqXHR ) {
 		}
 
 		// Use data converter to retrieve json after script execution
-		s.converters["script json"] = function() {
+		s.converters[ "script json" ] = function() {
 			if ( !responseContainer ) {
 				jQuery.error( callbackName + " was not called" );
 			}
@@ -9898,12 +10507,20 @@ jQuery.ajaxPrefilter( "json jsonp", function( s, originalSettings, jqXHR ) {
 		};
 
 		// Clean-up function (fires after converters)
-		jqXHR.always(function() {
-			// Restore preexisting value
-			window[ callbackName ] = overwritten;
+		jqXHR.always( function() {
+
+			// If previous value didn't exist - remove it
+			if ( overwritten === undefined ) {
+				jQuery( window ).removeProp( callbackName );
+
+			// Otherwise restore preexisting value
+			} else {
+				window[ callbackName ] = overwritten;
+			}
 
 			// Save back as free
 			if ( s[ callbackName ] ) {
+
 				// make sure that re-using the options doesn't screw things around
 				s.jsonpCallback = originalSettings.jsonpCallback;
 
@@ -9917,18 +10534,19 @@ jQuery.ajaxPrefilter( "json jsonp", function( s, originalSettings, jqXHR ) {
 			}
 
 			responseContainer = overwritten = undefined;
-		});
+		} );
 
 		// Delegate to script
 		return "script";
 	}
-});
+} );
 
 
 
 
 // data: string of html
-// context (optional): If specified, the fragment will be created in this context, defaults to document
+// context (optional): If specified, the fragment will be created in this context,
+// defaults to document
 // keepScripts (optional): If true, will include scripts passed in the html string
 jQuery.parseHTML = function( data, context, keepScripts ) {
 	if ( !data || typeof data !== "string" ) {
@@ -9945,10 +10563,10 @@ jQuery.parseHTML = function( data, context, keepScripts ) {
 
 	// Single tag
 	if ( parsed ) {
-		return [ context.createElement( parsed[1] ) ];
+		return [ context.createElement( parsed[ 1 ] ) ];
 	}
 
-	parsed = jQuery.buildFragment( [ data ], context, scripts );
+	parsed = buildFragment( [ data ], context, scripts );
 
 	if ( scripts && scripts.length ) {
 		jQuery( scripts ).remove();
@@ -9969,11 +10587,11 @@ jQuery.fn.load = function( url, params, callback ) {
 		return _load.apply( this, arguments );
 	}
 
-	var selector, response, type,
+	var selector, type, response,
 		self = this,
-		off = url.indexOf(" ");
+		off = url.indexOf( " " );
 
-	if ( off >= 0 ) {
+	if ( off > -1 ) {
 		selector = jQuery.trim( url.slice( off, url.length ) );
 		url = url.slice( 0, off );
 	}
@@ -9992,14 +10610,16 @@ jQuery.fn.load = function( url, params, callback ) {
 
 	// If we have elements to modify, make the request
 	if ( self.length > 0 ) {
-		jQuery.ajax({
+		jQuery.ajax( {
 			url: url,
 
-			// if "type" variable is undefined, then "GET" method will be used
-			type: type,
+			// If "type" variable is undefined, then "GET" method will be used.
+			// Make value of this field explicit since
+			// user can override it through ajaxSetup method
+			type: type || "GET",
 			dataType: "html",
 			data: params
-		}).done(function( responseText ) {
+		} ).done( function( responseText ) {
 
 			// Save response for use in complete callback
 			response = arguments;
@@ -10008,14 +10628,19 @@ jQuery.fn.load = function( url, params, callback ) {
 
 				// If a selector was specified, locate the right elements in a dummy div
 				// Exclude scripts to avoid IE 'Permission Denied' errors
-				jQuery("<div>").append( jQuery.parseHTML( responseText ) ).find( selector ) :
+				jQuery( "<div>" ).append( jQuery.parseHTML( responseText ) ).find( selector ) :
 
 				// Otherwise use the full result
 				responseText );
 
-		}).complete( callback && function( jqXHR, status ) {
-			self.each( callback, response || [ jqXHR.responseText, status, jqXHR ] );
-		});
+		// If the request succeeds, this function gets "data", "status", "jqXHR"
+		// but they are ignored because response was set above.
+		// If it fails, this function gets "jqXHR", "status", "error"
+		} ).always( callback && function( jqXHR, status ) {
+			self.each( function() {
+				callback.apply( this, response || [ jqXHR.responseText, status, jqXHR ] );
+			} );
+		} );
 	}
 
 	return this;
@@ -10025,26 +10650,31 @@ jQuery.fn.load = function( url, params, callback ) {
 
 
 // Attach a bunch of functions for handling common AJAX events
-jQuery.each( [ "ajaxStart", "ajaxStop", "ajaxComplete", "ajaxError", "ajaxSuccess", "ajaxSend" ], function( i, type ) {
+jQuery.each( [
+	"ajaxStart",
+	"ajaxStop",
+	"ajaxComplete",
+	"ajaxError",
+	"ajaxSuccess",
+	"ajaxSend"
+], function( i, type ) {
 	jQuery.fn[ type ] = function( fn ) {
 		return this.on( type, fn );
 	};
-});
+} );
 
 
 
 
 jQuery.expr.filters.animated = function( elem ) {
-	return jQuery.grep(jQuery.timers, function( fn ) {
+	return jQuery.grep( jQuery.timers, function( fn ) {
 		return elem === fn.elem;
-	}).length;
+	} ).length;
 };
 
 
 
 
-
-var docElem = window.document.documentElement;
 
 /**
  * Gets a window from an element
@@ -10073,9 +10703,10 @@ jQuery.offset = {
 		curCSSTop = jQuery.css( elem, "top" );
 		curCSSLeft = jQuery.css( elem, "left" );
 		calculatePosition = ( position === "absolute" || position === "fixed" ) &&
-			jQuery.inArray("auto", [ curCSSTop, curCSSLeft ] ) > -1;
+			jQuery.inArray( "auto", [ curCSSTop, curCSSLeft ] ) > -1;
 
-		// need to be able to calculate position if either top or left is auto and position is either absolute or fixed
+		// need to be able to calculate position if either top or left
+		// is auto and position is either absolute or fixed
 		if ( calculatePosition ) {
 			curPosition = curElem.position();
 			curTop = curPosition.top;
@@ -10086,7 +10717,9 @@ jQuery.offset = {
 		}
 
 		if ( jQuery.isFunction( options ) ) {
-			options = options.call( elem, i, curOffset );
+
+			// Use jQuery.extend here to allow modification of coordinates argument (gh-1848)
+			options = options.call( elem, i, jQuery.extend( {}, curOffset ) );
 		}
 
 		if ( options.top != null ) {
@@ -10104,14 +10737,14 @@ jQuery.offset = {
 	}
 };
 
-jQuery.fn.extend({
+jQuery.fn.extend( {
 	offset: function( options ) {
 		if ( arguments.length ) {
 			return options === undefined ?
 				this :
-				this.each(function( i ) {
+				this.each( function( i ) {
 					jQuery.offset.setOffset( this, options, i );
-				});
+				} );
 		}
 
 		var docElem, win,
@@ -10132,7 +10765,7 @@ jQuery.fn.extend({
 
 		// If we don't have gBCR, just use 0,0 rather than error
 		// BlackBerry 5, iOS 3 (original iPhone)
-		if ( typeof elem.getBoundingClientRect !== strundefined ) {
+		if ( typeof elem.getBoundingClientRect !== "undefined" ) {
 			box = elem.getBoundingClientRect();
 		}
 		win = getWindow( doc );
@@ -10151,11 +10784,14 @@ jQuery.fn.extend({
 			parentOffset = { top: 0, left: 0 },
 			elem = this[ 0 ];
 
-		// fixed elements are offset from window (parentOffset = {top:0, left: 0}, because it is its only offset parent
+		// Fixed elements are offset from window (parentOffset = {top:0, left: 0},
+		// because it is its only offset parent
 		if ( jQuery.css( elem, "position" ) === "fixed" ) {
+
 			// we assume that getBoundingClientRect is available when computed position is fixed
 			offset = elem.getBoundingClientRect();
 		} else {
+
 			// Get *real* offsetParent
 			offsetParent = this.offsetParent();
 
@@ -10175,21 +10811,22 @@ jQuery.fn.extend({
 		// are the same in Safari causing offset.left to incorrectly be 0
 		return {
 			top:  offset.top  - parentOffset.top - jQuery.css( elem, "marginTop", true ),
-			left: offset.left - parentOffset.left - jQuery.css( elem, "marginLeft", true)
+			left: offset.left - parentOffset.left - jQuery.css( elem, "marginLeft", true )
 		};
 	},
 
 	offsetParent: function() {
-		return this.map(function() {
-			var offsetParent = this.offsetParent || docElem;
+		return this.map( function() {
+			var offsetParent = this.offsetParent;
 
-			while ( offsetParent && ( !jQuery.nodeName( offsetParent, "html" ) && jQuery.css( offsetParent, "position" ) === "static" ) ) {
+			while ( offsetParent && ( !jQuery.nodeName( offsetParent, "html" ) &&
+				jQuery.css( offsetParent, "position" ) === "static" ) ) {
 				offsetParent = offsetParent.offsetParent;
 			}
-			return offsetParent || docElem;
-		});
+			return offsetParent || documentElement;
+		} );
 	}
-});
+} );
 
 // Create scrollLeft and scrollTop methods
 jQuery.each( { scrollLeft: "pageXOffset", scrollTop: "pageYOffset" }, function( method, prop ) {
@@ -10200,7 +10837,7 @@ jQuery.each( { scrollLeft: "pageXOffset", scrollTop: "pageYOffset" }, function( 
 			var win = getWindow( elem );
 
 			if ( val === undefined ) {
-				return win ? (prop in win) ? win[ prop ] :
+				return win ? ( prop in win ) ? win[ prop ] :
 					win.document.documentElement[ method ] :
 					elem[ method ];
 			}
@@ -10216,8 +10853,9 @@ jQuery.each( { scrollLeft: "pageXOffset", scrollTop: "pageYOffset" }, function( 
 			}
 		}, method, val, arguments.length, null );
 	};
-});
+} );
 
+// Support: Safari<7-8+, Chrome<37-44+
 // Add the top/left cssHooks using jQuery.fn.position
 // Webkit bug: https://bugs.webkit.org/show_bug.cgi?id=29084
 // getComputedStyle returns percent when specified for top/left/bottom/right
@@ -10227,6 +10865,7 @@ jQuery.each( [ "top", "left" ], function( i, prop ) {
 		function( elem, computed ) {
 			if ( computed ) {
 				computed = curCSS( elem, prop );
+
 				// if curCSS returns percentage, fallback to offset
 				return rnumnonpx.test( computed ) ?
 					jQuery( elem ).position()[ prop ] + "px" :
@@ -10234,12 +10873,14 @@ jQuery.each( [ "top", "left" ], function( i, prop ) {
 			}
 		}
 	);
-});
+} );
 
 
 // Create innerHeight, innerWidth, height, width, outerHeight and outerWidth methods
 jQuery.each( { Height: "height", Width: "width" }, function( name, type ) {
-	jQuery.each( { padding: "inner" + name, content: type, "": "outer" + name }, function( defaultExtra, funcName ) {
+	jQuery.each( { padding: "inner" + name, content: type, "": "outer" + name },
+	function( defaultExtra, funcName ) {
+
 		// margin is only for outerHeight, outerWidth
 		jQuery.fn[ funcName ] = function( margin, value ) {
 			var chainable = arguments.length && ( defaultExtra || typeof margin !== "boolean" ),
@@ -10249,6 +10890,7 @@ jQuery.each( { Height: "height", Width: "width" }, function( name, type ) {
 				var doc;
 
 				if ( jQuery.isWindow( elem ) ) {
+
 					// As of 5/8/2012 this will yield incorrect results for Mobile Safari, but there
 					// isn't a whole lot we can do. See pull request at this URL for discussion:
 					// https://github.com/jquery/jquery/pull/764
@@ -10259,8 +10901,10 @@ jQuery.each( { Height: "height", Width: "width" }, function( name, type ) {
 				if ( elem.nodeType === 9 ) {
 					doc = elem.documentElement;
 
-					// Either scroll[Width/Height] or offset[Width/Height] or client[Width/Height], whichever is greatest
-					// unfortunately, this causes bug #3838 in IE6/8 only, but there is currently no good, small way to fix it.
+					// Either scroll[Width/Height] or offset[Width/Height] or client[Width/Height],
+					// whichever is greatest
+					// unfortunately, this causes bug #3838 in IE6/8 only,
+					// but there is currently no good, small way to fix it.
 					return Math.max(
 						elem.body[ "scroll" + name ], doc[ "scroll" + name ],
 						elem.body[ "offset" + name ], doc[ "offset" + name ],
@@ -10269,6 +10913,7 @@ jQuery.each( { Height: "height", Width: "width" }, function( name, type ) {
 				}
 
 				return value === undefined ?
+
 					// Get width or height on the element, requesting but not forcing parseFloat
 					jQuery.css( elem, type, extra ) :
 
@@ -10276,9 +10921,30 @@ jQuery.each( { Height: "height", Width: "width" }, function( name, type ) {
 					jQuery.style( elem, type, value, extra );
 			}, type, chainable ? margin : undefined, chainable, null );
 		};
-	});
-});
+	} );
+} );
 
+
+jQuery.fn.extend( {
+
+	bind: function( types, data, fn ) {
+		return this.on( types, null, data, fn );
+	},
+	unbind: function( types, fn ) {
+		return this.off( types, null, fn );
+	},
+
+	delegate: function( selector, types, data, fn ) {
+		return this.on( types, selector, data, fn );
+	},
+	undelegate: function( selector, types, fn ) {
+
+		// ( namespace ) or ( selector, types [, fn] )
+		return arguments.length === 1 ?
+			this.off( selector, "**" ) :
+			this.off( types, selector || "**", fn );
+	}
+} );
 
 // The number of elements contained in the matched element set
 jQuery.fn.size = function() {
@@ -10306,13 +10972,13 @@ jQuery.fn.andSelf = jQuery.fn.addBack;
 if ( typeof define === "function" && define.amd ) {
 	define( "jquery", [], function() {
 		return jQuery;
-	});
+	} );
 }
 
 
 
-
 var
+
 	// Map over jQuery in case of overwrite
 	_jQuery = window.jQuery,
 
@@ -10334,13 +11000,9 @@ jQuery.noConflict = function( deep ) {
 // Expose jQuery and $ identifiers, even in
 // AMD (#7102#comment:10, https://github.com/jquery/jquery/pull/557)
 // and CommonJS for browser emulators (#13566)
-if ( typeof noGlobal === strundefined ) {
+if ( !noGlobal ) {
 	window.jQuery = window.$ = jQuery;
 }
 
-
-
-
 return jQuery;
-
 }));

--- a/examples/backbone_marionette/node_modules/todomvc-app-css/index.css
+++ b/examples/backbone_marionette/node_modules/todomvc-app-css/index.css
@@ -197,8 +197,8 @@ label[for='toggle-all'] {
 }
 
 #todo-list li label {
-	white-space: pre-line;
-	word-break: break-all;
+	white-space: pre;
+	word-break: break-word;
 	padding: 15px 60px 15px 15px;
 	margin-left: 45px;
 	display: block;

--- a/examples/backbone_marionette/node_modules/todomvc-common/base.js
+++ b/examples/backbone_marionette/node_modules/todomvc-common/base.js
@@ -114,7 +114,12 @@
 	})({});
 
 	if (location.hostname === 'todomvc.com') {
-		window._gaq = [['_setAccount','UA-31081062-1'],['_trackPageview']];(function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src='//www.google-analytics.com/ga.js';s.parentNode.insertBefore(g,s)}(document,'script'));
+		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+		})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+		ga('create', 'UA-31081062-1', 'auto');
+		ga('send', 'pageview');
 	}
 	/* jshint ignore:end */
 
@@ -228,7 +233,7 @@
 			xhr.onload = function (e) {
 				var parsedResponse = JSON.parse(e.target.responseText);
 				if (parsedResponse instanceof Array) {
-					var count = parsedResponse.length
+					var count = parsedResponse.length;
 					if (count !== 0) {
 						issueLink.innerHTML = 'This app has ' + count + ' open issues';
 						document.getElementById('issue-count').style.display = 'inline';

--- a/examples/backbone_marionette/node_modules/underscore/underscore.js
+++ b/examples/backbone_marionette/node_modules/underscore/underscore.js
@@ -1,6 +1,6 @@
-//     Underscore.js 1.7.0
+//     Underscore.js 1.8.3
 //     http://underscorejs.org
-//     (c) 2009-2014 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+//     (c) 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
 //     Underscore may be freely distributed under the MIT license.
 
 (function() {
@@ -21,7 +21,6 @@
   var
     push             = ArrayProto.push,
     slice            = ArrayProto.slice,
-    concat           = ArrayProto.concat,
     toString         = ObjProto.toString,
     hasOwnProperty   = ObjProto.hasOwnProperty;
 
@@ -30,7 +29,11 @@
   var
     nativeIsArray      = Array.isArray,
     nativeKeys         = Object.keys,
-    nativeBind         = FuncProto.bind;
+    nativeBind         = FuncProto.bind,
+    nativeCreate       = Object.create;
+
+  // Naked function reference for surrogate-prototype-swapping.
+  var Ctor = function(){};
 
   // Create a safe reference to the Underscore object for use below.
   var _ = function(obj) {
@@ -52,12 +55,12 @@
   }
 
   // Current version.
-  _.VERSION = '1.7.0';
+  _.VERSION = '1.8.3';
 
   // Internal function that returns an efficient (for current engines) version
   // of the passed-in callback, to be repeatedly applied in other Underscore
   // functions.
-  var createCallback = function(func, context, argCount) {
+  var optimizeCb = function(func, context, argCount) {
     if (context === void 0) return func;
     switch (argCount == null ? 3 : argCount) {
       case 1: return function(value) {
@@ -81,11 +84,59 @@
   // A mostly-internal function to generate callbacks that can be applied
   // to each element in a collection, returning the desired result — either
   // identity, an arbitrary callback, a property matcher, or a property accessor.
-  _.iteratee = function(value, context, argCount) {
+  var cb = function(value, context, argCount) {
     if (value == null) return _.identity;
-    if (_.isFunction(value)) return createCallback(value, context, argCount);
-    if (_.isObject(value)) return _.matches(value);
+    if (_.isFunction(value)) return optimizeCb(value, context, argCount);
+    if (_.isObject(value)) return _.matcher(value);
     return _.property(value);
+  };
+  _.iteratee = function(value, context) {
+    return cb(value, context, Infinity);
+  };
+
+  // An internal function for creating assigner functions.
+  var createAssigner = function(keysFunc, undefinedOnly) {
+    return function(obj) {
+      var length = arguments.length;
+      if (length < 2 || obj == null) return obj;
+      for (var index = 1; index < length; index++) {
+        var source = arguments[index],
+            keys = keysFunc(source),
+            l = keys.length;
+        for (var i = 0; i < l; i++) {
+          var key = keys[i];
+          if (!undefinedOnly || obj[key] === void 0) obj[key] = source[key];
+        }
+      }
+      return obj;
+    };
+  };
+
+  // An internal function for creating a new object that inherits from another.
+  var baseCreate = function(prototype) {
+    if (!_.isObject(prototype)) return {};
+    if (nativeCreate) return nativeCreate(prototype);
+    Ctor.prototype = prototype;
+    var result = new Ctor;
+    Ctor.prototype = null;
+    return result;
+  };
+
+  var property = function(key) {
+    return function(obj) {
+      return obj == null ? void 0 : obj[key];
+    };
+  };
+
+  // Helper for collection methods to determine whether a collection
+  // should be iterated as an array or as an object
+  // Related: http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tolength
+  // Avoids a very nasty iOS 8 JIT bug on ARM-64. #2094
+  var MAX_ARRAY_INDEX = Math.pow(2, 53) - 1;
+  var getLength = property('length');
+  var isArrayLike = function(collection) {
+    var length = getLength(collection);
+    return typeof length == 'number' && length >= 0 && length <= MAX_ARRAY_INDEX;
   };
 
   // Collection Functions
@@ -95,11 +146,10 @@
   // Handles raw objects in addition to array-likes. Treats all
   // sparse array-likes as if they were dense.
   _.each = _.forEach = function(obj, iteratee, context) {
-    if (obj == null) return obj;
-    iteratee = createCallback(iteratee, context);
-    var i, length = obj.length;
-    if (length === +length) {
-      for (i = 0; i < length; i++) {
+    iteratee = optimizeCb(iteratee, context);
+    var i, length;
+    if (isArrayLike(obj)) {
+      for (i = 0, length = obj.length; i < length; i++) {
         iteratee(obj[i], i, obj);
       }
     } else {
@@ -113,77 +163,66 @@
 
   // Return the results of applying the iteratee to each element.
   _.map = _.collect = function(obj, iteratee, context) {
-    if (obj == null) return [];
-    iteratee = _.iteratee(iteratee, context);
-    var keys = obj.length !== +obj.length && _.keys(obj),
+    iteratee = cb(iteratee, context);
+    var keys = !isArrayLike(obj) && _.keys(obj),
         length = (keys || obj).length,
-        results = Array(length),
-        currentKey;
+        results = Array(length);
     for (var index = 0; index < length; index++) {
-      currentKey = keys ? keys[index] : index;
+      var currentKey = keys ? keys[index] : index;
       results[index] = iteratee(obj[currentKey], currentKey, obj);
     }
     return results;
   };
 
-  var reduceError = 'Reduce of empty array with no initial value';
+  // Create a reducing function iterating left or right.
+  function createReduce(dir) {
+    // Optimized iterator function as using arguments.length
+    // in the main function will deoptimize the, see #1991.
+    function iterator(obj, iteratee, memo, keys, index, length) {
+      for (; index >= 0 && index < length; index += dir) {
+        var currentKey = keys ? keys[index] : index;
+        memo = iteratee(memo, obj[currentKey], currentKey, obj);
+      }
+      return memo;
+    }
+
+    return function(obj, iteratee, memo, context) {
+      iteratee = optimizeCb(iteratee, context, 4);
+      var keys = !isArrayLike(obj) && _.keys(obj),
+          length = (keys || obj).length,
+          index = dir > 0 ? 0 : length - 1;
+      // Determine the initial value if none is provided.
+      if (arguments.length < 3) {
+        memo = obj[keys ? keys[index] : index];
+        index += dir;
+      }
+      return iterator(obj, iteratee, memo, keys, index, length);
+    };
+  }
 
   // **Reduce** builds up a single result from a list of values, aka `inject`,
   // or `foldl`.
-  _.reduce = _.foldl = _.inject = function(obj, iteratee, memo, context) {
-    if (obj == null) obj = [];
-    iteratee = createCallback(iteratee, context, 4);
-    var keys = obj.length !== +obj.length && _.keys(obj),
-        length = (keys || obj).length,
-        index = 0, currentKey;
-    if (arguments.length < 3) {
-      if (!length) throw new TypeError(reduceError);
-      memo = obj[keys ? keys[index++] : index++];
-    }
-    for (; index < length; index++) {
-      currentKey = keys ? keys[index] : index;
-      memo = iteratee(memo, obj[currentKey], currentKey, obj);
-    }
-    return memo;
-  };
+  _.reduce = _.foldl = _.inject = createReduce(1);
 
   // The right-associative version of reduce, also known as `foldr`.
-  _.reduceRight = _.foldr = function(obj, iteratee, memo, context) {
-    if (obj == null) obj = [];
-    iteratee = createCallback(iteratee, context, 4);
-    var keys = obj.length !== + obj.length && _.keys(obj),
-        index = (keys || obj).length,
-        currentKey;
-    if (arguments.length < 3) {
-      if (!index) throw new TypeError(reduceError);
-      memo = obj[keys ? keys[--index] : --index];
-    }
-    while (index--) {
-      currentKey = keys ? keys[index] : index;
-      memo = iteratee(memo, obj[currentKey], currentKey, obj);
-    }
-    return memo;
-  };
+  _.reduceRight = _.foldr = createReduce(-1);
 
   // Return the first value which passes a truth test. Aliased as `detect`.
   _.find = _.detect = function(obj, predicate, context) {
-    var result;
-    predicate = _.iteratee(predicate, context);
-    _.some(obj, function(value, index, list) {
-      if (predicate(value, index, list)) {
-        result = value;
-        return true;
-      }
-    });
-    return result;
+    var key;
+    if (isArrayLike(obj)) {
+      key = _.findIndex(obj, predicate, context);
+    } else {
+      key = _.findKey(obj, predicate, context);
+    }
+    if (key !== void 0 && key !== -1) return obj[key];
   };
 
   // Return all the elements that pass a truth test.
   // Aliased as `select`.
   _.filter = _.select = function(obj, predicate, context) {
     var results = [];
-    if (obj == null) return results;
-    predicate = _.iteratee(predicate, context);
+    predicate = cb(predicate, context);
     _.each(obj, function(value, index, list) {
       if (predicate(value, index, list)) results.push(value);
     });
@@ -192,19 +231,17 @@
 
   // Return all the elements for which a truth test fails.
   _.reject = function(obj, predicate, context) {
-    return _.filter(obj, _.negate(_.iteratee(predicate)), context);
+    return _.filter(obj, _.negate(cb(predicate)), context);
   };
 
   // Determine whether all of the elements match a truth test.
   // Aliased as `all`.
   _.every = _.all = function(obj, predicate, context) {
-    if (obj == null) return true;
-    predicate = _.iteratee(predicate, context);
-    var keys = obj.length !== +obj.length && _.keys(obj),
-        length = (keys || obj).length,
-        index, currentKey;
-    for (index = 0; index < length; index++) {
-      currentKey = keys ? keys[index] : index;
+    predicate = cb(predicate, context);
+    var keys = !isArrayLike(obj) && _.keys(obj),
+        length = (keys || obj).length;
+    for (var index = 0; index < length; index++) {
+      var currentKey = keys ? keys[index] : index;
       if (!predicate(obj[currentKey], currentKey, obj)) return false;
     }
     return true;
@@ -213,24 +250,22 @@
   // Determine if at least one element in the object matches a truth test.
   // Aliased as `any`.
   _.some = _.any = function(obj, predicate, context) {
-    if (obj == null) return false;
-    predicate = _.iteratee(predicate, context);
-    var keys = obj.length !== +obj.length && _.keys(obj),
-        length = (keys || obj).length,
-        index, currentKey;
-    for (index = 0; index < length; index++) {
-      currentKey = keys ? keys[index] : index;
+    predicate = cb(predicate, context);
+    var keys = !isArrayLike(obj) && _.keys(obj),
+        length = (keys || obj).length;
+    for (var index = 0; index < length; index++) {
+      var currentKey = keys ? keys[index] : index;
       if (predicate(obj[currentKey], currentKey, obj)) return true;
     }
     return false;
   };
 
-  // Determine if the array or object contains a given value (using `===`).
-  // Aliased as `include`.
-  _.contains = _.include = function(obj, target) {
-    if (obj == null) return false;
-    if (obj.length !== +obj.length) obj = _.values(obj);
-    return _.indexOf(obj, target) >= 0;
+  // Determine if the array or object contains a given item (using `===`).
+  // Aliased as `includes` and `include`.
+  _.contains = _.includes = _.include = function(obj, item, fromIndex, guard) {
+    if (!isArrayLike(obj)) obj = _.values(obj);
+    if (typeof fromIndex != 'number' || guard) fromIndex = 0;
+    return _.indexOf(obj, item, fromIndex) >= 0;
   };
 
   // Invoke a method (with arguments) on every item in a collection.
@@ -238,7 +273,8 @@
     var args = slice.call(arguments, 2);
     var isFunc = _.isFunction(method);
     return _.map(obj, function(value) {
-      return (isFunc ? method : value[method]).apply(value, args);
+      var func = isFunc ? method : value[method];
+      return func == null ? func : func.apply(value, args);
     });
   };
 
@@ -250,13 +286,13 @@
   // Convenience version of a common use case of `filter`: selecting only objects
   // containing specific `key:value` pairs.
   _.where = function(obj, attrs) {
-    return _.filter(obj, _.matches(attrs));
+    return _.filter(obj, _.matcher(attrs));
   };
 
   // Convenience version of a common use case of `find`: getting the first object
   // containing specific `key:value` pairs.
   _.findWhere = function(obj, attrs) {
-    return _.find(obj, _.matches(attrs));
+    return _.find(obj, _.matcher(attrs));
   };
 
   // Return the maximum element (or element-based computation).
@@ -264,7 +300,7 @@
     var result = -Infinity, lastComputed = -Infinity,
         value, computed;
     if (iteratee == null && obj != null) {
-      obj = obj.length === +obj.length ? obj : _.values(obj);
+      obj = isArrayLike(obj) ? obj : _.values(obj);
       for (var i = 0, length = obj.length; i < length; i++) {
         value = obj[i];
         if (value > result) {
@@ -272,7 +308,7 @@
         }
       }
     } else {
-      iteratee = _.iteratee(iteratee, context);
+      iteratee = cb(iteratee, context);
       _.each(obj, function(value, index, list) {
         computed = iteratee(value, index, list);
         if (computed > lastComputed || computed === -Infinity && result === -Infinity) {
@@ -289,7 +325,7 @@
     var result = Infinity, lastComputed = Infinity,
         value, computed;
     if (iteratee == null && obj != null) {
-      obj = obj.length === +obj.length ? obj : _.values(obj);
+      obj = isArrayLike(obj) ? obj : _.values(obj);
       for (var i = 0, length = obj.length; i < length; i++) {
         value = obj[i];
         if (value < result) {
@@ -297,7 +333,7 @@
         }
       }
     } else {
-      iteratee = _.iteratee(iteratee, context);
+      iteratee = cb(iteratee, context);
       _.each(obj, function(value, index, list) {
         computed = iteratee(value, index, list);
         if (computed < lastComputed || computed === Infinity && result === Infinity) {
@@ -312,7 +348,7 @@
   // Shuffle a collection, using the modern version of the
   // [Fisher-Yates shuffle](http://en.wikipedia.org/wiki/Fisher–Yates_shuffle).
   _.shuffle = function(obj) {
-    var set = obj && obj.length === +obj.length ? obj : _.values(obj);
+    var set = isArrayLike(obj) ? obj : _.values(obj);
     var length = set.length;
     var shuffled = Array(length);
     for (var index = 0, rand; index < length; index++) {
@@ -328,7 +364,7 @@
   // The internal `guard` argument allows it to work with `map`.
   _.sample = function(obj, n, guard) {
     if (n == null || guard) {
-      if (obj.length !== +obj.length) obj = _.values(obj);
+      if (!isArrayLike(obj)) obj = _.values(obj);
       return obj[_.random(obj.length - 1)];
     }
     return _.shuffle(obj).slice(0, Math.max(0, n));
@@ -336,7 +372,7 @@
 
   // Sort the object's values by a criterion produced by an iteratee.
   _.sortBy = function(obj, iteratee, context) {
-    iteratee = _.iteratee(iteratee, context);
+    iteratee = cb(iteratee, context);
     return _.pluck(_.map(obj, function(value, index, list) {
       return {
         value: value,
@@ -358,7 +394,7 @@
   var group = function(behavior) {
     return function(obj, iteratee, context) {
       var result = {};
-      iteratee = _.iteratee(iteratee, context);
+      iteratee = cb(iteratee, context);
       _.each(obj, function(value, index) {
         var key = iteratee(value, index, obj);
         behavior(result, value, key);
@@ -386,37 +422,24 @@
     if (_.has(result, key)) result[key]++; else result[key] = 1;
   });
 
-  // Use a comparator function to figure out the smallest index at which
-  // an object should be inserted so as to maintain order. Uses binary search.
-  _.sortedIndex = function(array, obj, iteratee, context) {
-    iteratee = _.iteratee(iteratee, context, 1);
-    var value = iteratee(obj);
-    var low = 0, high = array.length;
-    while (low < high) {
-      var mid = low + high >>> 1;
-      if (iteratee(array[mid]) < value) low = mid + 1; else high = mid;
-    }
-    return low;
-  };
-
   // Safely create a real, live array from anything iterable.
   _.toArray = function(obj) {
     if (!obj) return [];
     if (_.isArray(obj)) return slice.call(obj);
-    if (obj.length === +obj.length) return _.map(obj, _.identity);
+    if (isArrayLike(obj)) return _.map(obj, _.identity);
     return _.values(obj);
   };
 
   // Return the number of elements in an object.
   _.size = function(obj) {
     if (obj == null) return 0;
-    return obj.length === +obj.length ? obj.length : _.keys(obj).length;
+    return isArrayLike(obj) ? obj.length : _.keys(obj).length;
   };
 
   // Split a collection into two arrays: one whose elements all satisfy the given
   // predicate, and one whose elements all do not satisfy the predicate.
   _.partition = function(obj, predicate, context) {
-    predicate = _.iteratee(predicate, context);
+    predicate = cb(predicate, context);
     var pass = [], fail = [];
     _.each(obj, function(value, key, obj) {
       (predicate(value, key, obj) ? pass : fail).push(value);
@@ -433,30 +456,27 @@
   _.first = _.head = _.take = function(array, n, guard) {
     if (array == null) return void 0;
     if (n == null || guard) return array[0];
-    if (n < 0) return [];
-    return slice.call(array, 0, n);
+    return _.initial(array, array.length - n);
   };
 
   // Returns everything but the last entry of the array. Especially useful on
   // the arguments object. Passing **n** will return all the values in
-  // the array, excluding the last N. The **guard** check allows it to work with
-  // `_.map`.
+  // the array, excluding the last N.
   _.initial = function(array, n, guard) {
     return slice.call(array, 0, Math.max(0, array.length - (n == null || guard ? 1 : n)));
   };
 
   // Get the last element of an array. Passing **n** will return the last N
-  // values in the array. The **guard** check allows it to work with `_.map`.
+  // values in the array.
   _.last = function(array, n, guard) {
     if (array == null) return void 0;
     if (n == null || guard) return array[array.length - 1];
-    return slice.call(array, Math.max(array.length - n, 0));
+    return _.rest(array, Math.max(0, array.length - n));
   };
 
   // Returns everything but the first entry of the array. Aliased as `tail` and `drop`.
   // Especially useful on the arguments object. Passing an **n** will return
-  // the rest N values in the array. The **guard**
-  // check allows it to work with `_.map`.
+  // the rest N values in the array.
   _.rest = _.tail = _.drop = function(array, n, guard) {
     return slice.call(array, n == null || guard ? 1 : n);
   };
@@ -467,18 +487,20 @@
   };
 
   // Internal implementation of a recursive `flatten` function.
-  var flatten = function(input, shallow, strict, output) {
-    if (shallow && _.every(input, _.isArray)) {
-      return concat.apply(output, input);
-    }
-    for (var i = 0, length = input.length; i < length; i++) {
+  var flatten = function(input, shallow, strict, startIndex) {
+    var output = [], idx = 0;
+    for (var i = startIndex || 0, length = getLength(input); i < length; i++) {
       var value = input[i];
-      if (!_.isArray(value) && !_.isArguments(value)) {
-        if (!strict) output.push(value);
-      } else if (shallow) {
-        push.apply(output, value);
-      } else {
-        flatten(value, shallow, strict, output);
+      if (isArrayLike(value) && (_.isArray(value) || _.isArguments(value))) {
+        //flatten current level of array or arguments object
+        if (!shallow) value = flatten(value, shallow, strict);
+        var j = 0, len = value.length;
+        output.length += len;
+        while (j < len) {
+          output[idx++] = value[j++];
+        }
+      } else if (!strict) {
+        output[idx++] = value;
       }
     }
     return output;
@@ -486,7 +508,7 @@
 
   // Flatten out an array, either recursively (by default), or just one level.
   _.flatten = function(array, shallow) {
-    return flatten(array, shallow, false, []);
+    return flatten(array, shallow, false);
   };
 
   // Return a version of the array that does not contain the specified value(s).
@@ -498,27 +520,26 @@
   // been sorted, you have the option of using a faster algorithm.
   // Aliased as `unique`.
   _.uniq = _.unique = function(array, isSorted, iteratee, context) {
-    if (array == null) return [];
     if (!_.isBoolean(isSorted)) {
       context = iteratee;
       iteratee = isSorted;
       isSorted = false;
     }
-    if (iteratee != null) iteratee = _.iteratee(iteratee, context);
+    if (iteratee != null) iteratee = cb(iteratee, context);
     var result = [];
     var seen = [];
-    for (var i = 0, length = array.length; i < length; i++) {
-      var value = array[i];
+    for (var i = 0, length = getLength(array); i < length; i++) {
+      var value = array[i],
+          computed = iteratee ? iteratee(value, i, array) : value;
       if (isSorted) {
-        if (!i || seen !== value) result.push(value);
-        seen = value;
+        if (!i || seen !== computed) result.push(value);
+        seen = computed;
       } else if (iteratee) {
-        var computed = iteratee(value, i, array);
-        if (_.indexOf(seen, computed) < 0) {
+        if (!_.contains(seen, computed)) {
           seen.push(computed);
           result.push(value);
         }
-      } else if (_.indexOf(result, value) < 0) {
+      } else if (!_.contains(result, value)) {
         result.push(value);
       }
     }
@@ -528,16 +549,15 @@
   // Produce an array that contains the union: each distinct element from all of
   // the passed-in arrays.
   _.union = function() {
-    return _.uniq(flatten(arguments, true, true, []));
+    return _.uniq(flatten(arguments, true, true));
   };
 
   // Produce an array that contains every item shared between all the
   // passed-in arrays.
   _.intersection = function(array) {
-    if (array == null) return [];
     var result = [];
     var argsLength = arguments.length;
-    for (var i = 0, length = array.length; i < length; i++) {
+    for (var i = 0, length = getLength(array); i < length; i++) {
       var item = array[i];
       if (_.contains(result, item)) continue;
       for (var j = 1; j < argsLength; j++) {
@@ -551,7 +571,7 @@
   // Take the difference between one array and a number of other arrays.
   // Only the elements present in just the first array will remain.
   _.difference = function(array) {
-    var rest = flatten(slice.call(arguments, 1), true, true, []);
+    var rest = flatten(arguments, true, true, 1);
     return _.filter(array, function(value){
       return !_.contains(rest, value);
     });
@@ -559,23 +579,28 @@
 
   // Zip together multiple lists into a single array -- elements that share
   // an index go together.
-  _.zip = function(array) {
-    if (array == null) return [];
-    var length = _.max(arguments, 'length').length;
-    var results = Array(length);
-    for (var i = 0; i < length; i++) {
-      results[i] = _.pluck(arguments, i);
+  _.zip = function() {
+    return _.unzip(arguments);
+  };
+
+  // Complement of _.zip. Unzip accepts an array of arrays and groups
+  // each array's elements on shared indices
+  _.unzip = function(array) {
+    var length = array && _.max(array, getLength).length || 0;
+    var result = Array(length);
+
+    for (var index = 0; index < length; index++) {
+      result[index] = _.pluck(array, index);
     }
-    return results;
+    return result;
   };
 
   // Converts lists into objects. Pass either a single array of `[key, value]`
   // pairs, or two parallel arrays of the same length -- one of keys, and one of
   // the corresponding values.
   _.object = function(list, values) {
-    if (list == null) return {};
     var result = {};
-    for (var i = 0, length = list.length; i < length; i++) {
+    for (var i = 0, length = getLength(list); i < length; i++) {
       if (values) {
         result[list[i]] = values[i];
       } else {
@@ -585,40 +610,73 @@
     return result;
   };
 
+  // Generator function to create the findIndex and findLastIndex functions
+  function createPredicateIndexFinder(dir) {
+    return function(array, predicate, context) {
+      predicate = cb(predicate, context);
+      var length = getLength(array);
+      var index = dir > 0 ? 0 : length - 1;
+      for (; index >= 0 && index < length; index += dir) {
+        if (predicate(array[index], index, array)) return index;
+      }
+      return -1;
+    };
+  }
+
+  // Returns the first index on an array-like that passes a predicate test
+  _.findIndex = createPredicateIndexFinder(1);
+  _.findLastIndex = createPredicateIndexFinder(-1);
+
+  // Use a comparator function to figure out the smallest index at which
+  // an object should be inserted so as to maintain order. Uses binary search.
+  _.sortedIndex = function(array, obj, iteratee, context) {
+    iteratee = cb(iteratee, context, 1);
+    var value = iteratee(obj);
+    var low = 0, high = getLength(array);
+    while (low < high) {
+      var mid = Math.floor((low + high) / 2);
+      if (iteratee(array[mid]) < value) low = mid + 1; else high = mid;
+    }
+    return low;
+  };
+
+  // Generator function to create the indexOf and lastIndexOf functions
+  function createIndexFinder(dir, predicateFind, sortedIndex) {
+    return function(array, item, idx) {
+      var i = 0, length = getLength(array);
+      if (typeof idx == 'number') {
+        if (dir > 0) {
+            i = idx >= 0 ? idx : Math.max(idx + length, i);
+        } else {
+            length = idx >= 0 ? Math.min(idx + 1, length) : idx + length + 1;
+        }
+      } else if (sortedIndex && idx && length) {
+        idx = sortedIndex(array, item);
+        return array[idx] === item ? idx : -1;
+      }
+      if (item !== item) {
+        idx = predicateFind(slice.call(array, i, length), _.isNaN);
+        return idx >= 0 ? idx + i : -1;
+      }
+      for (idx = dir > 0 ? i : length - 1; idx >= 0 && idx < length; idx += dir) {
+        if (array[idx] === item) return idx;
+      }
+      return -1;
+    };
+  }
+
   // Return the position of the first occurrence of an item in an array,
   // or -1 if the item is not included in the array.
   // If the array is large and already in sort order, pass `true`
   // for **isSorted** to use binary search.
-  _.indexOf = function(array, item, isSorted) {
-    if (array == null) return -1;
-    var i = 0, length = array.length;
-    if (isSorted) {
-      if (typeof isSorted == 'number') {
-        i = isSorted < 0 ? Math.max(0, length + isSorted) : isSorted;
-      } else {
-        i = _.sortedIndex(array, item);
-        return array[i] === item ? i : -1;
-      }
-    }
-    for (; i < length; i++) if (array[i] === item) return i;
-    return -1;
-  };
-
-  _.lastIndexOf = function(array, item, from) {
-    if (array == null) return -1;
-    var idx = array.length;
-    if (typeof from == 'number') {
-      idx = from < 0 ? idx + from + 1 : Math.min(idx, from + 1);
-    }
-    while (--idx >= 0) if (array[idx] === item) return idx;
-    return -1;
-  };
+  _.indexOf = createIndexFinder(1, _.findIndex, _.sortedIndex);
+  _.lastIndexOf = createIndexFinder(-1, _.findLastIndex);
 
   // Generate an integer Array containing an arithmetic progression. A port of
   // the native Python `range()` function. See
   // [the Python documentation](http://docs.python.org/library/functions.html#range).
   _.range = function(start, stop, step) {
-    if (arguments.length <= 1) {
+    if (stop == null) {
       stop = start || 0;
       start = 0;
     }
@@ -637,25 +695,25 @@
   // Function (ahem) Functions
   // ------------------
 
-  // Reusable constructor function for prototype setting.
-  var Ctor = function(){};
+  // Determines whether to execute a function as a constructor
+  // or a normal function with the provided arguments
+  var executeBound = function(sourceFunc, boundFunc, context, callingContext, args) {
+    if (!(callingContext instanceof boundFunc)) return sourceFunc.apply(context, args);
+    var self = baseCreate(sourceFunc.prototype);
+    var result = sourceFunc.apply(self, args);
+    if (_.isObject(result)) return result;
+    return self;
+  };
 
   // Create a function bound to a given object (assigning `this`, and arguments,
   // optionally). Delegates to **ECMAScript 5**'s native `Function.bind` if
   // available.
   _.bind = function(func, context) {
-    var args, bound;
     if (nativeBind && func.bind === nativeBind) return nativeBind.apply(func, slice.call(arguments, 1));
     if (!_.isFunction(func)) throw new TypeError('Bind must be called on a function');
-    args = slice.call(arguments, 2);
-    bound = function() {
-      if (!(this instanceof bound)) return func.apply(context, args.concat(slice.call(arguments)));
-      Ctor.prototype = func.prototype;
-      var self = new Ctor;
-      Ctor.prototype = null;
-      var result = func.apply(self, args.concat(slice.call(arguments)));
-      if (_.isObject(result)) return result;
-      return self;
+    var args = slice.call(arguments, 2);
+    var bound = function() {
+      return executeBound(func, bound, context, this, args.concat(slice.call(arguments)));
     };
     return bound;
   };
@@ -665,15 +723,16 @@
   // as a placeholder, allowing any combination of arguments to be pre-filled.
   _.partial = function(func) {
     var boundArgs = slice.call(arguments, 1);
-    return function() {
-      var position = 0;
-      var args = boundArgs.slice();
-      for (var i = 0, length = args.length; i < length; i++) {
-        if (args[i] === _) args[i] = arguments[position++];
+    var bound = function() {
+      var position = 0, length = boundArgs.length;
+      var args = Array(length);
+      for (var i = 0; i < length; i++) {
+        args[i] = boundArgs[i] === _ ? arguments[position++] : boundArgs[i];
       }
       while (position < arguments.length) args.push(arguments[position++]);
-      return func.apply(this, args);
+      return executeBound(func, bound, this, this, args);
     };
+    return bound;
   };
 
   // Bind a number of an object's methods to that object. Remaining arguments
@@ -693,7 +752,7 @@
   _.memoize = function(func, hasher) {
     var memoize = function(key) {
       var cache = memoize.cache;
-      var address = hasher ? hasher.apply(this, arguments) : key;
+      var address = '' + (hasher ? hasher.apply(this, arguments) : key);
       if (!_.has(cache, address)) cache[address] = func.apply(this, arguments);
       return cache[address];
     };
@@ -712,9 +771,7 @@
 
   // Defers a function, scheduling it to run after the current call stack has
   // cleared.
-  _.defer = function(func) {
-    return _.delay.apply(_, [func, 1].concat(slice.call(arguments, 1)));
-  };
+  _.defer = _.partial(_.delay, _, 1);
 
   // Returns a function, that, when invoked, will only be triggered at most once
   // during a given window of time. Normally, the throttled function will run
@@ -739,8 +796,10 @@
       context = this;
       args = arguments;
       if (remaining <= 0 || remaining > wait) {
-        clearTimeout(timeout);
-        timeout = null;
+        if (timeout) {
+          clearTimeout(timeout);
+          timeout = null;
+        }
         previous = now;
         result = func.apply(context, args);
         if (!timeout) context = args = null;
@@ -761,7 +820,7 @@
     var later = function() {
       var last = _.now() - timestamp;
 
-      if (last < wait && last > 0) {
+      if (last < wait && last >= 0) {
         timeout = setTimeout(later, wait - last);
       } else {
         timeout = null;
@@ -814,7 +873,7 @@
     };
   };
 
-  // Returns a function that will only be executed after being called N times.
+  // Returns a function that will only be executed on and after the Nth call.
   _.after = function(times, func) {
     return function() {
       if (--times < 1) {
@@ -823,15 +882,14 @@
     };
   };
 
-  // Returns a function that will only be executed before being called N times.
+  // Returns a function that will only be executed up to (but not including) the Nth call.
   _.before = function(times, func) {
     var memo;
     return function() {
       if (--times > 0) {
         memo = func.apply(this, arguments);
-      } else {
-        func = null;
       }
+      if (times <= 1) func = null;
       return memo;
     };
   };
@@ -843,13 +901,47 @@
   // Object Functions
   // ----------------
 
-  // Retrieve the names of an object's properties.
+  // Keys in IE < 9 that won't be iterated by `for key in ...` and thus missed.
+  var hasEnumBug = !{toString: null}.propertyIsEnumerable('toString');
+  var nonEnumerableProps = ['valueOf', 'isPrototypeOf', 'toString',
+                      'propertyIsEnumerable', 'hasOwnProperty', 'toLocaleString'];
+
+  function collectNonEnumProps(obj, keys) {
+    var nonEnumIdx = nonEnumerableProps.length;
+    var constructor = obj.constructor;
+    var proto = (_.isFunction(constructor) && constructor.prototype) || ObjProto;
+
+    // Constructor is a special case.
+    var prop = 'constructor';
+    if (_.has(obj, prop) && !_.contains(keys, prop)) keys.push(prop);
+
+    while (nonEnumIdx--) {
+      prop = nonEnumerableProps[nonEnumIdx];
+      if (prop in obj && obj[prop] !== proto[prop] && !_.contains(keys, prop)) {
+        keys.push(prop);
+      }
+    }
+  }
+
+  // Retrieve the names of an object's own properties.
   // Delegates to **ECMAScript 5**'s native `Object.keys`
   _.keys = function(obj) {
     if (!_.isObject(obj)) return [];
     if (nativeKeys) return nativeKeys(obj);
     var keys = [];
     for (var key in obj) if (_.has(obj, key)) keys.push(key);
+    // Ahem, IE < 9.
+    if (hasEnumBug) collectNonEnumProps(obj, keys);
+    return keys;
+  };
+
+  // Retrieve all the property names of an object.
+  _.allKeys = function(obj) {
+    if (!_.isObject(obj)) return [];
+    var keys = [];
+    for (var key in obj) keys.push(key);
+    // Ahem, IE < 9.
+    if (hasEnumBug) collectNonEnumProps(obj, keys);
     return keys;
   };
 
@@ -862,6 +954,21 @@
       values[i] = obj[keys[i]];
     }
     return values;
+  };
+
+  // Returns the results of applying the iteratee to each element of the object
+  // In contrast to _.map it returns an object
+  _.mapObject = function(obj, iteratee, context) {
+    iteratee = cb(iteratee, context);
+    var keys =  _.keys(obj),
+          length = keys.length,
+          results = {},
+          currentKey;
+      for (var index = 0; index < length; index++) {
+        currentKey = keys[index];
+        results[currentKey] = iteratee(obj[currentKey], currentKey, obj);
+      }
+      return results;
   };
 
   // Convert an object into a list of `[key, value]` pairs.
@@ -896,37 +1003,38 @@
   };
 
   // Extend a given object with all the properties in passed-in object(s).
-  _.extend = function(obj) {
-    if (!_.isObject(obj)) return obj;
-    var source, prop;
-    for (var i = 1, length = arguments.length; i < length; i++) {
-      source = arguments[i];
-      for (prop in source) {
-        if (hasOwnProperty.call(source, prop)) {
-            obj[prop] = source[prop];
-        }
-      }
+  _.extend = createAssigner(_.allKeys);
+
+  // Assigns a given object with all the own properties in the passed-in object(s)
+  // (https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/assign)
+  _.extendOwn = _.assign = createAssigner(_.keys);
+
+  // Returns the first key on an object that passes a predicate test
+  _.findKey = function(obj, predicate, context) {
+    predicate = cb(predicate, context);
+    var keys = _.keys(obj), key;
+    for (var i = 0, length = keys.length; i < length; i++) {
+      key = keys[i];
+      if (predicate(obj[key], key, obj)) return key;
     }
-    return obj;
   };
 
   // Return a copy of the object only containing the whitelisted properties.
-  _.pick = function(obj, iteratee, context) {
-    var result = {}, key;
+  _.pick = function(object, oiteratee, context) {
+    var result = {}, obj = object, iteratee, keys;
     if (obj == null) return result;
-    if (_.isFunction(iteratee)) {
-      iteratee = createCallback(iteratee, context);
-      for (key in obj) {
-        var value = obj[key];
-        if (iteratee(value, key, obj)) result[key] = value;
-      }
+    if (_.isFunction(oiteratee)) {
+      keys = _.allKeys(obj);
+      iteratee = optimizeCb(oiteratee, context);
     } else {
-      var keys = concat.apply([], slice.call(arguments, 1));
-      obj = new Object(obj);
-      for (var i = 0, length = keys.length; i < length; i++) {
-        key = keys[i];
-        if (key in obj) result[key] = obj[key];
-      }
+      keys = flatten(arguments, false, false, 1);
+      iteratee = function(value, key, obj) { return key in obj; };
+      obj = Object(obj);
+    }
+    for (var i = 0, length = keys.length; i < length; i++) {
+      var key = keys[i];
+      var value = obj[key];
+      if (iteratee(value, key, obj)) result[key] = value;
     }
     return result;
   };
@@ -936,7 +1044,7 @@
     if (_.isFunction(iteratee)) {
       iteratee = _.negate(iteratee);
     } else {
-      var keys = _.map(concat.apply([], slice.call(arguments, 1)), String);
+      var keys = _.map(flatten(arguments, false, false, 1), String);
       iteratee = function(value, key) {
         return !_.contains(keys, key);
       };
@@ -945,15 +1053,15 @@
   };
 
   // Fill in a given object with default properties.
-  _.defaults = function(obj) {
-    if (!_.isObject(obj)) return obj;
-    for (var i = 1, length = arguments.length; i < length; i++) {
-      var source = arguments[i];
-      for (var prop in source) {
-        if (obj[prop] === void 0) obj[prop] = source[prop];
-      }
-    }
-    return obj;
+  _.defaults = createAssigner(_.allKeys, true);
+
+  // Creates an object that inherits from the given prototype object.
+  // If additional properties are provided then they will be added to the
+  // created object.
+  _.create = function(prototype, props) {
+    var result = baseCreate(prototype);
+    if (props) _.extendOwn(result, props);
+    return result;
   };
 
   // Create a (shallow-cloned) duplicate of an object.
@@ -969,6 +1077,19 @@
     interceptor(obj);
     return obj;
   };
+
+  // Returns whether an object has a given set of `key:value` pairs.
+  _.isMatch = function(object, attrs) {
+    var keys = _.keys(attrs), length = keys.length;
+    if (object == null) return !length;
+    var obj = Object(object);
+    for (var i = 0; i < length; i++) {
+      var key = keys[i];
+      if (attrs[key] !== obj[key] || !(key in obj)) return false;
+    }
+    return true;
+  };
+
 
   // Internal recursive comparison function for `isEqual`.
   var eq = function(a, b, aStack, bStack) {
@@ -1004,74 +1125,76 @@
         // of `NaN` are not equivalent.
         return +a === +b;
     }
-    if (typeof a != 'object' || typeof b != 'object') return false;
+
+    var areArrays = className === '[object Array]';
+    if (!areArrays) {
+      if (typeof a != 'object' || typeof b != 'object') return false;
+
+      // Objects with different constructors are not equivalent, but `Object`s or `Array`s
+      // from different frames are.
+      var aCtor = a.constructor, bCtor = b.constructor;
+      if (aCtor !== bCtor && !(_.isFunction(aCtor) && aCtor instanceof aCtor &&
+                               _.isFunction(bCtor) && bCtor instanceof bCtor)
+                          && ('constructor' in a && 'constructor' in b)) {
+        return false;
+      }
+    }
     // Assume equality for cyclic structures. The algorithm for detecting cyclic
     // structures is adapted from ES 5.1 section 15.12.3, abstract operation `JO`.
+
+    // Initializing stack of traversed objects.
+    // It's done here since we only need them for objects and arrays comparison.
+    aStack = aStack || [];
+    bStack = bStack || [];
     var length = aStack.length;
     while (length--) {
       // Linear search. Performance is inversely proportional to the number of
       // unique nested structures.
       if (aStack[length] === a) return bStack[length] === b;
     }
-    // Objects with different constructors are not equivalent, but `Object`s
-    // from different frames are.
-    var aCtor = a.constructor, bCtor = b.constructor;
-    if (
-      aCtor !== bCtor &&
-      // Handle Object.create(x) cases
-      'constructor' in a && 'constructor' in b &&
-      !(_.isFunction(aCtor) && aCtor instanceof aCtor &&
-        _.isFunction(bCtor) && bCtor instanceof bCtor)
-    ) {
-      return false;
-    }
+
     // Add the first object to the stack of traversed objects.
     aStack.push(a);
     bStack.push(b);
-    var size, result;
+
     // Recursively compare objects and arrays.
-    if (className === '[object Array]') {
+    if (areArrays) {
       // Compare array lengths to determine if a deep comparison is necessary.
-      size = a.length;
-      result = size === b.length;
-      if (result) {
-        // Deep compare the contents, ignoring non-numeric properties.
-        while (size--) {
-          if (!(result = eq(a[size], b[size], aStack, bStack))) break;
-        }
+      length = a.length;
+      if (length !== b.length) return false;
+      // Deep compare the contents, ignoring non-numeric properties.
+      while (length--) {
+        if (!eq(a[length], b[length], aStack, bStack)) return false;
       }
     } else {
       // Deep compare objects.
       var keys = _.keys(a), key;
-      size = keys.length;
+      length = keys.length;
       // Ensure that both objects contain the same number of properties before comparing deep equality.
-      result = _.keys(b).length === size;
-      if (result) {
-        while (size--) {
-          // Deep compare each member
-          key = keys[size];
-          if (!(result = _.has(b, key) && eq(a[key], b[key], aStack, bStack))) break;
-        }
+      if (_.keys(b).length !== length) return false;
+      while (length--) {
+        // Deep compare each member
+        key = keys[length];
+        if (!(_.has(b, key) && eq(a[key], b[key], aStack, bStack))) return false;
       }
     }
     // Remove the first object from the stack of traversed objects.
     aStack.pop();
     bStack.pop();
-    return result;
+    return true;
   };
 
   // Perform a deep comparison to check if two objects are equal.
   _.isEqual = function(a, b) {
-    return eq(a, b, [], []);
+    return eq(a, b);
   };
 
   // Is a given array, string, or object empty?
   // An "empty" object has no enumerable own-properties.
   _.isEmpty = function(obj) {
     if (obj == null) return true;
-    if (_.isArray(obj) || _.isString(obj) || _.isArguments(obj)) return obj.length === 0;
-    for (var key in obj) if (_.has(obj, key)) return false;
-    return true;
+    if (isArrayLike(obj) && (_.isArray(obj) || _.isString(obj) || _.isArguments(obj))) return obj.length === 0;
+    return _.keys(obj).length === 0;
   };
 
   // Is a given value a DOM element?
@@ -1091,14 +1214,14 @@
     return type === 'function' || type === 'object' && !!obj;
   };
 
-  // Add some isType methods: isArguments, isFunction, isString, isNumber, isDate, isRegExp.
-  _.each(['Arguments', 'Function', 'String', 'Number', 'Date', 'RegExp'], function(name) {
+  // Add some isType methods: isArguments, isFunction, isString, isNumber, isDate, isRegExp, isError.
+  _.each(['Arguments', 'Function', 'String', 'Number', 'Date', 'RegExp', 'Error'], function(name) {
     _['is' + name] = function(obj) {
       return toString.call(obj) === '[object ' + name + ']';
     };
   });
 
-  // Define a fallback version of the method in browsers (ahem, IE), where
+  // Define a fallback version of the method in browsers (ahem, IE < 9), where
   // there isn't any inspectable "Arguments" type.
   if (!_.isArguments(arguments)) {
     _.isArguments = function(obj) {
@@ -1106,8 +1229,9 @@
     };
   }
 
-  // Optimize `isFunction` if appropriate. Work around an IE 11 bug.
-  if (typeof /./ !== 'function') {
+  // Optimize `isFunction` if appropriate. Work around some typeof bugs in old v8,
+  // IE 11 (#1621), and in Safari 8 (#1929).
+  if (typeof /./ != 'function' && typeof Int8Array != 'object') {
     _.isFunction = function(obj) {
       return typeof obj == 'function' || false;
     };
@@ -1159,6 +1283,7 @@
     return value;
   };
 
+  // Predicate-generating functions. Often useful outside of Underscore.
   _.constant = function(value) {
     return function() {
       return value;
@@ -1167,30 +1292,28 @@
 
   _.noop = function(){};
 
-  _.property = function(key) {
-    return function(obj) {
+  _.property = property;
+
+  // Generates a function for a given object that returns a given property.
+  _.propertyOf = function(obj) {
+    return obj == null ? function(){} : function(key) {
       return obj[key];
     };
   };
 
-  // Returns a predicate for checking whether an object has a given set of `key:value` pairs.
-  _.matches = function(attrs) {
-    var pairs = _.pairs(attrs), length = pairs.length;
+  // Returns a predicate for checking whether an object has a given set of
+  // `key:value` pairs.
+  _.matcher = _.matches = function(attrs) {
+    attrs = _.extendOwn({}, attrs);
     return function(obj) {
-      if (obj == null) return !length;
-      obj = new Object(obj);
-      for (var i = 0; i < length; i++) {
-        var pair = pairs[i], key = pair[0];
-        if (pair[1] !== obj[key] || !(key in obj)) return false;
-      }
-      return true;
+      return _.isMatch(obj, attrs);
     };
   };
 
   // Run a function **n** times.
   _.times = function(n, iteratee, context) {
     var accum = Array(Math.max(0, n));
-    iteratee = createCallback(iteratee, context, 1);
+    iteratee = optimizeCb(iteratee, context, 1);
     for (var i = 0; i < n; i++) accum[i] = iteratee(i);
     return accum;
   };
@@ -1239,10 +1362,12 @@
 
   // If the value of the named `property` is a function then invoke it with the
   // `object` as context; otherwise, return it.
-  _.result = function(object, property) {
-    if (object == null) return void 0;
-    var value = object[property];
-    return _.isFunction(value) ? object[property]() : value;
+  _.result = function(object, property, fallback) {
+    var value = object == null ? void 0 : object[property];
+    if (value === void 0) {
+      value = fallback;
+    }
+    return _.isFunction(value) ? value.call(object) : value;
   };
 
   // Generate a unique integer id (unique within the entire client session).
@@ -1357,8 +1482,8 @@
   // underscore functions. Wrapped objects may be chained.
 
   // Helper function to continue chaining intermediate results.
-  var result = function(obj) {
-    return this._chain ? _(obj).chain() : obj;
+  var result = function(instance, obj) {
+    return instance._chain ? _(obj).chain() : obj;
   };
 
   // Add your own custom functions to the Underscore object.
@@ -1368,7 +1493,7 @@
       _.prototype[name] = function() {
         var args = [this._wrapped];
         push.apply(args, arguments);
-        return result.call(this, func.apply(_, args));
+        return result(this, func.apply(_, args));
       };
     });
   };
@@ -1383,7 +1508,7 @@
       var obj = this._wrapped;
       method.apply(obj, arguments);
       if ((name === 'shift' || name === 'splice') && obj.length === 0) delete obj[0];
-      return result.call(this, obj);
+      return result(this, obj);
     };
   });
 
@@ -1391,13 +1516,21 @@
   _.each(['concat', 'join', 'slice'], function(name) {
     var method = ArrayProto[name];
     _.prototype[name] = function() {
-      return result.call(this, method.apply(this._wrapped, arguments));
+      return result(this, method.apply(this._wrapped, arguments));
     };
   });
 
   // Extracts the result from a wrapped and chained object.
   _.prototype.value = function() {
     return this._wrapped;
+  };
+
+  // Provide unwrapping proxy for some methods used in engine operations
+  // such as arithmetic and JSON stringification.
+  _.prototype.valueOf = _.prototype.toJSON = _.prototype.value;
+
+  _.prototype.toString = function() {
+    return '' + this._wrapped;
   };
 
   // AMD registration happens at the end for compatibility with AMD loaders

--- a/examples/backbone_marionette/package.json
+++ b/examples/backbone_marionette/package.json
@@ -1,10 +1,10 @@
 {
   "private": true,
   "dependencies": {
-    "backbone": "^1.1.2",
+    "backbone": "^1.3.3",
     "backbone.localstorage": "^1.1.6",
-    "backbone.marionette": "^2.4.1",
-    "backbone.radio": "^1.0.1",
+    "backbone.marionette": "^3.0.0",
+    "backbone.radio": "^2.0.0",
     "jquery": "^1.11.2",
     "todomvc-app-css": "^1.0.1",
     "todomvc-common": "^1.0.1",

--- a/examples/backbone_marionette/readme.md
+++ b/examples/backbone_marionette/readme.md
@@ -11,16 +11,16 @@ The [Backbone.Marionette website](http://marionettejs.com) is a great resource f
 
 Here are some links you may find helpful:
 
-* [API Reference](https://github.com/marionettejs/backbone.marionette/tree/master/docs)
-* [Applications built with Backbone.Marionette](https://github.com/marionettejs/backbone.marionette/wiki/Projects-and-websites-using-marionette)
-* [Introduction to Composite JavaScript Apps](https://github.com/marionettejs/backbone.marionette/wiki/Introduction-to-composite-javascript-apps)
-* [FAQ](https://github.com/marionettejs/backbone.marionette/wiki#frequently-asked-questions)
+* [API Reference](http://marionettejs.com/docs/current/)
+* [Additional Marionette Resources](http://marionettejs.com/additional-resources/)
 * [Backbone.Marionette on GitHub](https://github.com/marionettejs/backbone.marionette)
 
 Articles and guides from the community:
 
 * [A Thorough Introduction to Backbone.Marionette](http://coding.smashingmagazine.com/2013/02/11/introduction-backbone-marionette)
 * [Backbone Marionette: Better Backbone Apps](http://www.joezimjs.com/javascript/backbone-marionette-better-backbone-apps)
+* [Marionette Guides](https://www.gitbook.com/book/marionette/marionette-guides/details)
+* [Marionette.js v3. Getting started with new version](http://blog.marionettejs.com/2016/08/23/marionette-v3/index.html)
 
 Get help from other Backbone.Marionette users:
 
@@ -32,4 +32,4 @@ _If you have other helpful links to share, or find any of the links above no lon
 
 ## Implementation
 
-This implementation of the application uses Marionette's module system. Variations using RequireJS and a more classic approach to JavaScript modules [are also available here](https://github.com/marionettejs/backbone.marionette/wiki/Projects-and-websites-using-marionette).
+* [Simple setups with different build tools](https://github.com/marionettejs/marionette-integrations)

--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
 									<a href="examples/vue/" data-source="http://vuejs.org" data-content="Vue.js provides the benefits of MVVM data binding and a composable component system with an extremely simple and flexible API.">Vue.js</a>
 								</li>
 								<li class="routing">
-									<a href="examples/backbone_marionette/" data-source="http://marionettejs.com" data-content="Backbone.Marionette is a composite application library for Backbone.js that aims to simplify the construction of large scale JavaScript applications.">MarionetteJS</a>
+									<a href="examples/backbone_marionette/" data-source="http://marionettejs.com" data-content="Backbone.Marionette is a composite application library for Backbone.js that aims to simplify the construction of large scale JavaScript applications.">Marionette.js</a>
 								</li>
 								<li class="routing">
 									<a href="examples/troopjs_require/" data-source="https://github.com/troopjs/" data-content="TroopJS attempts to package popular front-end technologies and bind them with minimal effort for the developer. It includes jQuery for DOM manipulation, When.js for promises, RequireJS for modularity and Has.js for feature detection. On top, it includes Pub/Sub support, templating, weaving (widgets to DOM) and auto-wiring.">TroopJS + RequireJS</a>


### PR DESCRIPTION
Changes: 
 - update Todo example due to v3 [release](https://github.com/marionettejs/backbone.marionette/releases/tag/v3.0.0)
 - update readme file with links to resources. Some of them were broken so new links were added.
 - replaced `MarionetteJS` by `Marionette.js` on main page.