### PR TITLE
Focus caret at end of input when in editMode

### DIFF
--- a/examples/jquery/js/app.js
+++ b/examples/jquery/js/app.js
@@ -159,8 +159,8 @@ jQuery(function ($) {
 			var $input = $(e.target).closest('li').addClass('editing').find('.edit');
 			// puts caret at end of input
 			var tmpStr = $input.val();
-      			$input.val('');
-      			$input.val(tmpStr);
+			$input.val('');
+			$input.val(tmpStr);
 		},
 		editKeyup: function (e) {
 			if (e.which === ENTER_KEY) {


### PR DESCRIPTION
I updated the line of code that was supposed to focus the caret at the end of the input line when in editMode. It no longer does what I assume it was supposed to do, so I created a way for it to work. This makes it easier to backspace or add more to your Todo. It will also make the code easier for beginners to understand line by line.