### PR TITLE
Fixed the ember example to persist the renaming of todos

### DIFF
--- a/examples/emberjs/todomvc/app/components/todo-item.js
+++ b/examples/emberjs/todomvc/app/components/todo-item.js
@@ -21,6 +21,7 @@ export default Ember.Component.extend({
 				this.set('todo.title', todoTitle.trim());
 				this.set('editing', false);
 				this.get('onEndEdit')();
+                this.get('repo').persist();
 			}
 		},
 

--- a/examples/emberjs/todomvc/app/components/todo-item.js
+++ b/examples/emberjs/todomvc/app/components/todo-item.js
@@ -21,7 +21,7 @@ export default Ember.Component.extend({
 				this.set('todo.title', todoTitle.trim());
 				this.set('editing', false);
 				this.get('onEndEdit')();
-                this.get('repo').persist();
+				this.get('repo').persist();
 			}
 		},
 


### PR DESCRIPTION
After editing the name of a todo, a refresh of the page would cause the model to revert back to the name before it was edited. Added a persist() to resolve.