### PR TITLE
Update the Markdown Blog link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Helping you select an MV\* framework
 
-### [Website](http://todomvc.com)&nbsp;&nbsp;&nbsp;&nbsp;[Blog](http://blog.tastejs.com)&nbsp;&nbsp;&nbsp;&nbsp;[TasteJS](http://tastejs.com)
+### [Website](http://todomvc.com)&nbsp;&nbsp;&nbsp;&nbsp;[Blog](https://medium.com/tastejs-blog)&nbsp;&nbsp;&nbsp;&nbsp;[TasteJS](http://tastejs.com)
 
 [![Build Status](https://travis-ci.org/tastejs/todomvc.svg)](https://travis-ci.org/tastejs/todomvc)
 


### PR DESCRIPTION
Hi guys,
in the line 5, the Blog link is pointing to this url http://blog.tastejs.com/ and the browser returns the 'This site can’t be reached' error message. So I changed that link to your Medium blog link: https://medium.com/tastejs-blog .