### PR TITLE
Fix typo in examples/react/readme.md

### DIFF
--- a/examples/react/readme.md
+++ b/examples/react/readme.md
@@ -38,5 +38,5 @@ The only requirement is an installation of Node, to be able to install dependenc
 ```
 terminal:
 1. npm install
-2. npm run start
+2. npm run serve
 ```


### PR DESCRIPTION
`npm run start` => `npm run serve` (same as in package.json)