### PR TITLE
Wait for potential asynchronous code before updating counts and views

### DIFF
--- a/examples/javascript-es5/src/controller.js
+++ b/examples/javascript-es5/src/controller.js
@@ -151,9 +151,9 @@
         var self = this;
         self.model.remove(id, function () {
             self.view.render("removeItem", id);
-        });
 
-        self._filter();
+            self._filter();
+        });
     };
 
     /**
@@ -165,9 +165,9 @@
             data.forEach(function (item) {
                 self.removeItem(item.id);
             });
-        });
 
-        self._filter();
+            self._filter();
+        });
     };
 
     /**
@@ -186,10 +186,10 @@
                 id: id,
                 completed: completed,
             });
-        });
 
-        if (!silent)
-            self._filter();
+            if (!silent)
+                self._filter();
+        });
     };
 
     /**
@@ -202,9 +202,9 @@
             data.forEach(function (item) {
                 self.toggleComplete(item.id, completed, true);
             });
-        });
 
-        self._filter();
+            self._filter();
+        });
     };
 
     /**

--- a/examples/javascript-es5/src/model.js
+++ b/examples/javascript-es5/src/model.js
@@ -78,7 +78,7 @@
      * @param {function} callback The callback to fire when the removal is complete.
      */
     Model.prototype.remove = function (id, callback) {
-        this.storage.remove(id, callback);
+        return this.storage.remove(id, callback);
     };
 
     /**


### PR DESCRIPTION
Sharing this for informational purposes. Feel free to close, if it's not relevant.

---

Seems like these filter calls are not waiting for the CRUD operations to complete. This isn't really an issue when using the synchronous `MemoryStore`, but if there's asynchronous code (such as my demo [storing data remotely](https://todomvc.rosano.ca) it may not update the counts incorrectly.

If it's useful to keep the code broad in this way, it may require other modifications too; this is more of a hint if anyone is doing something similar.