### PR TITLE
jQuery - todo with empty value deletes todo #1789 #1801

### DIFF
--- a/examples/jquery/js/app.js
+++ b/examples/jquery/js/app.js
@@ -174,14 +174,12 @@ jQuery(function ($) {
 			var el = e.target;
 			var $el = $(el);
 			var val = $el.val().trim();
-
-			if (!val) {
-				this.destroy(e);
-				return;
-			}
-
+			
 			if ($el.data('abort')) {
 				$el.data('abort', false);
+			} else if (!val) {
+				this.destroy(e);
+				return;
 			} else {
 				this.todos[this.getIndexFromEl(el)].title = val;
 			}


### PR DESCRIPTION
When you're updating todo, you shouldn't leave out the value. If doing so, update operation should be aborted.