### PR TITLE
fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules
+/node_modules
 /bower_components
 /dist
 /tooling/node_modules


### PR DESCRIPTION
Reapplies [commit 05a858f](https://github.com/tastejs/todomvc/commit/05a858f419d7ebed2992e9f3d34a6473f7348e0e) and fixes the bug introduced by [commit 215af94](https://github.com/tastejs/todomvc/commit/215af94a43b19a76b0c5a795e6ec3509f7e5bbc1), which prevented all examples from adding anything in their node_modules.