### PR TITLE
Updated Router to fix Chrome/Safari

### DIFF
--- a/examples/jquery/js/app.js
+++ b/examples/jquery/js/app.js
@@ -49,7 +49,10 @@ jQuery(function ($) {
 				'/:filter': function (filter) {
 					this.filter = filter;
 					this.render();
-				}.bind(this)
+				}.bind(this),
+				'/': function () {
+					window.location.hash = '/all';
+				}
 			}).init('/all');
 		},
 		bindEvents: function () {


### PR DESCRIPTION
In Chrome and Safari, If the route is empty as: "#/", it doesn't reset to default "/all". 
The app returns to the initial "no todos" display mode, not displaying existing data.

Steps to reproduce:
1. Create new todos; 
2. Remove the route as: http://todomvc.com/examples/jquery/#/ 
(enter, focus back to address bar and enter again.)