### PR TITLE
Jquery - bug: escaping in edit mode with empty title destroys todo

### DIFF
--- a/examples/jquery/js/app.js
+++ b/examples/jquery/js/app.js
@@ -173,17 +173,18 @@ jQuery(function ($) {
 			var $el = $(el);
 			var val = $el.val().trim();
 
-			if (!val) {
-				this.destroy(e);
-				return;
-			}
 
 			if ($el.data('abort')) {
 				$el.data('abort', false);
 			} else {
-				this.todos[this.indexFromEl(el)].title = val;
+				if (!val) {
+					this.destroy(e);
+					return;
+				} else {
+					this.todos[this.indexFromEl(el)].title = val;
+				}
 			}
-
+			
 			this.render();
 		},
 		destroy: function (e) {


### PR DESCRIPTION
## Description of the problem

In edit state, after deleting the todo's title and escaping, the todo is destroyed.

## What was expected

From the [Application Specification](https://github.com/tastejs/todomvc/blob/master/app-spec.md#editing) 
>"_If escape is pressed during the edit, the edit state should be left and any changes be discarded._" 

I was expecting that pressing the escape key would not delete the todo. 

## Reproduction steps
1. Create one or more todo
2. Double click on a todo in the list to access edit mode
3. Delete the todo's title
4. Press the ESC key

## Browser version
Chrome Version 68.0.3440.106 (Official Build) (64-bit)