### PR TITLE
Fix cypress test run for enyo-backbone

### DIFF
--- a/examples/enyo_backbone/js/views/NotepadFooterView.js
+++ b/examples/enyo_backbone/js/views/NotepadFooterView.js
@@ -68,6 +68,7 @@ enyo.kind({
 		kind: 'enyo.Button',
 		id: 'clear-completed',
 		name: 'clear-completed',
+		content: 'Clear completed',
 		attributes: {
 			class: 'clear-completed'
 		},

--- a/examples/enyo_backbone/js/views/NotepadMainView.js
+++ b/examples/enyo_backbone/js/views/NotepadMainView.js
@@ -90,7 +90,7 @@ enyo.kind({
 					},
 					throwEdit: function () {
 						this.inherited(arguments);
-						this.bubble('onStartEdit', parent.$.inputField);
+						this.bubble('onStartEdit');
 						return true;
 					}
 				}, {


### PR DESCRIPTION
Remove unused arg that crashes cypress test.
Display the clear completed label.

Fixes #1904.