### PR TITLE
Update cypress dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bluebird": "^3.5.1",
     "chalk": "^2.3.0",
     "console.table": "^0.9.1",
-    "cypress": "^3.0.3",
+    "cypress": "^3.4.1",
     "del": "^0.1.1",
     "figlet": "^1.2.0",
     "gulp": "^3.9.0",


### PR DESCRIPTION
The version of Cypress in the project is a year old now. 

Cypress has had a lot of updates since ~3.0.3, including a lot of performance improvements. [Full changelog](https://on.cypress.io/changelog#3-4-1)