### PR TITLE
Add keys for todos in order to ensure checkboxes are not reused. 

### DIFF
--- a/examples/vue/index.html
+++ b/examples/vue/index.html
@@ -16,7 +16,7 @@
 			<section class="main" v-show="todos.length">
 				<input class="toggle-all" type="checkbox" v-model="allDone">
 				<ul class="todo-list">
-					<li class="todo" v-for="todo in filteredTodos" :class="{completed: todo.completed, editing: todo == editedTodo}">
+					<li class="todo" v-for="todo in filteredTodos" :key="todo.id" :class="{completed: todo.completed, editing: todo == editedTodo}">
 						<div class="view">
 							<input class="toggle" type="checkbox" v-model="todo.completed">
 							<label @dblclick="editTodo(todo)">{{todo.title}}</label>

--- a/examples/vue/js/app.js
+++ b/examples/vue/js/app.js
@@ -75,7 +75,7 @@
 				if (!value) {
 					return;
 				}
-				this.todos.push({ title: value, completed: false });
+				this.todos.push({ id: this.todos.length + 1, title: value, completed: false });
 				this.newTodo = '';
 			},
 


### PR DESCRIPTION
Currently the following behavior holds true in the VUE example:

Given I add three new todos in as TODO1, TODO2, and TODO3
and I mark them all as completed
and I filter for completed items
and I mark the top Todo as not completed
and the top Todo moves out of the view
Then I see the top TODO marked as not completed even though the todo data element is not completed

This fix ensures that when I mark the first todo as not completed the new top todo will not be marked visually as not completed while staying on the list

