### PR TITLE
Fix chromedriver lookup

### DIFF
--- a/tests/memory.js
+++ b/tests/memory.js
@@ -4,6 +4,11 @@ var drool = require('drool');
 var exceptions = require('./memory-exceptions.json');
 var frameworkPathLookup = require('./framework-path-lookup');
 var argv = require('optimist').default('laxMode', false).default('browser', 'chrome').argv;
+var chrome = require('selenium-webdriver/chrome');
+var chromedriver = require('chromedriver');
+
+chrome.setDefaultService(new chrome.ServiceBuilder(chromedriver.path).build());
+
 var driverConfig = {
 	chromeOptions: 'no-sandbox'
 };

--- a/tests/package.json
+++ b/tests/package.json
@@ -3,7 +3,7 @@
   "description": "An automated test suite for TodoMVC",
   "private": true,
   "devDependencies": {
-    "chromedriver": "^2.18.0",
+    "chromedriver": "2.28.0",
     "mocha": "*",
     "mocha-known-issues-reporter": "git+https://github.com/ColinEberhardt/mocha-known-issues-reporter.git#v0.0.0",
     "optimist": "^0.6.1",

--- a/tests/test.js
+++ b/tests/test.js
@@ -2,10 +2,13 @@
 
 var webdriver = require('selenium-webdriver');
 var chrome = require('selenium-webdriver/chrome');
+var chromedriver = require('chromedriver');
 var test = require('selenium-webdriver/testing');
 var Page = require('./page');
 var PageLaxMode = require('./pageLaxMode');
 var TestOperations = require('./testOperations');
+
+chrome.setDefaultService(new chrome.ServiceBuilder(chromedriver.path).build());
 
 module.exports.todoMVCTest = function (frameworkName, baseUrl, speedMode, laxMode, browserName) {
 


### PR DESCRIPTION
I think we need this line to make selenium-webdriver recognize the chromedriver's path automatically.

```
chrome.setDefaultService(new chrome.ServiceBuilder(chromedriver.path).build());
```

And I pinned the chromedriver's versioin to 2.28.0 because of this issue ( https://github.com/samccone/drool/issues/32 ).