### PR TITLE
jQuery - editingMode: todo should be focused #1877

### DIFF
--- a/examples/jquery/js/app.js
+++ b/examples/jquery/js/app.js
@@ -160,6 +160,7 @@ jQuery(function ($) {
 			var tmpStr = $input.val();
 			$input.val('');
 			$input.val(tmpStr);
+			$input.focus();
 		},
 		editKeyup: function (e) {
 			if (e.which === ENTER_KEY) {


### PR DESCRIPTION
Upon double-clicking todo, the input field is now in focus, so todo can be edited.