### PR TITLE
Remove dead link

### DIFF
--- a/examples/elm/readme.md
+++ b/examples/elm/readme.md
@@ -13,7 +13,6 @@ started.
 Here are some links you may find helpful:
 
 * [Try Elm](http://elm-lang.org/try)
-* [Learn Elm](http://elm-lang.org/Learn.elm)
 * [An Introduction to Elm](http://guide.elm-lang.org/)
 
 Get help from other Elm users:


### PR DESCRIPTION
The Learn Elm link does not point to a valid page any more.
That resource is now integrated in the "An Introduction to Elm" page as far as I know.