### PR TITLE
Update link to backbone app in App specification

### DIFF
--- a/app-spec.md
+++ b/app-spec.md
@@ -4,7 +4,7 @@ We have created this short spec to help you create awesome and consistent todo a
 
 ## Template Application
 
-Our [template](https://github.com/tastejs/todomvc-app-template/) should be used as the base when implementing a todo app. Before implementing, we recommend that you interact with some of the other apps to see how they're built and how they behave. Check out the [Backbone app](http://todomvc.com/examples/backbone) if you need a reference implementation. If something is unclear or could be improved, [let us know](https://github.com/tastejs/todomvc/issues).
+Our [template](https://github.com/tastejs/todomvc-app-template/) should be used as the base when implementing a todo app. Before implementing, we recommend that you interact with some of the other apps to see how they're built and how they behave. Check out the [Backbone app](http://todomvc.com/examples/backbone/dist) if you need a reference implementation. If something is unclear or could be improved, [let us know](https://github.com/tastejs/todomvc/issues).
 
 ## Structure
 


### PR DESCRIPTION
A link to the Backbone application seems to be outdated in the Application Specification.

It goes to a version of the todo list without any CSS, looking like this :
![2024-08-16 TODO MVC Backbone app](https://github.com/user-attachments/assets/9ad16a48-40d1-4cb1-a2f7-9f2f1b4c2280)

I updated the link using the one I found in the TodoMVC homepage.