### PR TITLE
jquery: requires safeBlur() to pass cypress test

### DIFF
--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -90,6 +90,7 @@ const blurAfterType = {
   ampersand: true,
   dijon: true,
   duel: true,
+  jquery: true,
   vanillajs: true,
   'vanilla-es6': true
 }


### PR DESCRIPTION
Fixes #1919 