### PR TITLE
Add TODOs badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@
 
 [![Build Status](https://travis-ci.org/tastejs/todomvc.svg)](https://travis-ci.org/tastejs/todomvc)
 [![Cypress.io tests](https://img.shields.io/badge/cypress.io-tests-green.svg?style=flat-square)](https://dashboard.cypress.io/#/projects/n4ynap/runs)
+[![TODOs](https://img.shields.io/endpoint?url=https://api.tickgit.com/badge?repo=github.com/tastejs/todomvc)](https://www.tickgit.com/browse?repo=github.com/tastejs/todomvc)
 
 Developers these days are spoiled with choice when it comes to selecting an MV\* framework for structuring and organizing JavaScript web apps.
 


### PR DESCRIPTION
Closes #2099 by adding a TODO badge to the README. Thank you for considering this PR, I understand not every badge is appropriate for every repo. `// TODO` comments are often forgotten, and hopefully, by surfacing them more readily with the badge/index, they can be continuously addressed as necessary!

[![TODOs](https://img.shields.io/endpoint?url=https://api.tickgit.com/badge?repo=github.com/tastejs/todomvc)](https://www.tickgit.com/browse?repo=github.com/tastejs/todomvc)