### PR TITLE
Update Elm links in learn.json to point to latest URLs

### DIFF
--- a/learn.json
+++ b/learn.json
@@ -341,13 +341,13 @@
 				"url": "http://elm-lang.org/"
 			}, {
 				"name": "Guides",
-				"url": "http://elm-lang.org/Learn.elm"
+				"url": "http://elm-lang.org/docs"
 			}, {
 				"name": "Syntax Reference",
-				"url": "http://elm-lang.org/learn/Syntax.elm"
+				"url": "http://elm-lang.org/docs/syntax"
 			}, {
 				"name": "Libraries",
-				"url": "http://elm-lang.org/Libraries.elm"
+				"url": "http://package.elm-lang.org/"
 			}, {
 				"name": "#elm IRC Channel on Freenode",
 				"url": "http://webchat.freenode.net/?channels=elm"


### PR DESCRIPTION
The old links are currently redirected to the new links. I figured I'd skip the redirect while I was looking at the file!

It may also be worth linking to [The Official Guide](http://guide.elm-lang.org/) in addition to these links. Not sure!