### PR TITLE
dojo: does not reliably save edits under cypress

### DIFF
--- a/tests/knownIssues.js
+++ b/tests/knownIssues.js
@@ -9,12 +9,13 @@ module.exports = [
   // 'TodoMVC - angularjs_require, Mark all as completed, should allow me to clear the completion state of all items',
   // jscs:disable
   // 'TodoMVC - angularjs_require, Mark all as completed, complete all checkbox should update state when items are completed / cleared',
-
   // jscs:enable
-  // https://github.com/tastejs/todomvc/issues/815
-  // does not hide other controls while editing
-  // 'TodoMVC - dojo, Editing, should hide other controls when editing',
+
+  // https://github.com/tastejs/todomvc/issues/1928
+  // does not reliably save edits
+  'dojo, should allow me to edit an item',
   'dojo, should save edits on blur',
+  'dojo, should trim entered text',
   'dojo, should remove the item if an empty text string was entered',
 
   // https://github.com/tastejs/todomvc/issues/816


### PR DESCRIPTION
This change skips the failing tests. See: #1928 for more details.