### PR TITLE
angularjs: do not use self-closing form of <ng-view /> tag

### DIFF
--- a/examples/angularjs/index.html
+++ b/examples/angularjs/index.html
@@ -8,7 +8,7 @@
 		<style>[ng-cloak] { display: none; }</style>
 	</head>
 	<body ng-app="todomvc">
-		<ng-view />
+		<ng-view></ng-view>
 
 		<script type="text/ng-template" id="todomvc-index.html">
 			<section id="todoapp">


### PR DESCRIPTION
Fixes #1748 by using full-form `<ng-view></ng-view>`.