### PR TITLE
Remove broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,13 +242,6 @@
 						</li>
 					</ul>
 					<hr>
-					<h2>Node.js</h2>
-					<ul class="applist">
-						<li>
-							<a href="http://gcloud-todos.appspot.com" data-source="http://googlecloudplatform.github.io/gcloud-node/" data-content="An Express backend implementation for the AngularJS front end using Google Cloud Client Library for Node.js.">Express + gcloud-node</a>
-						</li>
-					</ul>
-					<hr>
 					<h2>Compare these to a non-framework implementation</h2>
 					<ul class="applist">
 						<li class="routing">


### PR DESCRIPTION
Removed dead Link to the express app, seems it is not in the sources too, and its deployment is not active too.

This PR is regarding issues fixes #1797 fixes #1978 .