### PR TITLE
escape key pressed on blank todo deleted it

### DIFF
--- a/examples/jquery/js/app.js
+++ b/examples/jquery/js/app.js
@@ -173,15 +173,14 @@ jQuery(function ($) {
 			var $el = $(el);
 			var val = $el.val().trim();
 
-			if (!val) {
-				this.destroy(e);
-				return;
-			}
-
 			if ($el.data('abort')) {
 				$el.data('abort', false);
 			} else {
-				this.todos[this.getIndexFromEl(el)].title = val;
+				if (!val) {
+					this.destroy(e);
+				} else {
+					this.todos[this.getIndexFromEl(el)].title = val;
+				}
 			}
 
 			this.render();


### PR DESCRIPTION
escape key pressed on blank todo deleted it, rather than ignoring it just it does in all other versions.