### PR TITLE
Updating "Why I Like TypeScript" screencast link

### DIFF
--- a/examples/typescript-angular/readme.md
+++ b/examples/typescript-angular/readme.md
@@ -21,7 +21,7 @@ Here are some links you may find helpful:
 Articles and guides from the community:
 
 * [Thoughts on TypeScript](http://www.nczonline.net/blog/2012/10/04/thoughts-on-typescript)
-* [ScreenCast - Why I Like TypeScript](http://www.leebrimelow.com/why-i-like-typescripts)
+* [ScreenCast - Why I Like TypeScript](https://www.youtube.com/watch?v=Mh5VQVfWTbs)
 
 Get help from other TypeScript users:
 


### PR DESCRIPTION
Existing link for the screencast was leading to [a rather empty looking page](http://www.leebrimelow.com/why-i-like-typescripts).

I updated the link to what I believe is the same screencast the original link was referring to. The link redirects to the video ["Why I Like TypeScript"](https://www.youtube.com/watch?v=Mh5VQVfWTbs) on YouTube by Lee Brimelow.