### PR TITLE
Point to Elm Slack instead of IRC

### DIFF
--- a/learn.json
+++ b/learn.json
@@ -349,8 +349,8 @@
 				"name": "Libraries",
 				"url": "http://elm-lang.org/Libraries.elm"
 			}, {
-				"name": "#elm IRC Channel on Freenode",
-				"url": "http://webchat.freenode.net/?channels=elm"
+				"name": "Elm Slack Channel",
+				"url": "http://elmlang.herokuapp.com/"
 			}]
 		}]
 	},


### PR DESCRIPTION
Once someone in the community created a Slack channel, pretty much all conversation migrated over there. These days it is a great place to ask questions and have a friendly discussion about Elm, so I think this would be a more helpful link for people.
